### PR TITLE
feat: add DreamPlace padding and routability_opt_flag controls

### DIFF
--- a/ecos/gui/src/composables/useParameters.ts
+++ b/ecos/gui/src/composables/useParameters.ts
@@ -65,6 +65,9 @@ export interface ParametersData {
   'Target density': number
   'Target overflow': number
   'Global right padding': number
+  'Cell padding x': number
+  'Boundary padding x': number
+  'Boundary padding y': number
   Clock: string
   'Frequency max [MHz]': number
   'Bottom layer': string
@@ -119,6 +122,9 @@ export interface ConfigData {
   targetDensity: number
   targetOverflow: number
   globalRightPadding: number
+  cellPaddingX: number
+  bndryPaddingX: number
+  bndryPaddingY: number
   clock: string
   frequencyMax: number
   bottomLayer: string
@@ -157,6 +163,9 @@ function getDefaultConfig(): ConfigData {
     targetDensity: 0.3,
     targetOverflow: 0.1,
     globalRightPadding: 0,
+    cellPaddingX: 600,
+    bndryPaddingX: 0,
+    bndryPaddingY: 0,
     clock: '',
     frequencyMax: 100,
     bottomLayer: 'MET1',
@@ -199,6 +208,9 @@ function transformParametersToConfig(data: ParametersData): ConfigData {
     targetDensity: data['Target density'] || 0.3,
     targetOverflow: data['Target overflow'] || 0.1,
     globalRightPadding: data['Global right padding'] || 0,
+    cellPaddingX: data['Cell padding x'] ?? 600,
+    bndryPaddingX: data['Boundary padding x'] ?? 0,
+    bndryPaddingY: data['Boundary padding y'] ?? 0,
     clock: data.Clock || '',
     frequencyMax: data['Frequency max [MHz]'] || 100,
     bottomLayer: data['Bottom layer'] || 'MET1',
@@ -272,6 +284,9 @@ function transformConfigToParameters(config: ConfigData): ParametersData {
     'Target density': config.targetDensity,
     'Target overflow': config.targetOverflow,
     'Global right padding': config.globalRightPadding,
+    'Cell padding x': config.cellPaddingX,
+    'Boundary padding x': config.bndryPaddingX,
+    'Boundary padding y': config.bndryPaddingY,
     Clock: config.clock,
     'Frequency max [MHz]': config.frequencyMax,
     'Bottom layer': config.bottomLayer,

--- a/ecos/gui/src/composables/useParameters.ts
+++ b/ecos/gui/src/composables/useParameters.ts
@@ -162,7 +162,7 @@ function getDefaultConfig(): ConfigData {
     targetOverflow: 0.1,
     globalRightPadding: 0,
     cellPaddingX: 600,
-    routabilityOptFlag: false,
+    routabilityOptFlag: true,
     clock: '',
     frequencyMax: 100,
     bottomLayer: 'MET1',

--- a/ecos/gui/src/composables/useParameters.ts
+++ b/ecos/gui/src/composables/useParameters.ts
@@ -66,8 +66,7 @@ export interface ParametersData {
   'Target overflow': number
   'Global right padding': number
   'Cell padding x': number
-  'Boundary padding x': number
-  'Boundary padding y': number
+  'Routability opt flag': number
   Clock: string
   'Frequency max [MHz]': number
   'Bottom layer': string
@@ -123,8 +122,7 @@ export interface ConfigData {
   targetOverflow: number
   globalRightPadding: number
   cellPaddingX: number
-  bndryPaddingX: number
-  bndryPaddingY: number
+  routabilityOptFlag: boolean
   clock: string
   frequencyMax: number
   bottomLayer: string
@@ -164,8 +162,7 @@ function getDefaultConfig(): ConfigData {
     targetOverflow: 0.1,
     globalRightPadding: 0,
     cellPaddingX: 600,
-    bndryPaddingX: 0,
-    bndryPaddingY: 0,
+    routabilityOptFlag: false,
     clock: '',
     frequencyMax: 100,
     bottomLayer: 'MET1',
@@ -209,8 +206,7 @@ function transformParametersToConfig(data: ParametersData): ConfigData {
     targetOverflow: data['Target overflow'] || 0.1,
     globalRightPadding: data['Global right padding'] || 0,
     cellPaddingX: data['Cell padding x'] ?? 600,
-    bndryPaddingX: data['Boundary padding x'] ?? 0,
-    bndryPaddingY: data['Boundary padding y'] ?? 0,
+    routabilityOptFlag: !!data['Routability opt flag'],
     clock: data.Clock || '',
     frequencyMax: data['Frequency max [MHz]'] || 100,
     bottomLayer: data['Bottom layer'] || 'MET1',
@@ -285,8 +281,7 @@ function transformConfigToParameters(config: ConfigData): ParametersData {
     'Target overflow': config.targetOverflow,
     'Global right padding': config.globalRightPadding,
     'Cell padding x': config.cellPaddingX,
-    'Boundary padding x': config.bndryPaddingX,
-    'Boundary padding y': config.bndryPaddingY,
+    'Routability opt flag': config.routabilityOptFlag ? 1 : 0,
     Clock: config.clock,
     'Frequency max [MHz]': config.frequencyMax,
     'Bottom layer': config.bottomLayer,

--- a/ecos/gui/src/views/ConfigureView.vue
+++ b/ecos/gui/src/views/ConfigureView.vue
@@ -190,6 +190,20 @@ const toggleSection = (key: keyof typeof expandedSections) => {
                 <InputNumber v-model="config.globalRightPadding" size="small" :min="0" />
               </div>
             </div>
+            <div class="field-row">
+              <div class="field">
+                <label>Cell padding X</label>
+                <InputNumber v-model="config.cellPaddingX" size="small" :min="0" />
+              </div>
+              <div class="field">
+                <label>Boundary padding X</label>
+                <InputNumber v-model="config.bndryPaddingX" size="small" :min="0" />
+              </div>
+              <div class="field">
+                <label>Boundary padding Y</label>
+                <InputNumber v-model="config.bndryPaddingY" size="small" :min="0" />
+              </div>
+            </div>
             <div class="field">
               <div class="label-row">
                 <label>Target Density</label>

--- a/ecos/gui/src/views/ConfigureView.vue
+++ b/ecos/gui/src/views/ConfigureView.vue
@@ -196,12 +196,8 @@ const toggleSection = (key: keyof typeof expandedSections) => {
                 <InputNumber v-model="config.cellPaddingX" size="small" :min="0" />
               </div>
               <div class="field">
-                <label>Boundary padding X</label>
-                <InputNumber v-model="config.bndryPaddingX" size="small" :min="0" />
-              </div>
-              <div class="field">
-                <label>Boundary padding Y</label>
-                <InputNumber v-model="config.bndryPaddingY" size="small" :min="0" />
+                <label>Routability optimization</label>
+                <Checkbox v-model="config.routabilityOptFlag" :binary="true" />
               </div>
             </div>
             <div class="field">

--- a/ecos/server/ecos.spec
+++ b/ecos/server/ecos.spec
@@ -66,49 +66,39 @@ datas.extend(klayout_datas)
 datas.extend(torch_datas)
 datas.extend(dp_datas)
 
-# DreamPlace FLUTE LUT files: native C++ opens via fixed relative path
-#   thirdparty/flute/lut.ICCAD2015/{POWV9.dat,POST9.dat}
-# These files are NOT included in the dreamplace wheel, so collect_all()
-# cannot find them. We locate them directly from the source tree.
+# DreamPlace ships thirdparty data files that native C++ code opens via fixed
+# relative paths (e.g. thirdparty/flute/lut.ICCAD2015/POWV9.dat).  These are
+# NOT included in the dreamplace wheel, so collect_all() cannot find them.
+# We locate them from the source tree and bundle them at the expected paths.
 # (run_server.py sets CWD to _MEIPASS so the relative open() resolves.)
-_flute_targets = {"POWV9.dat", "POST9.dat"}
-_flute_lut_dir = (
+_dreamplace_thirdparty = (
     Path(SPECPATH).parent.parent / "ecc" / "chipcompiler" / "thirdparty"
-    / "ecc-dreamplace" / "thirdparty" / "flute" / "lut.ICCAD2015"
+    / "ecc-dreamplace" / "thirdparty"
 )
-_flute_found = set()
-for fname in _flute_targets:
-    src = _flute_lut_dir / fname
-    if src.exists():
-        datas.append((str(src), "thirdparty/flute/lut.ICCAD2015"))
-        _flute_found.add(fname)
-if _flute_found != _flute_targets:
-    warnings.warn(
-        f"DreamPlace FLUTE LUT files not found in {_flute_lut_dir}; "
-        "placement may fail at runtime when opening POWV9.dat/POST9.dat.",
-        stacklevel=1,
-    )
 
-# DreamPlace NCTUgr: routability optimization depends on external binary + config
-#   thirdparty/NCTUgr.ICCAD2012/{NCTUgr,*.dat,*.set}
-# Same situation as FLUTE: not included in the dreamplace wheel.
-_nctugr_targets = {"NCTUgr", "PORT9.dat", "POST9.dat", "POWV9.dat", "DAC12.set", "ICCAD12.set"}
-_nctugr_dir = (
-    Path(SPECPATH).parent.parent / "ecc" / "chipcompiler" / "thirdparty"
-    / "ecc-dreamplace" / "thirdparty" / "NCTUgr.ICCAD2012"
+def _collect_thirdparty_files(subdir, targets, warning_msg):
+    """Collect files from a DreamPlace thirdparty subdirectory into datas."""
+    src_dir = _dreamplace_thirdparty / subdir
+    bundle_dest = f"thirdparty/{subdir}"
+    found = set()
+    for fname in targets:
+        src = src_dir / fname
+        if src.exists():
+            datas.append((str(src), bundle_dest))
+            found.add(fname)
+    if found != targets:
+        warnings.warn(f"{warning_msg} (missing from {src_dir})", stacklevel=2)
+
+_collect_thirdparty_files(
+    "flute/lut.ICCAD2015",
+    {"POWV9.dat", "POST9.dat"},
+    "DreamPlace FLUTE LUT files not found; placement may fail at runtime.",
 )
-_nctugr_found = set()
-for fname in _nctugr_targets:
-    src = _nctugr_dir / fname
-    if src.exists():
-        datas.append((str(src), "thirdparty/NCTUgr.ICCAD2012"))
-        _nctugr_found.add(fname)
-if _nctugr_found != _nctugr_targets:
-    warnings.warn(
-        f"DreamPlace NCTUgr files not found in {_nctugr_dir}; "
-        "routability optimization (routability_opt_flag=1) will fail at runtime.",
-        stacklevel=1,
-    )
+_collect_thirdparty_files(
+    "NCTUgr.ICCAD2012",
+    {"NCTUgr", "PORT9.dat", "POST9.dat", "POWV9.dat", "DAC12.set", "ICCAD12.set"},
+    "DreamPlace NCTUgr files not found; routability optimization will fail at runtime.",
+)
 
 # --- Binaries ---
 binaries = []

--- a/ecos/server/ecos.spec
+++ b/ecos/server/ecos.spec
@@ -89,6 +89,27 @@ if _flute_found != _flute_targets:
         stacklevel=1,
     )
 
+# DreamPlace NCTUgr: routability optimization depends on external binary + config
+#   thirdparty/NCTUgr.ICCAD2012/{NCTUgr,*.dat,*.set}
+# Same situation as FLUTE: not included in the dreamplace wheel.
+_nctugr_targets = {"NCTUgr", "PORT9.dat", "POST9.dat", "POWV9.dat", "DAC12.set", "ICCAD12.set"}
+_nctugr_dir = (
+    Path(SPECPATH).parent.parent / "ecc" / "chipcompiler" / "thirdparty"
+    / "ecc-dreamplace" / "thirdparty" / "NCTUgr.ICCAD2012"
+)
+_nctugr_found = set()
+for fname in _nctugr_targets:
+    src = _nctugr_dir / fname
+    if src.exists():
+        datas.append((str(src), "thirdparty/NCTUgr.ICCAD2012"))
+        _nctugr_found.add(fname)
+if _nctugr_found != _nctugr_targets:
+    warnings.warn(
+        f"DreamPlace NCTUgr files not found in {_nctugr_dir}; "
+        "routability optimization (routability_opt_flag=1) will fail at runtime.",
+        stacklevel=1,
+    )
+
 # --- Binaries ---
 binaries = []
 binaries.extend(ecc_binaries)


### PR DESCRIPTION
This pull request adds support for three new padding configuration options—cell padding X, boundary padding X, and boundary padding Y—across the parameters data model, configuration interface, and the user interface for configuration. These changes ensure that the new padding values are included in data transformations, have default values, and are exposed to users in the configuration view.

**Parameter and configuration model updates:**

* Added `cellPaddingX`, `bndryPaddingX`, and `bndryPaddingY` fields to the `ParametersData` and `ConfigData` TypeScript interfaces in `useParameters.ts` to support the new padding options. [[1]](diffhunk://#diff-481e503f69c0039d2ff29e5911538d5dd5cfecf62902872819a582758f21921aR68-R70) [[2]](diffhunk://#diff-481e503f69c0039d2ff29e5911538d5dd5cfecf62902872819a582758f21921aR125-R127)

* Updated the `getDefaultConfig` function to provide default values for the new padding fields (`cellPaddingX: 600`, `bndryPaddingX: 0`, `bndryPaddingY: 0`).

* Modified the `transformParametersToConfig` and `transformConfigToParameters` functions to correctly map the new padding fields between parameter and config representations. [[1]](diffhunk://#diff-481e503f69c0039d2ff29e5911538d5dd5cfecf62902872819a582758f21921aR211-R213) [[2]](diffhunk://#diff-481e503f69c0039d2ff29e5911538d5dd5cfecf62902872819a582758f21921aR287-R289)

**User interface update:**

* Added new input fields for "Cell padding X", "Boundary padding X", and "Boundary padding Y" in the configuration view (`ConfigureView.vue`), allowing users to set these values through the UI.