### PR TITLE
docs: add AppImage introduction and GUI environment requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Enabling mainstream manufacturing processes.
 
 - [ECOS-Studio AppImage (amd64)](https://github.com/openecos-projects/ecos-studio/releases/latest/)
 
-For Linux Desktop x86_64 users, you can download the latest ECOS Studio AppImage from the releases page. After downloading, make the file executable and run it to launch ECOS Studio.
+[AppImage](https://en.wikipedia.org/wiki/AppImage) is a portable Linux application format — download a single file, make it executable, and run it without installation. For Linux Desktop x86_64 users, you can download the latest ECOS Studio AppImage from the releases page.
 ```shell
 # Download and run ECOS Studio on Linux x86_64
 wget https://github.com/openecos-projects/ecos-studio/releases/latest/download/<latest-release-file>.AppImage

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Enabling mainstream manufacturing processes.
 
 - [ECOS-Studio AppImage (amd64)](https://github.com/openecos-projects/ecos-studio/releases/latest/)
 
-[AppImage](https://en.wikipedia.org/wiki/AppImage) is a portable Linux application format — download a single file, make it executable, and run it without installation. For Linux Desktop x86_64 users, you can download the latest ECOS Studio AppImage from the releases page.
+[AppImage](https://en.wikipedia.org/wiki/AppImage) is a portable Linux application format — download a single file, make it executable, and run it without installation. ECOS Studio is a GUI application and requires a desktop environment (X11 or Wayland) to run — it cannot be launched from a headless environment. For Linux Desktop x86_64 users, you can download the latest ECOS Studio AppImage from the releases page.
 ```shell
 # Download and run ECOS Studio on Linux x86_64
 wget https://github.com/openecos-projects/ecos-studio/releases/latest/download/<latest-release-file>.AppImage

--- a/ecos/README.md
+++ b/ecos/README.md
@@ -14,7 +14,7 @@ ECOS Studio is a desktop application that provides an integrated development env
 
 - [ECOS-Studio AppImage (amd64)](https://github.com/openecos-projects/ecos-studio/releases/latest/)
 
-For Linux Desktop x86_64 users, you can download the latest ECOS Studio AppImage from the releases page. After downloading, make the file executable and run it to launch ECOS Studio.
+[AppImage](https://en.wikipedia.org/wiki/AppImage) is a portable Linux application format — download a single file, make it executable, and run it without installation. For Linux Desktop x86_64 users, you can download the latest ECOS Studio AppImage from the releases page.
 ```shell
 # Download and run ECOS Studio on Linux x86_64
 wget https://github.com/openecos-projects/ecos-studio/releases/latest/download/<latest-release-file>.AppImage

--- a/ecos/README.md
+++ b/ecos/README.md
@@ -14,7 +14,7 @@ ECOS Studio is a desktop application that provides an integrated development env
 
 - [ECOS-Studio AppImage (amd64)](https://github.com/openecos-projects/ecos-studio/releases/latest/)
 
-[AppImage](https://en.wikipedia.org/wiki/AppImage) is a portable Linux application format — download a single file, make it executable, and run it without installation. For Linux Desktop x86_64 users, you can download the latest ECOS Studio AppImage from the releases page.
+[AppImage](https://en.wikipedia.org/wiki/AppImage) is a portable Linux application format — download a single file, make it executable, and run it without installation. ECOS Studio is a GUI application and requires a desktop environment (X11 or Wayland) to run — it cannot be launched from a headless environment. For Linux Desktop x86_64 users, you can download the latest ECOS Studio AppImage from the releases page.
 ```shell
 # Download and run ECOS Studio on Linux x86_64
 wget https://github.com/openecos-projects/ecos-studio/releases/latest/download/<latest-release-file>.AppImage

--- a/ecos/docs/FAQ.md
+++ b/ecos/docs/FAQ.md
@@ -33,6 +33,8 @@ Yes, ECOS Studio is open-source software. See the [LICENSE](../../LICENSE) file 
 
 Download the AppImage from the [Releases](https://github.com/openecos-projects/ecos-studio/releases/latest) page, then run:
 
+> [AppImage](https://en.wikipedia.org/wiki/AppImage) is a portable Linux application format — download a single file, make it executable, and run it without installation. ECOS Studio is a GUI application and requires a desktop environment (X11 or Wayland) to run — it cannot be launched from a headless environment.
+
 ```bash
 chmod +x ECOS-Studio_*.AppImage
 ./ECOS-Studio_*.AppImage

--- a/ecos/docs/user-guide.md
+++ b/ecos/docs/user-guide.md
@@ -39,6 +39,9 @@ This guide will walk you through using ECOS Studio to design and implement your 
 ### Launching ECOS Studio
 
 **Linux (AppImage):**
+
+> [AppImage](https://en.wikipedia.org/wiki/AppImage) is a portable Linux application format — download a single file, make it executable, and run it without installation. ECOS Studio is a GUI application and requires a desktop environment (X11 or Wayland) to run — it cannot be launched from a headless environment.
+
 ```bash
 chmod +x ./ECOS-Studio_*.AppImage
 ./ECOS-Studio_*.AppImage


### PR DESCRIPTION
Briefly explain what AppImage is (portable Linux app format) with Wikipedia link, and note that a desktop environment (X11/Wayland) is required in README, ecos/README, user-guide, and FAQ.