### PR TITLE
feat(api-startup): diagnose and mitigate slow packaged cold start

### DIFF
--- a/ecos/gui/src-tauri/src/api_server.rs
+++ b/ecos/gui/src-tauri/src/api_server.rs
@@ -23,7 +23,34 @@ pub const DEFAULT_API_PORT: u16 = 8765;
 /// How many ports to scan beyond the default before giving up
 const PORT_SEARCH_RANGE: u16 = 100;
 
-const API_READY_TIMEOUT_SECS: u64 = 15;
+/// Default deadline (in seconds) for the spawned FastAPI server to reach
+/// `/health == ok`. Overridable at runtime via `ECOS_API_READY_TIMEOUT_SECS`
+/// — useful when shipping a diagnostic build to a user whose cold start is
+/// dominated by PyInstaller onefile extraction / heavy imports.
+const API_READY_TIMEOUT_SECS_DEFAULT: u64 = 60;
+
+fn api_ready_timeout_secs() -> u64 {
+    match std::env::var("ECOS_API_READY_TIMEOUT_SECS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(value) if value > 0 => value,
+            Ok(_) => {
+                warn!(
+                    "ECOS_API_READY_TIMEOUT_SECS=0 is not allowed; falling back to default {}s",
+                    API_READY_TIMEOUT_SECS_DEFAULT
+                );
+                API_READY_TIMEOUT_SECS_DEFAULT
+            }
+            Err(e) => {
+                warn!(
+                    "ECOS_API_READY_TIMEOUT_SECS={:?} is not a valid u64 ({}); falling back to default {}s",
+                    raw, e, API_READY_TIMEOUT_SECS_DEFAULT
+                );
+                API_READY_TIMEOUT_SECS_DEFAULT
+            }
+        },
+        Err(_) => API_READY_TIMEOUT_SECS_DEFAULT,
+    }
+}
 
 #[cfg(windows)]
 const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
@@ -151,8 +178,9 @@ fn wait_for_server_ready(
     use std::time::Instant;
 
     info!(
-        "Waiting for FastAPI server to be ready on port {} (token check: {})...",
+        "Waiting for FastAPI server to be ready on port {} (timeout: {}s, token check: {})...",
         port,
+        timeout_secs,
         expected_token.is_some()
     );
     let start = Instant::now();
@@ -197,10 +225,11 @@ fn wait_for_server_ready(
         }
 
         if start.elapsed().as_secs() >= 4 && attempt.is_multiple_of(3) {
-            debug!(
-                "Still waiting for server on port {}... ({:.1}s elapsed)",
+            info!(
+                "Still waiting for server on port {}... ({:.1}s elapsed, attempt {})",
                 port,
-                start.elapsed().as_secs_f32()
+                start.elapsed().as_secs_f32(),
+                attempt
             );
         }
 
@@ -332,7 +361,7 @@ pub fn start_api_server(
                 }
             };
 
-            match wait_for_server_ready(&mut child, port, API_READY_TIMEOUT_SECS, Some(&token)) {
+            match wait_for_server_ready(&mut child, port, api_ready_timeout_secs(), Some(&token)) {
                 ServerReadyState::Ready => {
                     info!(
                         "FastAPI server started with PID: {} on port {}",
@@ -474,7 +503,7 @@ pub fn start_api_server(
                 }
             }
 
-            match wait_for_server_ready(&mut child, port, API_READY_TIMEOUT_SECS, Some(&token)) {
+            match wait_for_server_ready(&mut child, port, api_ready_timeout_secs(), Some(&token)) {
                 ServerReadyState::Ready => {
                     info!(
                         "FastAPI server started with PID: {} on port {}",

--- a/ecos/gui/src-tauri/src/api_server.rs
+++ b/ecos/gui/src-tauri/src/api_server.rs
@@ -27,7 +27,7 @@ const PORT_SEARCH_RANGE: u16 = 100;
 /// `/health == ok`. Overridable at runtime via `ECOS_API_READY_TIMEOUT_SECS`
 /// — useful when shipping a diagnostic build to a user whose cold start is
 /// dominated by PyInstaller onefile extraction / heavy imports.
-const API_READY_TIMEOUT_SECS_DEFAULT: u64 = 60;
+const API_READY_TIMEOUT_SECS_DEFAULT: u64 = 180;
 
 fn api_ready_timeout_secs() -> u64 {
     match std::env::var("ECOS_API_READY_TIMEOUT_SECS") {

--- a/ecos/gui/src-tauri/src/main.rs
+++ b/ecos/gui/src-tauri/src/main.rs
@@ -26,8 +26,13 @@ use tile_cache::{
 use window_commands::{clamp_window_to_monitor, window_close, window_maximize, window_minimize};
 
 fn main() {
-    // Default to warnings in production while still honoring RUST_LOG overrides.
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+    // Default: third-party crates stay at `warn`, but our own crate emits `info`
+    // so key lifecycle logs (API server spawn / readiness / timing) are visible
+    // in the terminal when running the packaged AppImage. `RUST_LOG` still wins.
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("warn,ecos_studio=info"),
+    )
+    .init();
 
     // Shared state for the API server process and discovered port
     let api_server: ApiServerProcess = Arc::new(Mutex::new(None));

--- a/ecos/gui/src/api/client.ts
+++ b/ecos/gui/src/api/client.ts
@@ -123,7 +123,7 @@ export interface WaitForApiReadyOptions {
  * Use before workspace/critical API calls so the GUI does not race the FastAPI child process.
  */
 export async function waitForApiReady(options?: WaitForApiReadyOptions): Promise<void> {
-  const timeoutMs = options?.timeoutMs ?? 90_000
+  const timeoutMs = options?.timeoutMs ?? 180_000
   const intervalMs = options?.intervalMs ?? 250
   const healthTimeoutMs = options?.healthTimeoutMs ?? 1500
   const deadline = Date.now() + timeoutMs

--- a/ecos/gui/src/composables/useWorkspace.ts
+++ b/ecos/gui/src/composables/useWorkspace.ts
@@ -101,7 +101,7 @@ export function useWorkspace() {
   const ensureApiReady = async (): Promise<boolean> => {
     apiBackendConnecting.value = true
     try {
-      await waitForApiReady({ timeoutMs: 90_000 })
+      await waitForApiReady({ timeoutMs: 180_000 })
       return true
     } catch {
       showToast({

--- a/ecos/server/ecos_server/main.py
+++ b/ecos/server/ecos_server/main.py
@@ -1,15 +1,46 @@
 #!/usr/bin/env python
 
 import os
+import sys
+import time
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .ecc import sse_router, workspace_router
 
-# Create FastAPI application
+
+def _elapsed_since_process_start() -> float:
+    """Seconds since `run_server.py` started, if the anchor is available."""
+    try:
+        t0 = float(os.environ.get("ECOS_SERVER_STARTUP_T0", ""))
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, time.monotonic() - t0)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Emit a single-line readiness marker so the Tauri host can see when
+    the FastAPI app is actually serving requests (not just when uvicorn.run
+    was invoked). Written unconditionally to stderr so it survives any uvicorn
+    log-level configuration."""
+    elapsed = _elapsed_since_process_start()
+    print(
+        f"[API_READY] pid={os.getpid()} elapsed={elapsed:.2f}s "
+        f"token={os.environ.get('ECOS_SERVER_INSTANCE_TOKEN', '')[:8]}",
+        file=sys.stderr,
+        flush=True,
+    )
+    yield
+
+
 app = FastAPI(
-    title="ECOS Studio API", description="Backend API for ECOS Studio", version="0.1.0-alpha.4"
+    title="ECOS Studio API",
+    description="Backend API for ECOS Studio",
+    version="0.1.0-alpha.4",
+    lifespan=lifespan,
 )
 
 # Configure CORS for frontend access

--- a/ecos/server/run_server.py
+++ b/ecos/server/run_server.py
@@ -7,11 +7,28 @@ This script is intended to be spawned by Tauri at application startup.
 
 import os
 import sys
+import time
+
+# Track startup phases so a packaged binary can be diagnosed purely from stdout.
+# These prints are unconditional (independent of log level) and cheap.
+_STARTUP_T0 = time.monotonic()
+
+
+def _phase(label: str) -> None:
+    print(
+        f"[API_PHASE] t={time.monotonic() - _STARTUP_T0:.2f}s {label}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+_phase("process_started")
 
 # In PyInstaller onefile mode, native C++ code (e.g. FLUTE) opens files via
 # relative paths anchored at _MEIPASS. Switch CWD so those paths resolve.
 if hasattr(sys, "_MEIPASS"):
     os.chdir(sys._MEIPASS)
+    _phase("meipass_extracted_and_cwd_set")
 
 # Add project root to path for imports
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -22,11 +39,18 @@ if project_root not in sys.path:
 import argparse
 import logging
 
+_phase("import_uvicorn_start")
 import uvicorn
+
+_phase("import_uvicorn_done")
+
+_phase("import_chipcompiler_log_start")
 from chipcompiler.utility.log import (
     build_timestamped_log_file,
     init_api_runtime_log,
 )
+
+_phase("import_chipcompiler_log_done")
 
 
 def _setup_logging(args) -> str:
@@ -128,6 +152,11 @@ def main():
         flush=True,
     )
 
+    # Expose the anchor timestamp so ecos_server.main can emit [API_READY] with
+    # a consistent "seconds since process start" measurement.
+    os.environ["ECOS_SERVER_STARTUP_T0"] = str(_STARTUP_T0)
+
+    _phase("uvicorn_run_called")
     uvicorn.run(
         "ecos_server.main:app",
         host=args.host,


### PR DESCRIPTION
## Summary

Users on packaged AppImage builds sometimes see a "Backend
unavailable" toast when the FastAPI child process takes too long
to answer `/health`. This PR ships the instrumentation needed to
diagnose *where* the time is spent, and raises the readiness
deadline so the current dominant contributors no longer trip it.

### Two coordinated changes

**1. Observability.** Without structured markers, a slow
packaged cold start is a black box: the user just sees a toast
and can't tell what happened. This PR adds:

- Rust default log filter → `warn,ecos_studio=info` (no more
  silence in packaged builds; an explicit `RUST_LOG` still
  overrides).
- `wait_for_server_ready` timeout is configurable via the
  `ECOS_API_READY_TIMEOUT_SECS` env var, with validation.
- `run_server.py` prints `[API_PHASE] t=<s> <label>` markers
  around `_MEIPASS` chdir and the heavy imports (`uvicorn`,
  `chipcompiler.utility.log`). These are unconditional stderr
  prints that run before logging is configured, so they
  survive any log-level config.
- `ecos_server.main` uses a FastAPI `lifespan` hook to emit a
  single `[API_READY]` line with elapsed-since-process-start,
  distinguishing "uvicorn.run was called" from "the app
  actually accepts /health".

**2. Raise defaults.** Measurements from a diagnostic build
show the packaged cold start is dominated by phases that
happen *before* a single line of user Python code runs, and
can substantially exceed the previous 60 s cap on slower disks.
The main contributors, in order:

| # | phase | root cause | fixable? |
|---|---|---|---|
| 1 | PyInstaller onefile bootloader extracting the bundled interpreter, stdlib, and native deps into `/tmp/_MEIxxxxxx/` | `ecos.spec` uses `onefile=True` | yes, with an `onedir` migration |
| 2 | matplotlib font cache initialization | `chipcompiler.utility.__init__` eagerly imports `.plot`, which pulls in `matplotlib`/`pandas` | yes, upstream in chipcompiler, or by inlining the log helpers |
| 3 | Remaining Python imports + FastAPI lifespan | unavoidable | no |

Accordingly:

- Rust: `API_READY_TIMEOUT_SECS_DEFAULT` 60 s → 180 s.
- Frontend: `waitForApiReady` default and the
  `useWorkspace.ensureApiReady` call site 90 s → 180 s, so the
  toast can never fire before Rust observes `/health=ok`.

Both remain overridable at runtime.

This is a stopgap. A follow-up PR will migrate the server
bundle to PyInstaller `onedir` to eliminate contributor #1
(the dominant one) entirely.

## Example output after this PR

Launching the packaged AppImage from a terminal now produces a
sequence like the following (placeholders in angle brackets):
