### PR TITLE
refactor(bazel): reduce bundle size, specify py interpreter path

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "ecos-bazel")
 git_override(
     module_name = "ecos-bazel",
     remote = "https://github.com/Emin017/ecos-bazel.git",
-    commit = "6a1fbd31b0255f80b0c429984d92a41a221e15e1",
+    commit = "53fbe16e11c5150d96bdd3302a10b95ff20344e2",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,4 +21,4 @@ http_file(
 )
 
 oss_cad_suite = use_extension("@ecos-bazel//rules:oss_cad_suite.bzl", "oss_cad_suite")
-use_repo(oss_cad_suite, "oss_cad_suite")
+use_repo(oss_cad_suite, "oss_cad_suite", "oss_cad_suite_pruned")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,16 +9,11 @@ bazel_dep(name = "ecos-bazel")
 git_override(
     module_name = "ecos-bazel",
     remote = "https://github.com/Emin017/ecos-bazel.git",
-    commit = "53fbe16e11c5150d96bdd3302a10b95ff20344e2",
+    commit = "db88cd95392ae56e99ceb1cc584eccf3881a2f2f",
 )
 
-http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-http_file(
-    name = "appimagetool_x86_64_linux",
-    urls = ["https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"],
-    sha256 = "b90f4a8b18967545fda78a445b27680a1642f1ef9488ced28b65398f2be7add2",
-    executable = True,
-)
+appimage_tool = use_extension("@ecos-bazel//rules:appimage-tool.bzl", "appimage_tool")
+use_repo(appimage_tool, "appimagetool_x86_64_linux")
 
 oss_cad_suite = use_extension("@ecos-bazel//rules:oss_cad_suite.bzl", "oss_cad_suite")
 use_repo(oss_cad_suite, "oss_cad_suite", "oss_cad_suite_pruned")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -146,6 +146,22 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@ecos-bazel+//rules:appimage-tool.bzl%appimage_tool": {
+      "general": {
+        "bzlTransitiveDigest": "PNR0LYRvoPIaEvYGn5B+v/0b0lPRaBfroqxpzQQK+R4=",
+        "usagesDigest": "2lKJdNFL48xez/QRAdRHcU/PwOPSzZNHrqrFsu0mqjg=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "appimagetool_x86_64_linux": {
+            "repoRuleId": "@@ecos-bazel+//rules:appimage-tool.bzl%_appimagetool_repo",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@ecos-bazel+//rules:oss_cad_suite.bzl%oss_cad_suite": {
       "general": {
         "bzlTransitiveDigest": "03Inx7wQyprKJ4MWxzsdFZLuQH3MHKojPiyQ94ViMA4=",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -148,7 +148,7 @@
   "moduleExtensions": {
     "@@ecos-bazel+//rules:oss_cad_suite.bzl%oss_cad_suite": {
       "general": {
-        "bzlTransitiveDigest": "llqB5NGvTkda66lWR6gFbFZkVmh4MYyOO4xj7Bi3xCY=",
+        "bzlTransitiveDigest": "03Inx7wQyprKJ4MWxzsdFZLuQH3MHKojPiyQ94ViMA4=",
         "usagesDigest": "HTNgbM2/pL+JEjRQ83zAxQHAFCcbMfr8uVvXZq1qTd0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -162,6 +162,15 @@
               ],
               "sha256": "b536961118dd7497707752d9fd45714c5f6dacd150e02387bac4f75c28a16567",
               "build_file_template": "@@ecos-bazel+//rules:oss_cad_suite.BUILD.bazel"
+            }
+          },
+          "oss_cad_suite_pruned": {
+            "repoRuleId": "@@ecos-bazel+//rules:oss_cad_suite.bzl%_oss_cad_suite_pruned_repo",
+            "attributes": {
+              "urls": [
+                "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2026-01-22/oss-cad-suite-linux-x64-20260122.tgz"
+              ],
+              "sha256": "b536961118dd7497707752d9fd45714c5f6dacd150e02387bac4f75c28a16567"
             }
           }
         },

--- a/ecos/BUILD.bazel
+++ b/ecos/BUILD.bazel
@@ -43,7 +43,7 @@ genrule(
     ]) + [
         "//ecos/gui/src-tauri:tauri_rust_sources",
         ":build_ecos_server",
-        "@appimagetool_x86_64_linux//file",
+        "@appimagetool_x86_64_linux//:appimagetool",
         "@oss_cad_suite_pruned//:all_files",
         "@oss_cad_suite_pruned//:yosys_bin",
         ":build_gui_script",
@@ -56,7 +56,7 @@ genrule(
         bash "$(location :build_gui_script)" \\
             --gui-src-dir "$$(dirname $(location gui/package.json))" \\
             --api-server-bin "$(location :build_ecos_server)" \\
-            --appimagetool-bin "$(location @appimagetool_x86_64_linux//file)" \\
+            --appimagetool-bin "$(location @appimagetool_x86_64_linux//:appimagetool)" \\
             --oss-cad-bin "$(location @oss_cad_suite_pruned//:yosys_bin)" \\
             --out-tar "$@"
     """,

--- a/ecos/BUILD.bazel
+++ b/ecos/BUILD.bazel
@@ -24,6 +24,7 @@ python_pyinstaller_bundle(
         "server/ecos_server/**/*.py",
     ]),
     output_name = "ecos-server",
+    env = {"PYTHON_INTERPRETER": "ecos/server/.venv/bin/python"},
     pyinstaller = "@ecos-bazel//tools:pyinstaller",
 )
 

--- a/ecos/BUILD.bazel
+++ b/ecos/BUILD.bazel
@@ -44,8 +44,8 @@ genrule(
         "//ecos/gui/src-tauri:tauri_rust_sources",
         ":build_ecos_server",
         "@appimagetool_x86_64_linux//file",
-        "@oss_cad_suite//:all_files",
-        "@oss_cad_suite//:yosys_bin",
+        "@oss_cad_suite_pruned//:all_files",
+        "@oss_cad_suite_pruned//:yosys_bin",
         ":build_gui_script",
     ],
     outs = ["ecos_studio_bundle/ecos_studio_bundle.tar"],
@@ -57,7 +57,7 @@ genrule(
             --gui-src-dir "$$(dirname $(location gui/package.json))" \\
             --api-server-bin "$(location :build_ecos_server)" \\
             --appimagetool-bin "$(location @appimagetool_x86_64_linux//file)" \\
-            --oss-cad-bin "$(location @oss_cad_suite//:yosys_bin)" \\
+            --oss-cad-bin "$(location @oss_cad_suite_pruned//:yosys_bin)" \\
             --out-tar "$@"
     """,
 )

--- a/ecos/server/ecos.spec
+++ b/ecos/server/ecos.spec
@@ -149,9 +149,26 @@ a = Analysis(
     datas=datas,
     hiddenimports=hiddenimports,
     hookspath=[str(HOOKS_DIR)],
-    excludes=["tkinter", "test"],
+    excludes=[
+        "tkinter",
+        "test",
+        "chipcompiler.thirdparty",
+        "setuptools",
+        "distutils",
+        "_distutils_hack",
+        "mypy",
+        "pip",
+        "pkg_resources",
+    ],
     noarchive=False,
 )
+
+# Remove thirdparty files that collect_all("chipcompiler") pulled in.
+# The needed ECC binaries (ecc_py*.so, lib/*.so) are already collected via
+# collect_all into ecc_binaries, but the full thirdparty source tree
+# (ecc-tools: ~1.1 GB of build scripts/src/docs) is not needed at runtime.
+a.datas = [d for d in a.datas if not d[0].startswith("chipcompiler/thirdparty")]
+a.binaries = [b for b in a.binaries if not b[0].startswith("chipcompiler/thirdparty")]
 
 pyz = PYZ(a.pure, a.zipped_data)
 


### PR DESCRIPTION
This pull request introduces several improvements to dependency management and packaging in the project, focusing on optimizing the build process and reducing unnecessary files in the final bundle. The most notable changes include switching to a pruned version of the OSS CAD Suite, updating Bazel module references, and refining the PyInstaller configuration to exclude unneeded packages and files.

**Dependency management and build optimization:**

* Updated the `ecos-bazel` Bazel module reference in `MODULE.bazel` to use a newer commit, ensuring compatibility and access to recent improvements.
* Switched to using the pruned OSS CAD Suite repository (`oss_cad_suite_pruned`) in `MODULE.bazel` and `ecos/BUILD.bazel`, which reduces the size of dependencies included in the build. [[1]](diffhunk://#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdcL24-R24) [[2]](diffhunk://#diff-bc53820e3fbf22e3a98ccd19d355b246e38068caa15b5de708283f206f3ce049L46-R48) [[3]](diffhunk://#diff-bc53820e3fbf22e3a98ccd19d355b246e38068caa15b5de708283f206f3ce049L59-R60)

**Packaging improvements:**

* Added a `PYTHON_INTERPRETER` environment variable to the `python_pyinstaller_bundle` rule in `ecos/BUILD.bazel`, specifying the interpreter path for more reliable builds.
* Expanded the list of excluded packages in the PyInstaller `Analysis` step in `ecos/server/ecos.spec` to omit several unnecessary Python modules and third-party directories, streamlining the packaged application.
* Explicitly removed third-party files from the PyInstaller datas and binaries, preventing large, unneeded source trees from being included in the final bundle.

---

After this PR, the AppImage bundle can be reduced to around **300 MB**.
