### PR TITLE
fix(gui): capitalize PDN "grid" key to "Grid" for backend compatibility

### DIFF
--- a/ecos/gui/src/composables/useParameters.ts
+++ b/ecos/gui/src/composables/useParameters.ts
@@ -313,7 +313,7 @@ function transformConfigToParameters(config: ConfigData): ParametersData {
         'instance pin name': gc.instancePinName,
         'is power': gc.isPower
       })),
-      grid: {
+      Grid: {
         layer: config.pdn.grid.layer,
         'power net': config.pdn.grid.powerNet,
         'ground net': config.pdn.grid.groundNet,


### PR DESCRIPTION
The frontend's transformConfigToParameters() was writing "grid" (lowercase) while the backend runner.py reads "Grid" (uppercase). After any GUI save, PDN grid config was silently lost.