### PR TITLE
fix(gui): stabilize packaged splitter layout

### DIFF
--- a/ecos/gui/src/styles/index.css
+++ b/ecos/gui/src/styles/index.css
@@ -153,7 +153,7 @@ img {
 }
 
 /* 优化 Splitter 性能 */
-.p-splitter-panel {
+.p-splitterpanel {
   will-change: auto;
   contain: layout style paint;
 }

--- a/ecos/gui/src/views/HomeView.vue
+++ b/ecos/gui/src/views/HomeView.vue
@@ -8,16 +8,12 @@
       class="dashboard-splitter"
       layout="vertical"
       :gutterSize="6"
-      stateKey="home-dashboard-outer"
-      stateStorage="local"
     >
       <!-- ================= Row 1: Chip Info | Runtime Monitoring ================= -->
       <SplitterPanel :size="26" :minSize="10" class="dashboard-row">
         <Splitter
           class="dashboard-row-splitter"
           :gutterSize="6"
-          stateKey="home-dashboard-row1"
-          stateStorage="local"
         >
           <SplitterPanel :size="45" :minSize="15" class="dashboard-cell">
       <section class="section-card chip-info-area">
@@ -100,8 +96,6 @@
         <Splitter
           class="dashboard-row-splitter"
           :gutterSize="6"
-          stateKey="home-dashboard-row2"
-          stateStorage="local"
         >
           <SplitterPanel :size="45" :minSize="15" class="dashboard-cell">
       <!-- ========== Row 2 Left+Center: Layout Preview ========== -->
@@ -177,8 +171,6 @@
         <Splitter
           class="dashboard-row-splitter"
           :gutterSize="6"
-          stateKey="home-dashboard-row3"
-          stateStorage="local"
         >
           <SplitterPanel :size="45" :minSize="15" class="dashboard-cell">
       <!-- ========== Row 3 Left: Flow step log ========== -->
@@ -1016,6 +1008,10 @@ function stateClass(state: string): string {
   z-index: 1;
   height: 100%;
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
   padding: 8px;
   background: transparent;
   border: none;
@@ -1037,9 +1033,14 @@ function stateClass(state: string): string {
 }
 
 .dashboard-row-splitter {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
   flex: 1;
   width: 100%;
   height: 100%;
+  min-width: 0;
+  min-height: 0;
   background: transparent;
   border: none;
   border-radius: 0;

--- a/ecos/gui/src/views/WorkspaceView.vue
+++ b/ecos/gui/src/views/WorkspaceView.vue
@@ -140,10 +140,18 @@ onUnmounted(() => {
 }
 
 :deep(.p-splitter) {
+  display: flex;
+  flex-wrap: nowrap;
+  min-width: 0;
+  min-height: 0;
   background: transparent;
   border: none;
   /* layout only; avoid paint containment on panels (conflicts with wide tables + scrollbars in WebKitGTK) */
   contain: layout;
+}
+
+:deep(.p-splitter.p-splitter-vertical) {
+  flex-direction: column;
 }
 
 /*
@@ -152,9 +160,29 @@ onUnmounted(() => {
  * 在此用更高优先级只保留 style containment，避免横向把整行撑出视口。
  */
 :deep(.p-splitterpanel) {
+  display: flex;
+  flex-grow: 1;
   min-width: 0;
+  min-height: 0;
   overflow: hidden;
   contain: style;
+}
+
+:deep(.p-splitterpanel-nested) {
+  display: flex;
+}
+
+:deep(.p-splitterpanel > *) {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+}
+
+:deep(.p-splitterpanel .p-splitter) {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  border: 0 none;
 }
 
 :deep(.p-splitter-gutter) {

--- a/ecos/gui/src/views/WorkspaceView.vue
+++ b/ecos/gui/src/views/WorkspaceView.vue
@@ -147,11 +147,11 @@ onUnmounted(() => {
 }
 
 /*
- * index.css 对 .p-splitter-panel 使用了 contain: layout style paint；
+ * index.css 对 .p-splitterpanel 使用了 contain: layout style paint；
  * 在部分 WebKit/GTK 下与宽图/替换元素组合时，会误参与祖先的 min-content 宽度。
  * 在此用更高优先级只保留 style containment，避免横向把整行撑出视口。
  */
-:deep(.p-splitter-panel) {
+:deep(.p-splitterpanel) {
   min-width: 0;
   overflow: hidden;
   contain: style;
@@ -193,14 +193,14 @@ onUnmounted(() => {
  * Right Chat/Inspector: PrimeVue sets flex-basis; theme often uses flex:1 with flex-shrink 1.
  * Wide Floorplan tables have huge min-content and shrink this column; !important prevents flex-shrink.
  */
-:deep(.p-splitter-panel.chat-panel) {
+:deep(.p-splitterpanel.chat-panel) {
   box-sizing: border-box;
   flex-grow: 0 !important;
   flex-shrink: 0 !important;
 }
 
 /* Fill column width; avoid subtree content width affecting parent flex */
-:deep(.chat-panel.p-splitter-panel > *) {
+:deep(.chat-panel.p-splitterpanel > *) {
   min-width: 0;
   width: 100%;
   max-width: 100%;


### PR DESCRIPTION
## Summary

This PR fixes a packaged-build GUI regression related to PrimeVue `Splitter`.

After `HomeView` was migrated to `Splitter`, packaged Tauri builds could render both `HomeView` and `WorkspaceView` incorrectly. In practice, panels could collapse, stack vertically, or lose their intended split layout, while development mode often still looked normal.

## Root Cause

There were two issues behind this regression:

- Our Splitter panel compatibility selectors targeted `.p-splitter-panel`, but PrimeVue 4 actually renders `.p-splitterpanel`.
- `HomeView` and `WorkspaceView` relied too much on implicit Splitter base flex behavior, which was more fragile in packaged builds than in dev mode.

Because of that, the intended sizing, overflow, and containment fixes were not actually applied where we expected them to be.

## Changes

- Update Splitter panel selectors to use the correct PrimeVue 4 class name: `.p-splitterpanel`.
- Remove `HomeView` Splitter state persistence so the dashboard always starts from the code-defined layout.
- Make `HomeView` Splitter layout more explicit instead of relying on implicit runtime styling.
- Harden `WorkspaceView` Splitter layout with explicit flex/min-size rules for nested Splitter panels.

## Result

- `HomeView` now renders correctly in packaged builds.
- `WorkspaceView` no longer collapses or stacks incorrectly in packaged builds.
- Splitter behavior is now more consistent between dev and packaged environments.

## Testing

- Verified `HomeView` layout in packaged build.
- Verified `WorkspaceView` layout in packaged build.
- Ran frontend typecheck:

```bash
pnpm exec vue-tsc --noEmit
