### PR TITLE
refactor(log): integrate server logs into workspace, migrate to log crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ bazel-*
 # Nix result
 result
 
+# direnv
+.direnv/
+
+.vscode/
+# Claude Code
+.claude/
+.humanize*

--- a/ecos/gui/default.nix
+++ b/ecos/gui/default.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ];
     };
 
-  cargoHash = "sha256-FWwjXeTCXqGUfOv+EZUGCFm0iHeFuMqYLaFaUf9W4lo=";
+  cargoHash = "sha256-P3EAtI+ZyKM+cZK/ybzPmRTiKAkZ8fhAvrmhzl6nlI8=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) version src;

--- a/ecos/gui/src-tauri/Cargo.lock
+++ b/ecos/gui/src-tauri/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +401,12 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -697,6 +753,8 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "ecos-studio"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
+ "log",
  "serde",
  "serde_json",
  "tauri",
@@ -762,6 +820,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1658,6 +1739,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1771,30 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2253,6 +2364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2649,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -4394,6 +4526,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/ecos/gui/src-tauri/Cargo.toml
+++ b/ecos/gui/src-tauri/Cargo.toml
@@ -19,6 +19,8 @@ tauri-plugin-fs = "~2.4"
 tauri-plugin-shell = "~2.3"
 tauri-plugin-store = "~2.4"
 ureq = "2"
+log = "0.4"
+env_logger = "0.11"
 
 [features]
 default = ["custom-protocol"]

--- a/ecos/gui/src-tauri/src/main.rs
+++ b/ecos/gui/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ use std::thread;
 use std::time::Duration;
 use tauri::Manager;
 use tauri_plugin_fs::FsExt;
+use log::{info, warn, error, debug};
 
 /// Fixed log file path for the API server (matches Python's --log-file default).
 /// In terminal mode Rust tees here; in desktop mode Python writes here directly.
@@ -126,15 +127,15 @@ fn kill_process_on_port(port: u16) -> bool {
         match output {
             Ok(out) => {
                 if out.status.success() {
-                    println!("✅ Killed process on port {}", port);
+                    info!("Killed process on port {}", port);
                     true
                 } else {
-                    eprintln!("⚠️ Could not kill process on port {}", port);
+                    warn!("Could not kill process on port {}", port);
                     false
                 }
             }
             Err(e) => {
-                eprintln!("❌ Failed to execute kill command: {}", e);
+                error!("Failed to execute kill command: {}", e);
                 false
             }
         }
@@ -157,26 +158,26 @@ fn kill_process_on_port(port: u16) -> bool {
                     .collect();
 
                 if pids.is_empty() {
-                    println!("No process found on port {}", port);
+                    debug!("No process found on port {}", port);
                     return true;
                 }
 
                 let mut all_killed = true;
                 for pid in pids {
-                    println!("Found process {} on port {}, killing...", pid, port);
+                    info!("Found process {} on port {}, killing...", pid, port);
                     let kill_result = Command::new("kill").args(["-9", pid]).output();
 
                     match kill_result {
                         Ok(kill_out) => {
                             if kill_out.status.success() {
-                                println!("✅ Killed process {} on port {}", pid, port);
+                                info!("Killed process {} on port {}", pid, port);
                             } else {
-                                eprintln!("⚠️ Failed to kill process {}", pid);
+                                warn!("Failed to kill process {}", pid);
                                 all_killed = false;
                             }
                         }
                         Err(e) => {
-                            eprintln!("❌ Failed to execute kill command: {}", e);
+                            error!("Failed to execute kill command: {}", e);
                             all_killed = false;
                         }
                     }
@@ -184,7 +185,7 @@ fn kill_process_on_port(port: u16) -> bool {
                 all_killed
             }
             Err(e) => {
-                eprintln!("❌ Failed to execute lsof: {}", e);
+                error!("Failed to execute lsof: {}", e);
                 false
             }
         }
@@ -199,8 +200,8 @@ fn find_available_port(preferred: u16) -> Option<u16> {
         return Some(preferred);
     }
 
-    println!(
-        "⚠️ Preferred port {} is in use, scanning for available port...",
+    warn!(
+        "Preferred port {} is in use, scanning for available port...",
         preferred
     );
 
@@ -208,14 +209,14 @@ fn find_available_port(preferred: u16) -> Option<u16> {
     for offset in 1..=PORT_SEARCH_RANGE {
         if let Some(port) = preferred.checked_add(offset) {
             if is_port_available(port) {
-                println!("✅ Found available port: {}", port);
+                info!("Found available port: {}", port);
                 return Some(port);
             }
         }
     }
 
-    eprintln!(
-        "❌ Could not find any available port in range {}-{}",
+    error!(
+        "Could not find any available port in range {}-{}",
         preferred,
         preferred.saturating_add(PORT_SEARCH_RANGE)
     );
@@ -258,7 +259,7 @@ fn is_api_server_healthy(port: u16) -> bool {
 fn wait_for_server_ready(port: u16, timeout_secs: u64) -> bool {
     use std::time::Instant;
 
-    println!("Waiting for FastAPI server to be ready on port {}...", port);
+    info!("Waiting for FastAPI server to be ready on port {}...", port);
     let start = Instant::now();
     let deadline = Duration::from_secs(timeout_secs);
     let mut delay_ms: u64 = 100;
@@ -272,8 +273,8 @@ fn wait_for_server_ready(port: u16, timeout_secs: u64) -> bool {
         if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok()
             && is_api_server_healthy(port)
         {
-            println!(
-                "✅ FastAPI server ready on port {} after {} attempts ({:.1}s)",
+            info!(
+                "FastAPI server ready on port {} after {} attempts ({:.1}s)",
                 port,
                 attempt,
                 start.elapsed().as_secs_f32()
@@ -282,8 +283,8 @@ fn wait_for_server_ready(port: u16, timeout_secs: u64) -> bool {
         }
 
         if start.elapsed().as_secs() >= 4 && attempt % 3 == 0 {
-            println!(
-                "⏳ Still waiting for server on port {}... ({:.1}s elapsed)",
+            debug!(
+                "Still waiting for server on port {}... ({:.1}s elapsed)",
                 port,
                 start.elapsed().as_secs_f32()
             );
@@ -327,14 +328,14 @@ fn start_api_server(
             .unwrap_or_default()
             == "1";
         if reuse {
-            println!(
-                "✅ Healthy API server on port {} and ECOS_REUSE_API_SERVER=1, reusing it",
+            info!(
+                "Healthy API server on port {} and ECOS_REUSE_API_SERVER=1, reusing it",
                 DEFAULT_API_PORT
             );
             return ApiStartResult::ExternalDetected(DEFAULT_API_PORT);
         }
-        println!(
-            "⚠️ Port {} has a healthy API server but ECOS_REUSE_API_SERVER is not set — \
+        warn!(
+            "Port {} has a healthy API server but ECOS_REUSE_API_SERVER is not set - \
              will start on a different port (set ECOS_REUSE_API_SERVER=1 to reuse)",
             DEFAULT_API_PORT
         );
@@ -344,8 +345,8 @@ fn start_api_server(
     let port = match find_available_port(DEFAULT_API_PORT) {
         Some(p) => p,
         None => {
-            eprintln!(
-                "❌ Cannot start API server: no available port found (tried {} - {})",
+            error!(
+                "Cannot start API server: no available port found (tried {} - {})",
                 DEFAULT_API_PORT,
                 DEFAULT_API_PORT + PORT_SEARCH_RANGE
             );
@@ -354,8 +355,8 @@ fn start_api_server(
     };
 
     if port != DEFAULT_API_PORT {
-        println!(
-            "📌 Using alternative port {} (default port {} was occupied)",
+        info!(
+            "Using alternative port {} (default port {} was occupied)",
             port, DEFAULT_API_PORT
         );
     }
@@ -377,10 +378,10 @@ fn start_api_server(
         let venv_python = server_dir.join(".venv").join("bin").join("python3");
 
         let interpreter = if venv_python.exists() {
-            println!("Using venv Python: {:?}", venv_python);
+            debug!("Using venv Python: {:?}", venv_python);
             venv_python.to_string_lossy().to_string()
         } else {
-            println!("Venv not found at {:?}, using system Python", venv_python);
+            debug!("Venv not found at {:?}, using system Python", venv_python);
             #[cfg(target_os = "windows")]
             {
                 "python".to_string()
@@ -391,7 +392,7 @@ fn start_api_server(
             }
         };
 
-        println!(
+        info!(
             "Starting FastAPI server (dev mode) from: {:?} on port {}",
             server_script, port
         );
@@ -412,15 +413,15 @@ fn start_api_server(
 
         match cmd.spawn() {
             Ok(child) => {
-                println!(
-                    "✅ FastAPI server started with PID: {} on port {}",
+                info!(
+                    "FastAPI server started with PID: {} on port {}",
                     child.id(),
                     port
                 );
                 return ApiStartResult::Started(child, port);
             }
             Err(e) => {
-                eprintln!("❌ Failed to start FastAPI server: {}", e);
+                error!("Failed to start FastAPI server: {}", e);
                 return ApiStartResult::Failed;
             }
         }
@@ -438,7 +439,7 @@ fn start_api_server(
         for binary_name in &binary_candidates {
             let possible_paths = get_possible_binary_paths(app_handle, binary_name);
             for path in possible_paths {
-                println!("Checking for api-server at: {:?}", path);
+                debug!("Checking for api-server at: {:?}", path);
                 checked_paths.push(path.clone());
                 if path.exists() {
                     server_binary = Some(path);
@@ -453,11 +454,11 @@ fn start_api_server(
         let server_binary = match server_binary {
             Some(path) => path,
             None => {
-                eprintln!("❌ API server binary not found. Checked locations:");
+                error!("API server binary not found. Checked locations:");
                 let mut seen = std::collections::HashSet::new();
                 for path in checked_paths {
                     if seen.insert(path.clone()) {
-                        eprintln!("   - {:?}", path);
+                        error!("   - {:?}", path);
                     }
                 }
                 return ApiStartResult::Failed;
@@ -466,7 +467,7 @@ fn start_api_server(
 
         let launched_from_terminal = is_launched_from_terminal();
 
-        println!(
+        info!(
             "Starting FastAPI server (prod mode) from: {:?} on port {} (terminal: {})",
             server_binary, port, launched_from_terminal
         );
@@ -474,11 +475,11 @@ fn start_api_server(
         let mut cmd = Command::new(&server_binary);
 
         if let Some(oss_dir) = get_oss_cad_dir(app_handle) {
-            println!("Setting CHIPCOMPILER_OSS_CAD_DIR to {:?}", oss_dir);
+            debug!("Setting CHIPCOMPILER_OSS_CAD_DIR to {:?}", oss_dir);
             cmd.env("CHIPCOMPILER_OSS_CAD_DIR", &oss_dir);
         } else {
-            eprintln!("⚠️ Expected oss-cad-suite at <resource_dir>/resources/oss-cad-suite, but it was not found.");
-            eprintln!("⚠️ Synthesis may fail if yosys is unavailable in PATH.");
+            warn!("Expected oss-cad-suite at <resource_dir>/resources/oss-cad-suite, but it was not found.");
+            warn!("Synthesis may fail if yosys is unavailable in PATH.");
         }
 
         // Always pass a fixed log-file path so we know where to look on errors.
@@ -495,20 +496,20 @@ fn start_api_server(
             // Python will NOT redirect to file; Rust handles writing to both
             // the terminal and the log file via the tee threads below.
             cmd.arg("--disable-stdio-redirect");
-            println!("📋 Server logs → terminal + {}", API_SERVER_LOG_FILE);
+            info!("Server logs -> terminal + {}", API_SERVER_LOG_FILE);
         } else {
             // Desktop launch: Python redirects its own stdio to the log file.
             // Rust only needs to drain the pipes to prevent buffer blocking.
-            println!("📋 Server logs → {}", API_SERVER_LOG_FILE);
+            info!("Server logs -> {}", API_SERVER_LOG_FILE);
         }
-        println!("📋 Workspace logs will be saved to <workspace>/log/ when a project is opened");
+        info!("Workspace logs will be saved to <workspace>/log/ when a project is opened");
 
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
         match cmd.spawn() {
             Ok(mut child) => {
-                println!(
-                    "✅ FastAPI server started with PID: {} on port {}",
+                info!(
+                    "FastAPI server started with PID: {} on port {}",
                     child.id(),
                     port
                 );
@@ -536,9 +537,9 @@ fn start_api_server(
                 ApiStartResult::Started(child, port)
             }
             Err(e) => {
-                eprintln!("❌ Failed to start FastAPI server: {}", e);
-                eprintln!("   Binary path: {:?}", server_binary);
-                eprintln!("   Error details: {:?}", e.kind());
+                error!("Failed to start FastAPI server: {}", e);
+                error!("   Binary path: {:?}", server_binary);
+                error!("   Error details: {:?}", e.kind());
                 // Write the error into the log file so desktop users can see it
                 // when the file is opened automatically.
                 if !launched_from_terminal {
@@ -548,7 +549,7 @@ fn start_api_server(
                         .append(true)
                         .open(API_SERVER_LOG_FILE)
                     {
-                        let _ = writeln!(f, "❌ Failed to start FastAPI server: {}", e);
+                        let _ = writeln!(f, "Failed to start FastAPI server: {}", e);
                         let _ = writeln!(f, "   Binary path: {:?}", server_binary);
                         let _ = writeln!(f, "   Error details: {:?}", e.kind());
                     }
@@ -636,7 +637,7 @@ fn get_possible_binary_paths(
 fn stop_api_server(process: &mut Option<Child>, port: u16) {
     if let Some(ref mut child) = process {
         let pid = child.id();
-        println!("Stopping FastAPI server (PID: {}, port: {})...", pid, port);
+        info!("Stopping FastAPI server (PID: {}, port: {})...", pid, port);
 
         // On Unix, kill the entire process group so that child workers
         // (e.g. uvicorn reloader/workers spawned by `--reload`) are also
@@ -649,7 +650,7 @@ fn stop_api_server(process: &mut Option<Child>, port: u16) {
                 .output();
             match pgid_kill {
                 Ok(out) if out.status.success() => {
-                    println!("Sent SIGTERM to process group -{}", pid);
+                    info!("Sent SIGTERM to process group -{}", pid);
                 }
                 _ => {
                     // Process group kill failed; fall back to single-process kill
@@ -662,10 +663,10 @@ fn stop_api_server(process: &mut Option<Child>, port: u16) {
 
         // Force-kill the direct child (SIGKILL on Unix, TerminateProcess on Windows)
         match child.kill() {
-            Ok(_) => println!("✅ FastAPI server process killed"),
+            Ok(_) => info!("FastAPI server process killed"),
             Err(e) => {
                 // "InvalidInput" / "not running" is fine — process already exited
-                eprintln!("⚠️ child.kill(): {} (process may have already exited)", e);
+                warn!("child.kill(): {} (process may have already exited)", e);
             }
         }
 
@@ -677,15 +678,15 @@ fn stop_api_server(process: &mut Option<Child>, port: u16) {
         // up via port-based lookup (lsof + kill) so the port is free on next start.
         thread::sleep(Duration::from_millis(300));
         if !is_port_available(port) {
-            println!("⚠️ Port {} still occupied after stopping server, cleaning up orphaned processes...", port);
+            warn!("Port {} still occupied after stopping server, cleaning up orphaned processes...", port);
             kill_process_on_port(port);
             thread::sleep(Duration::from_millis(300));
         }
 
         if is_port_available(port) {
-            println!("✅ Port {} is now free", port);
+            info!("Port {} is now free", port);
         } else {
-            eprintln!("❌ Port {} is still occupied after cleanup", port);
+            error!("Port {} is still occupied after cleanup", port);
         }
     }
 }
@@ -693,12 +694,14 @@ fn stop_api_server(process: &mut Option<Child>, port: u16) {
 /// 窗口最小化
 #[tauri::command]
 fn window_minimize(window: tauri::Window) {
+    debug!("cmd=window_minimize");
     let _ = window.minimize();
 }
 
 /// 窗口最大化/还原
 #[tauri::command]
 fn window_maximize(window: tauri::Window) {
+    debug!("cmd=window_maximize");
     if window.is_maximized().unwrap_or(false) {
         let _ = window.unmaximize();
     } else {
@@ -709,12 +712,14 @@ fn window_maximize(window: tauri::Window) {
 /// 窗口关闭
 #[tauri::command]
 fn window_close(window: tauri::Window) {
+    debug!("cmd=window_close");
     let _ = window.close();
 }
 
 /// 获取 API 服务器状态
 #[tauri::command]
 fn get_api_server_status(port_state: tauri::State<'_, ActualApiPort>) -> serde_json::Value {
+    debug!("cmd=get_api_server_status");
     let port = *port_state.lock().unwrap();
     let port_available = is_port_available(port);
     let server_running = !port_available; // If port is not available, server might be running
@@ -742,6 +747,7 @@ fn restart_api_server(
     state: tauri::State<'_, ApiServerProcess>,
     port_state: tauri::State<'_, ActualApiPort>,
 ) -> Result<String, String> {
+    info!("cmd=restart_api_server");
     let mut server = state.lock().map_err(|e| format!("Lock error: {}", e))?;
 
     // Stop our managed child process (if any).
@@ -785,6 +791,7 @@ fn kill_port_process(port_state: tauri::State<'_, ActualApiPort>) -> Result<Stri
     let port = *port_state
         .lock()
         .map_err(|e| format!("Lock error: {}", e))?;
+    info!("cmd=kill_port_process port={}", port);
 
     if is_port_available(port) {
         return Ok(format!("Port {} is already available", port));
@@ -806,6 +813,7 @@ fn get_debug_info(
     app: tauri::AppHandle,
     port_state: tauri::State<'_, ActualApiPort>,
 ) -> serde_json::Value {
+    debug!("cmd=get_debug_info");
     let port = *port_state.lock().unwrap();
 
     let mut info = serde_json::json!({
@@ -866,6 +874,7 @@ fn get_debug_info(
 
 #[tauri::command]
 fn get_api_port(port_state: tauri::State<'_, ActualApiPort>) -> u16 {
+    debug!("cmd=get_api_port");
     *port_state.lock().unwrap()
 }
 
@@ -873,6 +882,7 @@ fn get_api_port(port_state: tauri::State<'_, ActualApiPort>) -> u16 {
 async fn request_project_permission(app: tauri::AppHandle, path: String) -> Result<(), String> {
     use std::path::PathBuf;
 
+    info!("cmd=request_project_permission path={}", path);
     let scope = app.fs_scope();
     let path_buf = PathBuf::from(&path);
 
@@ -884,6 +894,11 @@ async fn request_project_permission(app: tauri::AppHandle, path: String) -> Resu
 
 fn main() {
     use std::path::PathBuf;
+
+    // Initialize logger with default filter level "info"
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("info")
+    ).init();
 
     // Shared state for the API server process and discovered port
     let api_server: ApiServerProcess = Arc::new(Mutex::new(None));
@@ -919,8 +934,8 @@ fn main() {
                         ApiStartResult::Failed => {
                             *server = None;
                             *api_port.lock().unwrap() = DEFAULT_API_PORT;
-                            eprintln!(
-                                "⚠️ No API server available — GUI may not function correctly"
+                            warn!(
+                                "No API server available — GUI may not function correctly"
                             );
                             (false, DEFAULT_API_PORT)
                         }
@@ -931,18 +946,18 @@ fn main() {
                 // loading immediately (splash screen visible sooner).
                 thread::spawn(move || {
                     if using_external_server {
-                        println!(
+                        info!(
                             "Using externally started API server (debugger mode) on port {}",
                             actual_port
                         );
                     }
                     if !wait_for_server_ready(actual_port, 15) {
-                        eprintln!("⚠️ FastAPI server may not be fully ready after 15s");
+                        warn!("FastAPI server may not be fully ready after 15s");
                         // In release desktop mode, open the log file so the user
                         // can see what went wrong without needing a terminal.
                         #[cfg(not(debug_assertions))]
                         if !is_launched_from_terminal() {
-                            eprintln!("Opening server log: {}", API_SERVER_LOG_FILE);
+                            warn!("Opening server log: {}", API_SERVER_LOG_FILE);
                             open_log_file(API_SERVER_LOG_FILE);
                         }
                     }
@@ -956,8 +971,8 @@ fn main() {
                     let final_path = data_path.canonicalize().unwrap_or(data_path.clone());
                     let scope = app.fs_scope();
                     match scope.allow_directory(&final_path, true) {
-                        Ok(()) => println!("✅ Granted fs scope: {:?}", final_path),
-                        Err(e) => eprintln!("❌ Failed to grant fs scope: {}", e),
+                        Ok(()) => info!("Granted fs scope: {:?}", final_path),
+                        Err(e) => error!("Failed to grant fs scope: {}", e),
                     }
                 }
 
@@ -965,8 +980,8 @@ fn main() {
                 {
                     let scale_factor = window.scale_factor().unwrap_or(1.0);
                     if let Ok(size) = window.inner_size() {
-                        println!("=== Window Debug Info ===");
-                        println!(
+                        debug!("=== Window Debug Info ===");
+                        debug!(
                             "Logical size: {}x{}",
                             size.width as f64 / scale_factor,
                             size.height as f64 / scale_factor
@@ -983,7 +998,7 @@ fn main() {
                 if let Ok(false) = window.is_visible() {
                     let _ = window.show();
                     let _ = window.set_focus();
-                    println!("Window shown via page load finished");
+                    debug!("Window shown via page load finished");
                 }
             }
         })

--- a/ecos/gui/src-tauri/src/main.rs
+++ b/ecos/gui/src-tauri/src/main.rs
@@ -694,15 +694,16 @@ fn stop_api_server(process: &mut Option<Child>, port: u16) {
 /// 窗口最小化
 #[tauri::command]
 fn window_minimize(window: tauri::Window) {
-    debug!("cmd=window_minimize");
+    debug!("cmd=window_minimize window={}", window.label());
     let _ = window.minimize();
 }
 
 /// 窗口最大化/还原
 #[tauri::command]
 fn window_maximize(window: tauri::Window) {
-    debug!("cmd=window_maximize");
-    if window.is_maximized().unwrap_or(false) {
+    let is_maximized = window.is_maximized().unwrap_or(false);
+    debug!("cmd=window_maximize window={} action={}", window.label(), if is_maximized { "unmaximize" } else { "maximize" });
+    if is_maximized {
         let _ = window.unmaximize();
     } else {
         let _ = window.maximize();
@@ -712,15 +713,15 @@ fn window_maximize(window: tauri::Window) {
 /// 窗口关闭
 #[tauri::command]
 fn window_close(window: tauri::Window) {
-    debug!("cmd=window_close");
+    debug!("cmd=window_close window={}", window.label());
     let _ = window.close();
 }
 
 /// 获取 API 服务器状态
 #[tauri::command]
 fn get_api_server_status(port_state: tauri::State<'_, ActualApiPort>) -> serde_json::Value {
-    debug!("cmd=get_api_server_status");
     let port = *port_state.lock().unwrap();
+    debug!("cmd=get_api_server_status port={}", port);
     let port_available = is_port_available(port);
     let server_running = !port_available; // If port is not available, server might be running
 
@@ -747,7 +748,9 @@ fn restart_api_server(
     state: tauri::State<'_, ApiServerProcess>,
     port_state: tauri::State<'_, ActualApiPort>,
 ) -> Result<String, String> {
-    info!("cmd=restart_api_server");
+    let current_port = *port_state.lock().map_err(|e| format!("Lock error: {}", e))?;
+    let has_server = state.lock().map_err(|e| format!("Lock error: {}", e))?.is_some();
+    info!("cmd=restart_api_server current_port={} has_server={}", current_port, has_server);
     let mut server = state.lock().map_err(|e| format!("Lock error: {}", e))?;
 
     // Stop our managed child process (if any).
@@ -813,8 +816,8 @@ fn get_debug_info(
     app: tauri::AppHandle,
     port_state: tauri::State<'_, ActualApiPort>,
 ) -> serde_json::Value {
-    debug!("cmd=get_debug_info");
     let port = *port_state.lock().unwrap();
+    debug!("cmd=get_debug_info port={} is_debug={}", port, cfg!(debug_assertions));
 
     let mut info = serde_json::json!({
         "api_port": port,
@@ -874,8 +877,9 @@ fn get_debug_info(
 
 #[tauri::command]
 fn get_api_port(port_state: tauri::State<'_, ActualApiPort>) -> u16 {
-    debug!("cmd=get_api_port");
-    *port_state.lock().unwrap()
+    let port = *port_state.lock().unwrap();
+    debug!("cmd=get_api_port port={}", port);
+    port
 }
 
 #[tauri::command]

--- a/ecos/gui/src-tauri/src/main.rs
+++ b/ecos/gui/src-tauri/src/main.rs
@@ -10,76 +10,22 @@ use tauri::Manager;
 use tauri_plugin_fs::FsExt;
 use log::{info, warn, error, debug};
 
-/// Fixed log file path for the API server (matches Python's --log-file default).
-/// In terminal mode Rust tees here; in desktop mode Python writes here directly.
-const API_SERVER_LOG_FILE: &str = "/tmp/ecos-studio-api-server.log";
-
 /// Returns true when the process was launched from an interactive terminal
 /// (i.e. stderr is a TTY). False when launched from a desktop file / launcher.
 fn is_launched_from_terminal() -> bool {
     std::io::stderr().is_terminal()
 }
 
-/// Open a file with the system's default application (text editor / file manager).
-fn open_log_file(path: &str) {
-    #[cfg(target_os = "linux")]
-    let _ = Command::new("xdg-open").arg(path).spawn();
-    #[cfg(target_os = "macos")]
-    let _ = Command::new("open").arg(path).spawn();
-    #[cfg(target_os = "windows")]
-    let _ = Command::new("cmd").args(["/C", "start", "", path]).spawn();
-}
-
-/// Drain a child's stdout or stderr pipe in a background thread.
-///
-/// * `to_terminal` – if true, also echo each line to Rust's own stdout/stderr
-///   AND write it to `log_path` (used in terminal-launch mode where Python has
-///   `--disable-stdio-redirect` so all output stays on the pipe).
-/// * `to_terminal = false` – desktop-launch mode: Python writes to log itself;
-///   we only drain the pipe to prevent the child from blocking on a full buffer.
+/// Drain a child's stdout or stderr pipe in a background thread to prevent
+/// the child from blocking when the OS pipe buffer fills up.
 #[cfg(not(debug_assertions))]
-fn tee_output(
-    reader: impl std::io::Read + Send + 'static,
-    log_path: String,
-    to_terminal: bool,
-    is_stderr: bool,
-) {
-    use std::fs::OpenOptions;
-    use std::io::{BufRead, BufReader, Write};
-
+fn drain_pipe(reader: impl std::io::Read + Send + 'static) {
+    use std::io::{BufRead, BufReader};
     thread::spawn(move || {
-        // Only open the log file when WE are responsible for writing to it
-        // (terminal mode). In desktop mode Python already writes there.
-        let mut log_writer = if to_terminal {
-            OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&log_path)
-                .map_err(|e| {
-                    eprintln!("⚠️ Cannot open log file {}: {}", log_path, e);
-                    e
-                })
-                .ok()
-        } else {
-            None
-        };
-
         let reader = BufReader::new(reader);
         for line in reader.lines() {
-            match line {
-                Ok(l) => {
-                    if let Some(ref mut f) = log_writer {
-                        let _ = writeln!(f, "{}", l);
-                    }
-                    if to_terminal {
-                        if is_stderr {
-                            eprintln!("{}", l);
-                        } else {
-                            println!("{}", l);
-                        }
-                    }
-                }
-                Err(_) => break,
+            if line.is_err() {
+                break;
             }
         }
     });
@@ -482,29 +428,24 @@ fn start_api_server(
             warn!("Synthesis may fail if yosys is unavailable in PATH.");
         }
 
-        // Always pass a fixed log-file path so we know where to look on errors.
         cmd.arg("--host")
             .arg("127.0.0.1")
             .arg("--port")
             .arg(port.to_string())
-            .arg("--log-file")
-            .arg(API_SERVER_LOG_FILE)
-            .arg("--no-timestamp-log-file");
+            .arg("--disable-stdio-redirect");
 
         if launched_from_terminal {
-            // Terminal launch: keep output on child's stdio so we can tee it.
-            // Python will NOT redirect to file; Rust handles writing to both
-            // the terminal and the log file via the tee threads below.
-            cmd.arg("--disable-stdio-redirect");
-            info!("Server logs -> terminal + {}", API_SERVER_LOG_FILE);
+            info!("Server output -> terminal (stdio)");
         } else {
-            // Desktop launch: Python redirects its own stdio to the log file.
-            // Rust only needs to drain the pipes to prevent buffer blocking.
-            info!("Server logs -> {}", API_SERVER_LOG_FILE);
+            info!("Server output -> discarded (desktop mode, no terminal)");
         }
         info!("Workspace logs will be saved to <workspace>/log/ when a project is opened");
 
-        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        if launched_from_terminal {
+            cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        } else {
+            cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        }
 
         match cmd.spawn() {
             Ok(mut child) => {
@@ -513,47 +454,16 @@ fn start_api_server(
                     child.id(),
                     port
                 );
-
-                // Drain (and optionally tee) the child's stdout/stderr pipes.
-                // This is required in both modes to prevent the child from
-                // blocking when the OS pipe buffer fills up.
-                if let Some(stdout) = child.stdout.take() {
-                    tee_output(
-                        stdout,
-                        API_SERVER_LOG_FILE.to_string(),
-                        launched_from_terminal,
-                        false,
-                    );
+                if !launched_from_terminal {
+                    if let Some(stdout) = child.stdout.take() { drain_pipe(stdout); }
+                    if let Some(stderr) = child.stderr.take() { drain_pipe(stderr); }
                 }
-                if let Some(stderr) = child.stderr.take() {
-                    tee_output(
-                        stderr,
-                        API_SERVER_LOG_FILE.to_string(),
-                        launched_from_terminal,
-                        true,
-                    );
-                }
-
                 ApiStartResult::Started(child, port)
             }
             Err(e) => {
                 error!("Failed to start FastAPI server: {}", e);
                 error!("   Binary path: {:?}", server_binary);
                 error!("   Error details: {:?}", e.kind());
-                // Write the error into the log file so desktop users can see it
-                // when the file is opened automatically.
-                if !launched_from_terminal {
-                    use std::io::Write;
-                    if let Ok(mut f) = std::fs::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open(API_SERVER_LOG_FILE)
-                    {
-                        let _ = writeln!(f, "Failed to start FastAPI server: {}", e);
-                        let _ = writeln!(f, "   Binary path: {:?}", server_binary);
-                        let _ = writeln!(f, "   Error details: {:?}", e.kind());
-                    }
-                }
                 ApiStartResult::Failed
             }
         }
@@ -899,9 +809,9 @@ async fn request_project_permission(app: tauri::AppHandle, path: String) -> Resu
 fn main() {
     use std::path::PathBuf;
 
-    // Initialize logger with default filter level "info"
+    // Default to warnings in production while still honoring RUST_LOG overrides.
     env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("info")
+        env_logger::Env::default().default_filter_or("warn")
     ).init();
 
     // Shared state for the API server process and discovered port
@@ -957,13 +867,6 @@ fn main() {
                     }
                     if !wait_for_server_ready(actual_port, 15) {
                         warn!("FastAPI server may not be fully ready after 15s");
-                        // In release desktop mode, open the log file so the user
-                        // can see what went wrong without needing a terminal.
-                        #[cfg(not(debug_assertions))]
-                        if !is_launched_from_terminal() {
-                            warn!("Opening server log: {}", API_SERVER_LOG_FILE);
-                            open_log_file(API_SERVER_LOG_FILE);
-                        }
                     }
                 });
 

--- a/ecos/gui/src-tauri/src/main.rs
+++ b/ecos/gui/src-tauri/src/main.rs
@@ -501,6 +501,7 @@ fn start_api_server(
             // Rust only needs to drain the pipes to prevent buffer blocking.
             println!("📋 Server logs → {}", API_SERVER_LOG_FILE);
         }
+        println!("📋 Workspace logs will be saved to <workspace>/log/ when a project is opened");
 
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 

--- a/ecos/server/ecos_server/ecc/services/ecc.py
+++ b/ecos/server/ecos_server/ecc/services/ecc.py
@@ -4,6 +4,7 @@ import logging
 import os
 import time
 from functools import wraps
+from logging.handlers import RotatingFileHandler
 
 from ..schemas import (
     CMDEnum,
@@ -40,26 +41,52 @@ def _log_api_command(func):
     def wrapper(self, request: ECCRequest, *args, **kwargs):
         cmd = getattr(request, "cmd", "?")
         data = getattr(request, "data", {})
-        logger.info("[CMD] %s %s", cmd, _summarize_request(data))
+        logger.info("[CMD:start] cmd=%s %s", cmd, _summarize_request(data))
 
         start = time.time()
         try:
             response = func(self, request, *args, **kwargs)
         except Exception:
-            logger.exception("[CMD] %s failed (%.0fms)", cmd, (time.time() - start) * 1000)
+            elapsed_ms = (time.time() - start) * 1000
+            logger.exception("[CMD:error] cmd=%s elapsed=%.0fms", cmd, elapsed_ms)
             raise
 
         elapsed_ms = (time.time() - start) * 1000
         result = getattr(response, "response", type(response).__name__)
-        logger.info("[CMD] %s -> %s (%.0fms)", cmd, result, elapsed_ms)
+        logger.info("[CMD:done] cmd=%s result=%s elapsed=%.0fms", cmd, result, elapsed_ms)
         return response
     return wrapper
 
 
 class ECCService:
+    # Logger subtree that receives workspace-level file logging
+    _WS_LOGGER_NAME = "ecos_server.ecc"
+
     def __init__(self):
         self.workspace = None
         self.engine_flow = None
+        self._workspace_log_handler = None
+
+    def _attach_workspace_log(self, workspace_dir: str):
+        """Attach a rotating file handler that mirrors API logs into {workspace}/log/server.log."""
+        self._detach_workspace_log()
+        log_dir = os.path.join(os.path.abspath(workspace_dir), "log")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(log_dir, "server.log")
+        handler = RotatingFileHandler(log_path, maxBytes=10 * 1024 * 1024, backupCount=5)
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        ))
+        logging.getLogger(self._WS_LOGGER_NAME).addHandler(handler)
+        self._workspace_log_handler = handler
+        logger.info("Server API logs -> %s", log_path)
+
+    def _detach_workspace_log(self):
+        """Remove the previous workspace file handler, if any."""
+        if self._workspace_log_handler:
+            logging.getLogger(self._WS_LOGGER_NAME).removeHandler(self._workspace_log_handler)
+            self._workspace_log_handler.close()
+            self._workspace_log_handler = None
 
     @staticmethod
     def _normalize_rtl_list(rtl_list) -> list[str]:
@@ -206,6 +233,9 @@ class ECCService:
             # 设置 gui_notify 的 workspace_id
             gui_notify.set_workspace(workspace.directory)
 
+            # Attach workspace-level log handler
+            self._attach_workspace_log(workspace.directory)
+
             response_data = {
                 "directory" : data.get("directory", ""),
                 "workspace_id": workspace.directory  # 前端用于订阅 SSE
@@ -340,6 +370,9 @@ class ECCService:
             # 设置 gui_notify 的 workspace_id
             gui_notify.set_workspace(workspace.directory)
 
+            # Attach workspace-level log handler
+            self._attach_workspace_log(workspace.directory)
+
             response_data = {
                 "directory" : data.get("directory", ""),
                 "workspace_id": workspace.directory  # 前端用于订阅 SSE
@@ -382,6 +415,7 @@ class ECCService:
             )
 
         # process cmd
+        self._detach_workspace_log()
         self.engine_flow = None
         self.workspace = None
 
@@ -465,9 +499,11 @@ class ECCService:
                     failed_step = workspace_step.name
                     break
                 else:
+                    log_file = workspace_step.log.get("file", "")
                     gui_notify.notify_step(step=workspace_step.name,
                                                step_path=self.workspace.flow.path,
-                                               home_page=self.workspace.home.path)
+                                               home_page=self.workspace.home.path,
+                                               log_file=os.path.abspath(log_file) if log_file else "")
             # self.engine_flow.run_steps()
         except Exception as e:
             logger.exception("rtl2gds: execution failed")

--- a/ecos/server/ecos_server/ecc/sse/notify_service.py
+++ b/ecos/server/ecos_server/ecc/sse/notify_service.py
@@ -99,14 +99,16 @@ class NotifyService:
         event_manager.notify(workspace_id=workspace_id,
                              response=response)
 
-    def notify_step(self, step : str, step_path : str, home_page : str):
+    def notify_step(self, step : str, step_path : str, home_page : str, log_file : str = ""):
         """
         update step status for home page
         "response" : {
             "step" : "",
             "id" : "",
             "info" : {
-                "step_path" : ""
+                "step_path" : "",
+                "home_page" : "",
+                "log_file" : ""
             }
         }
         """
@@ -120,7 +122,8 @@ class NotifyService:
                 "id" : NotifyEnum.step.value,
                 "info": {
                     "step_path" : step_path,
-                    "home_page" : home_page
+                    "home_page" : home_page,
+                    "log_file" : log_file
                 }
             },
 

--- a/ecos/server/run_server.py
+++ b/ecos/server/run_server.py
@@ -31,14 +31,16 @@ def _setup_logging(args) -> str:
     """
     log_file = os.path.abspath(os.path.expanduser(args.log_file))
 
+    if args.timestamp_log_file:
+        log_file = build_timestamped_log_file(log_file=log_file, pid=os.getpid())
+
     if args.disable_stdio_redirect:
-        os.environ.pop(API_RUNTIME_LOG_ENV_KEY, None)
+        # Don't redirect this process's stdio, but still expose the log path
+        # to EDA subprocesses so they can redirect their own output.
+        os.environ[API_RUNTIME_LOG_ENV_KEY] = log_file
         print("[API_LOG] stdio redirect disabled; logs stay on console.",
               file=sys.stderr, flush=True)
         return log_file
-
-    if args.timestamp_log_file:
-        log_file = build_timestamped_log_file(log_file=log_file, pid=os.getpid())
 
     print(f"[API_LOG] log -> {log_file} (tail -f {log_file})",
           file=sys.stderr, flush=True)

--- a/ecos/server/run_server.py
+++ b/ecos/server/run_server.py
@@ -69,6 +69,13 @@ def main():
                         help="Number of backup files to keep")
     parser.add_argument("--disable-stdio-redirect", action="store_true",
                         help="Keep stdout/stderr on console")
+    parser.add_argument("--log-level", default=os.environ.get("ECOS_API_LOG_LEVEL", "warning"),
+                        help="Uvicorn log level (default: warning)")
+    parser.add_argument("--access-log", dest="access_log", action="store_true",
+                        help="Enable Uvicorn access logs")
+    parser.add_argument("--no-access-log", dest="access_log", action="store_false",
+                        help="Disable Uvicorn access logs (default)")
+    parser.set_defaults(access_log=False)
     parser.add_argument("--timestamp-log-file", dest="timestamp_log_file",
                         action="store_true", default=True,
                         help="Timestamped log filename per startup (default)")
@@ -96,7 +103,8 @@ def main():
         port=args.port,
         reload=args.reload,
         reload_dirs=reload_dirs or None,
-        log_level="info"
+        log_level=args.log_level,
+        access_log=args.access_log,
     )
 
 

--- a/ecos/server/run_server.py
+++ b/ecos/server/run_server.py
@@ -19,7 +19,6 @@ import argparse
 import uvicorn
 
 from chipcompiler.utility.log import (
-    API_RUNTIME_LOG_ENV_KEY,
     build_timestamped_log_file,
     init_api_runtime_log,
 )
@@ -35,9 +34,6 @@ def _setup_logging(args) -> str:
         log_file = build_timestamped_log_file(log_file=log_file, pid=os.getpid())
 
     if args.disable_stdio_redirect:
-        # Don't redirect this process's stdio, but still expose the log path
-        # to EDA subprocesses so they can redirect their own output.
-        os.environ[API_RUNTIME_LOG_ENV_KEY] = log_file
         print("[API_LOG] stdio redirect disabled; logs stay on console.",
               file=sys.stderr, flush=True)
         return log_file
@@ -50,7 +46,6 @@ def _setup_logging(args) -> str:
         max_bytes=args.log_max_bytes,
         backup_count=args.log_backup_count,
     )
-    os.environ[API_RUNTIME_LOG_ENV_KEY] = log_file
     return log_file
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,16 @@
               infraOverlay
             ];
           };
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [
+              pkgs.ecos-server
+            ];
+            buildInputs = [
+              pkgs.nixfmt
+              pkgs.git
+              pkgs.uv
+            ];
+          };
           treefmt = {
             projectRootFile = "flake.nix";
             programs = {

--- a/flake.nix
+++ b/flake.nix
@@ -54,11 +54,15 @@
           devShells.default = pkgs.mkShell {
             inputsFrom = [
               pkgs.ecos-server
+              pkgs.ecos-studio
             ];
             buildInputs = [
               pkgs.nixfmt
               pkgs.git
               pkgs.uv
+              pkgs.cargo
+              pkgs.rustc
+              pkgs.clippy
             ];
           };
           treefmt = {


### PR DESCRIPTION
- Add workspace-level server log handler (RotatingFileHandler) that writes API logs to {workspace}/log/server.log when a project is opened; detached on workspace deletion
- Add log_file field to SSE notify_step() so frontend can locate step detail logs
- Improve _log_api_command decorator tags: [CMD] -> [CMD:start] / [CMD:done] / [CMD:error] with key=value style for easier grep
- Add workspace log path hint in Tauri startup output