### PR TITLE
refactor(server): replace @_log_api_command decorator with ECCService dispatch()

### DIFF
--- a/ecos/server/ecos_server/ecc/routers/workspace.py
+++ b/ecos/server/ecos_server/ecc/routers/workspace.py
@@ -23,53 +23,60 @@ async def create_workspace(request: ECCRequest):
     """
     Create a new ECC project.
     """
-    return ecc_serv.create_workspace(request)
+    return ecc_serv.dispatch(request)
+
 
 @router.post("/set_pdk_root", response_model=ECCResponse)
 async def set_pdk_root(request: ECCRequest):
     """
     Set PDK root path for backend runtime resolution.
     """
-    return ecc_serv.set_pdk_root(request)
+    return ecc_serv.dispatch(request)
+
 
 @router.post("/load_workspace", response_model=ECCResponse)
 async def load_workspace(request: ECCRequest):
     """
     Open an existing ECC project.
     """
-    return ecc_serv.load_workspace(request)
+    return ecc_serv.dispatch(request)
+
 
 @router.post("/delete_workspace", response_model=ECCResponse)
 async def delete_workspace(request: ECCRequest):
     """
     Delete an existing ECC project.
     """
-    return ecc_serv.delete_workspace(request)
+    return ecc_serv.dispatch(request)
+
 
 @router.post("/rtl2gds", response_model=ECCResponse)
 def rtl2gds(request: ECCRequest):
     """
     run rtl2gds flow for current workspace.
     """
-    return ecc_serv.rtl2gds(request)
+    return ecc_serv.dispatch(request)
+
 
 @router.post("/run_step", response_model=ECCResponse)
 async def run_step(request: ECCRequest):
     """
     run step for current workspace.
     """
-    return ecc_serv.run_step(request)
+    return ecc_serv.dispatch(request)
+
 
 @router.post("/get_info", response_model=ECCResponse)
 async def get_info(request: ECCRequest):
     """
     get information by step and id.
     """
-    return ecc_serv.get_info(request)
+    return ecc_serv.dispatch(request)
+
 
 @router.post("/get_home_page", response_model=ECCResponse)
 async def get_home_page(request: ECCRequest):
     """
     get home page information.
     """
-    return ecc_serv.get_home_page(request)
+    return ecc_serv.dispatch(request)

--- a/ecos/server/ecos_server/ecc/services/ecc.py
+++ b/ecos/server/ecos_server/ecc/services/ecc.py
@@ -9,8 +9,8 @@ from ..schemas import (
     CMDEnum,
     ECCRequest,
     ECCResponse,
-    ResponseEnum
-    )
+    ResponseEnum,
+)
 
 from ..sse import server_notify
 gui_notify = server_notify()
@@ -27,7 +27,7 @@ def _summarize_request(data: dict) -> dict:
         if key in data:
             summary[key] = data[key]
     if "parameters" in data:
-        summary["parameters_keys"] = len(data.get("parameters", {}))
+        summary["parameters_keys"] = len(data["parameters"])
     if "rtl_list" in data:
         rtl = data["rtl_list"]
         summary["rtl_count"] = len(rtl.splitlines() if isinstance(rtl, str) else rtl)
@@ -38,11 +38,8 @@ class ECCService:
     # Logger subtree that receives workspace-level file logging
     _WS_LOGGER_NAME = "ecos_server.ecc"
 
-    _COMMANDS = frozenset({
-        "create_workspace", "set_pdk_root", "load_workspace",
-        "delete_workspace", "rtl2gds", "run_step",
-        "get_info", "home_page",
-    })
+    # All CMDEnum values except "notify" (which is SSE-only, not dispatched).
+    _COMMANDS = frozenset(e.value for e in CMDEnum if e is not CMDEnum.notify)
 
     def __init__(self):
         self.workspace = None
@@ -628,12 +625,6 @@ class ECCService:
             "path" : ""
         }
         """
-        # get data
-        data = request.data
-
-        # check data
-
-        # process cmd
         if os.path.exists(self.workspace.home.path):
             response_data = {
                 "path" : self.workspace.home.path

--- a/ecos/server/ecos_server/ecc/services/ecc.py
+++ b/ecos/server/ecos_server/ecc/services/ecc.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import time
-from functools import wraps
 from logging.handlers import RotatingFileHandler
 
 from ..schemas import (
@@ -35,17 +34,38 @@ def _summarize_request(data: dict) -> dict:
     return summary
 
 
-def _log_api_command(func):
-    """Decorator to log API command execution with timing."""
-    @wraps(func)
-    def wrapper(self, request: ECCRequest, *args, **kwargs):
-        cmd = getattr(request, "cmd", "?")
-        data = getattr(request, "data", {})
-        logger.info("[CMD:start] cmd=%s %s", cmd, _summarize_request(data))
+class ECCService:
+    # Logger subtree that receives workspace-level file logging
+    _WS_LOGGER_NAME = "ecos_server.ecc"
+
+    _COMMANDS = frozenset({
+        "create_workspace", "set_pdk_root", "load_workspace",
+        "delete_workspace", "rtl2gds", "run_step",
+        "get_info", "home_page",
+    })
+
+    def __init__(self):
+        self.workspace = None
+        self.engine_flow = None
+        self._workspace_log_handler = None
+
+    def dispatch(self, request: ECCRequest) -> ECCResponse:
+        """Route request to the matching handler method and log execution."""
+        cmd = request.cmd
+        if cmd not in self._COMMANDS:
+            return ECCResponse(
+                cmd=cmd,
+                response=ResponseEnum.error.value,
+                data={},
+                message=[f"unknown command: {cmd}"],
+            )
+
+        handler = getattr(self, cmd)
+        logger.info("[CMD:start] cmd=%s %s", cmd, _summarize_request(request.data))
 
         start = time.time()
         try:
-            response = func(self, request, *args, **kwargs)
+            response = handler(request)
         except Exception:
             elapsed_ms = (time.time() - start) * 1000
             logger.exception("[CMD:error] cmd=%s elapsed=%.0fms", cmd, elapsed_ms)
@@ -55,17 +75,6 @@ def _log_api_command(func):
         result = getattr(response, "response", type(response).__name__)
         logger.info("[CMD:done] cmd=%s result=%s elapsed=%.0fms", cmd, result, elapsed_ms)
         return response
-    return wrapper
-
-
-class ECCService:
-    # Logger subtree that receives workspace-level file logging
-    _WS_LOGGER_NAME = "ecos_server.ecc"
-
-    def __init__(self):
-        self.workspace = None
-        self.engine_flow = None
-        self._workspace_log_handler = None
 
     def _attach_workspace_log(self, workspace_dir: str):
         """Attach a rotating file handler that mirrors API logs into {workspace}/log/server.log."""
@@ -121,20 +130,6 @@ class ECCService:
                     f.write(f"{path}\n")
         return filelist_path
 
-    def check_cmd(self, request: ECCRequest, cmd : CMDEnum):
-        # check cmd
-        if request.cmd != cmd.value:
-            response = ECCResponse(
-                cmd=request.cmd,
-                response=ResponseEnum.failed.value,
-                data={},
-                message=[f"request cmd not match: expected={cmd.value}, got={request.cmd}"]
-            )
-
-            return False, response
-
-        return True, None
-
     def __build_flow(self):
         from chipcompiler.engine import EngineFlow
         from chipcompiler.rtl2gds import build_rtl2gds_flow
@@ -153,7 +148,6 @@ class ECCService:
             return
         engine_flow.create_step_workspaces()
 
-    @_log_api_command
     def create_workspace(self, request: ECCRequest) -> ECCResponse:
         """
         "request" : {
@@ -171,11 +165,6 @@ class ECCService:
         }
         """
         from chipcompiler.data import create_workspace as _create_workspace
-
-        # check cmd
-        state, response = self.check_cmd(request, CMDEnum.create_workspace)
-        if not state:
-            return response
 
         # get data
         data = request.data
@@ -247,7 +236,6 @@ class ECCService:
                 message = [f"create workspace success : {data.get('directory', '')}"]
             )
 
-    @_log_api_command
     def set_pdk_root(self, request: ECCRequest) -> ECCResponse:
         """
         "request" : {
@@ -261,10 +249,6 @@ class ECCService:
         }
         """
         from chipcompiler.data import get_pdk
-
-        state, response = self.check_cmd(request, CMDEnum.set_pdk_root)
-        if not state:
-            return response
 
         data = request.data
         pdk_name = str(data.get("pdk", "")).strip().lower()
@@ -322,7 +306,6 @@ class ECCService:
             message=[f"set pdk root success: {pdk_name} -> {response_data['pdk_root']}"],
         )
 
-    @_log_api_command
     def load_workspace(self, request: ECCRequest) -> ECCResponse:
         """
         "request" : {
@@ -333,11 +316,6 @@ class ECCService:
         }
         """
         from chipcompiler.data import load_workspace as _load_workspace
-
-        # check cmd
-        state, response = self.check_cmd(request, CMDEnum.load_workspace)
-        if not state:
-            return response
 
         # get data
         data = request.data
@@ -384,7 +362,6 @@ class ECCService:
                 message = [f"load workspace success : {data.get('directory', '')}"]
             )
 
-    @_log_api_command
     def delete_workspace(self, request: ECCRequest) -> ECCResponse:
         """
         "request" : {
@@ -394,11 +371,6 @@ class ECCService:
             "directory" : ""
         }
         """
-        # check cmd
-        state, response = self.check_cmd(request, CMDEnum.delete_workspace)
-        if not state:
-            return response
-
         # get data
         data = request.data
         directory = data.get('directory', '')
@@ -438,7 +410,6 @@ class ECCService:
             message = [f"delete workspace success : {directory}"]
         )
 
-    @_log_api_command
     def rtl2gds(self, request: ECCRequest) -> ECCResponse:
         """
         "request" : {
@@ -448,11 +419,6 @@ class ECCService:
             "rerun" : False
         }
         """
-        # check cmd
-        state, response = self.check_cmd(request, CMDEnum.rtl2gds)
-        if not state:
-            return response
-
         # get data
         data = request.data
 
@@ -529,7 +495,6 @@ class ECCService:
                 message = [f"run rtl2gds failed in step : {failed_step}"]
             )
 
-    @_log_api_command
     def run_step(self, request: ECCRequest) -> ECCResponse:
         """
         "request" : {
@@ -542,11 +507,6 @@ class ECCService:
         }
         """
         from chipcompiler.data import StateEnum
-
-        # check cmd
-        state, response = self.check_cmd(request, CMDEnum.run_step)
-        if not state:
-            return response
 
         # get data
         data = request.data
@@ -593,7 +553,6 @@ class ECCService:
                 message = [f"run step {step} failed with state {state.value} : {self.workspace.directory}"]
             )
 
-    @_log_api_command
     def get_info(self, request: ECCRequest) -> ECCResponse:
         """
         get information by step (defined by StepEnum) and id (defined by InfoEnum)
@@ -607,11 +566,6 @@ class ECCService:
             "info" : {}
         }
         """
-        # check cmd
-        state, response = self.check_cmd(request, CMDEnum.get_info)
-        if not state:
-            return response
-
         # get data
         data = request.data
         step = data.get("step", "")
@@ -667,19 +621,13 @@ class ECCService:
                 message = [f"get information success : {step} - {id}"]
             )
 
-    @_log_api_command
-    def get_home_page(self, request: ECCRequest) -> ECCResponse:
+    def home_page(self, request: ECCRequest) -> ECCResponse:
         """
         "request" : {},
         "response" : {
             "path" : ""
         }
         """
-        # check cmd
-        state, response = self.check_cmd(request, CMDEnum.home_page)
-        if not state:
-            return response
-
         # get data
         data = request.data
 

--- a/ecos/server/run_server.py
+++ b/ecos/server/run_server.py
@@ -45,14 +45,15 @@ def _setup_logging(args) -> str:
         logging.getLogger("ecos_server").setLevel(logging.INFO)
         return log_file
 
-    print(f"[API_LOG] log -> {log_file} (tail -f {log_file})",
-          file=sys.stderr, flush=True)
-
     log_file = init_api_runtime_log(
         log_file=log_file,
         max_bytes=args.log_max_bytes,
         backup_count=args.log_backup_count,
     )
+
+    print(f"[API_LOG] log -> {log_file} (tail -f {log_file})",
+          file=sys.stderr, flush=True)
+
     return log_file
 
 

--- a/ecos/server/run_server.py
+++ b/ecos/server/run_server.py
@@ -21,6 +21,7 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 import argparse
+import logging
 import uvicorn
 
 from chipcompiler.utility.log import (
@@ -41,6 +42,7 @@ def _setup_logging(args) -> str:
     if args.disable_stdio_redirect:
         print("[API_LOG] stdio redirect disabled; logs stay on console.",
               file=sys.stderr, flush=True)
+        logging.getLogger("ecos_server").setLevel(logging.INFO)
         return log_file
 
     print(f"[API_LOG] log -> {log_file} (tail -f {log_file})",
@@ -98,7 +100,8 @@ def main():
 
     print(
         f"[API_START] pid={os.getpid()} {args.host}:{args.port} "
-        f"reload={args.reload} reload_dirs={reload_dirs or 'default'} log={log_file}",
+        f"reload={args.reload} reload_dirs={reload_dirs or 'default'} "
+        f"log={'console' if args.disable_stdio_redirect else log_file}",
         flush=True,
     )
 

--- a/ecos/server/tests/test_dispatch.py
+++ b/ecos/server/tests/test_dispatch.py
@@ -55,8 +55,7 @@ class TestDispatch:
 
     @pytest.fixture
     def service(self):
-        svc = ECCService()
-        return svc
+        return ECCService()
 
     def test_unknown_command_returns_error(self, service):
         request = ECCRequest(cmd="nonexistent_cmd", data={})

--- a/ecos/server/tests/test_dispatch.py
+++ b/ecos/server/tests/test_dispatch.py
@@ -1,0 +1,95 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from ecos_server.ecc.schemas import ECCRequest, ECCResponse, ResponseEnum
+from ecos_server.ecc.services.ecc import _summarize_request, ECCService
+
+
+class TestSummarizeRequest:
+    def test_extracts_known_fields(self):
+        data = {
+            "directory": "/tmp/ws",
+            "step": "Synthesis_yosys",
+            "id": "timing",
+            "pdk": "ics55",
+            "pdk_root": "/pdk",
+            "rerun": False,
+        }
+        result = _summarize_request(data)
+        assert result == {
+            "directory": "/tmp/ws",
+            "step": "Synthesis_yosys",
+            "id": "timing",
+            "pdk": "ics55",
+            "pdk_root": "/pdk",
+            "rerun": False,
+        }
+
+    def test_parameters_as_key_count(self):
+        data = {"parameters": {"A": 1, "B": 2, "C": 3}}
+        result = _summarize_request(data)
+        assert result == {"parameters_keys": 3}
+
+    def test_rtl_list_string_as_line_count(self):
+        data = {"rtl_list": "a.v\nb.v\nc.v"}
+        result = _summarize_request(data)
+        assert result == {"rtl_count": 3}
+
+    def test_rtl_list_list_as_length(self):
+        data = {"rtl_list": ["a.v", "b.v"]}
+        result = _summarize_request(data)
+        assert result == {"rtl_count": 2}
+
+    def test_returns_empty_for_non_dict(self):
+        assert _summarize_request(None) == {}
+        assert _summarize_request("string") == {}
+
+    def test_empty_dict(self):
+        assert _summarize_request({}) == {}
+
+
+class TestDispatch:
+    """Tests for ECCService.dispatch()."""
+
+    @pytest.fixture
+    def service(self):
+        svc = ECCService()
+        return svc
+
+    def test_unknown_command_returns_error(self, service):
+        request = ECCRequest(cmd="nonexistent_cmd", data={})
+        response = service.dispatch(request)
+        assert response.response == ResponseEnum.error.value
+        assert "unknown command" in response.message[0]
+        assert "nonexistent_cmd" in response.message[0]
+
+    def test_dispatch_routes_to_correct_method(self, service, caplog):
+        request = ECCRequest(cmd="set_pdk_root", data={"pdk": "ics55", "pdk_root": "/tmp"})
+        with caplog.at_level(logging.INFO, logger="ecos_server.ecc.services.ecc"):
+            try:
+                response = service.dispatch(request)
+            except Exception:
+                pass  # chipcompiler not installed in test env — that's fine
+        assert "[CMD:start] cmd=set_pdk_root" in caplog.text
+        assert ("[CMD:done]" in caplog.text or "[CMD:error]" in caplog.text)
+
+    def test_dispatch_logs_timing(self, service, caplog):
+        request = ECCRequest(cmd="set_pdk_root", data={"pdk": "ics55", "pdk_root": "/tmp"})
+        with caplog.at_level(logging.INFO, logger="ecos_server.ecc.services.ecc"):
+            try:
+                service.dispatch(request)
+            except Exception:
+                pass  # chipcompiler not installed in test env — that's fine
+        assert "elapsed=" in caplog.text
+
+    def test_dispatch_exception_logs_error_and_reraises(self, service, caplog):
+        service.create_workspace = MagicMock(side_effect=RuntimeError("test boom"))
+        request = ECCRequest(cmd="create_workspace", data={})
+        with caplog.at_level(logging.INFO, logger="ecos_server.ecc.services.ecc"):
+            with pytest.raises(RuntimeError, match="test boom"):
+                service.dispatch(request)
+        assert "[CMD:error] cmd=create_workspace" in caplog.text
+        assert "[CMD:done]" not in caplog.text
+


### PR DESCRIPTION
….dispatch()

- Add dispatch() method to ECCService with _COMMANDS frozenset for routing and centralized [CMD:start]/[CMD:done]/[CMD:error] logging with timing
- Remove _log_api_command decorator, check_cmd method, and functools import
- Rename get_home_page -> home_page to match CMDEnum.home_page
- Update all router endpoints to call ecc_serv.dispatch(request)
- Set ecos_server logger to INFO level when stdio redirect is disabled, so CMD logs are visible in terminal mode
- Fix misleading log= field in API_START message (shows 'console' when stdio redirect is disabled)
- Add tests for _summarize_request and dispatch routing/logging behavior