### PR TITLE
ci: add cargo clippy and vue-tsc jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,12 +30,15 @@ jobs:
         with:
           workspaces: ecos/gui/src-tauri
       # api-server is built by Bazel/PyInstaller and does not exist in CI.
-      # tauri-build's build.rs validates externalBin entries before compilation,
-      # so we stub the file to satisfy the check without the real binary.
+      # oss-cad-suite is not committed to git (only .gitkeep).
+      # tauri-build validates externalBin and resource paths in build.rs,
+      # so we stub them to satisfy the checks without the real artifacts.
       - run: |
           mkdir -p binaries
           touch binaries/api-server-x86_64-unknown-linux-gnu
           chmod +x binaries/api-server-x86_64-unknown-linux-gnu
+          mkdir -p resources/oss-cad-suite
+          touch resources/oss-cad-suite/README
       - run: cargo clippy -- -D warnings
 
   vue-tsc:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,33 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uvx ruff format --check
       - run: uvx ruff check
+
+  clippy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ecos/gui/src-tauri
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ecos/gui/src-tauri
+      - run: cargo clippy -- -D warnings
+
+  vue-tsc:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ecos/gui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ecos/gui/.nvmrc
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec vue-tsc --noEmit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,16 +29,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ecos/gui/src-tauri
-      # api-server is built by Bazel/PyInstaller and does not exist in CI.
-      # oss-cad-suite is not committed to git (only .gitkeep).
-      # tauri-build validates externalBin and resource paths in build.rs,
-      # so we stub them to satisfy the checks without the real artifacts.
+      # Stub artifacts absent in CI:
+      # - api-server: Bazel/PyInstaller sidecar, checked by tauri-build build.rs
+      # - oss-cad-suite: not committed to git, checked by tauri-build build.rs
+      # - ../dist: Vite output, checked by tauri::generate_context!() proc macro
       - run: |
           mkdir -p binaries
           touch binaries/api-server-x86_64-unknown-linux-gnu
           chmod +x binaries/api-server-x86_64-unknown-linux-gnu
           mkdir -p resources/oss-cad-suite
           touch resources/oss-cad-suite/README
+          mkdir -p ../dist
       - run: cargo clippy -- -D warnings
 
   vue-tsc:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ecos/gui/src-tauri
+      # api-server is built by Bazel/PyInstaller and does not exist in CI.
+      # tauri-build's build.rs validates externalBin entries before compilation,
+      # so we stub the file to satisfy the check without the real binary.
+      - run: |
+          mkdir -p binaries
+          touch binaries/api-server-x86_64-unknown-linux-gnu
+          chmod +x binaries/api-server-x86_64-unknown-linux-gnu
       - run: cargo clippy -- -D warnings
 
   vue-tsc:

--- a/ecos/gui/src-tauri/src/gen_layout_tiles.rs
+++ b/ecos/gui/src-tauri/src/gen_layout_tiles.rs
@@ -619,7 +619,6 @@ fn parse_dbu_per_micron(units: Option<&Value>) -> i64 {
         return 1000;
     };
     let first = u
-        .trim()
         .split_whitespace()
         .next()
         .and_then(|s| s.parse::<f64>().ok())

--- a/ecos/gui/src-tauri/src/main.rs
+++ b/ecos/gui/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 mod gen_layout_tiles;
 
+#[cfg(not(debug_assertions))]
 use std::io::IsTerminal;
 use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
@@ -16,6 +17,7 @@ use sha2::{Digest, Sha256};
 
 /// Returns true when the process was launched from an interactive terminal
 /// (i.e. stderr is a TTY). False when launched from a desktop file / launcher.
+#[cfg(not(debug_assertions))]
 fn is_launched_from_terminal() -> bool {
     std::io::stderr().is_terminal()
 }
@@ -232,7 +234,7 @@ fn wait_for_server_ready(port: u16, timeout_secs: u64) -> bool {
             return true;
         }
 
-        if start.elapsed().as_secs() >= 4 && attempt % 3 == 0 {
+        if start.elapsed().as_secs() >= 4 && attempt.is_multiple_of(3) {
             debug!(
                 "Still waiting for server on port {}... ({:.1}s elapsed)",
                 port,
@@ -368,11 +370,11 @@ fn start_api_server(
                     child.id(),
                     port
                 );
-                return ApiStartResult::Started(child, port);
+                ApiStartResult::Started(child, port)
             }
             Err(e) => {
                 error!("Failed to start FastAPI server: {}", e);
-                return ApiStartResult::Failed;
+                ApiStartResult::Failed
             }
         }
     }
@@ -1026,7 +1028,7 @@ fn main() {
                 // Start the FastAPI server (or detect an externally started one)
                 let (using_external_server, actual_port) = {
                     let mut server = api_server.lock().unwrap();
-                    match start_api_server(&app.handle()) {
+                    match start_api_server(app.handle()) {
                         ApiStartResult::Started(child, port) => {
                             *server = Some(child);
                             *api_port.lock().unwrap() = port;


### PR DESCRIPTION
- clippy: cargo clippy -D warnings with Swatinem/rust-cache; needs webkit2gtk system deps for Tauri's build.rs but subsequent runs are fast via dependency cache
- vue-tsc: --noEmit only, skips Vite build