### PR TITLE
ci: fix apt-get 404 by running update before install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: ecos/gui/src-tauri
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: sudo apt-get update && sudo apt-get install -y --fix-missing libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Stale package index on ubuntu-latest caused gdk-pixbuf 404s. Add apt-get update and --fix-missing to the clippy job.