### PR TITLE
fix(gui): restore warn default for Rust logs, make py log level controllable

### DIFF
--- a/ecos/README.md
+++ b/ecos/README.md
@@ -57,6 +57,18 @@ cd ecos/gui && RUST_LOG=ecos_studio=info pnpm tauri dev
 cd ecos/gui && RUST_LOG=ecos_studio::api_server=debug pnpm tauri dev
 ```
 
+Python API server startup markers (`[API_PHASE]`, `[API_START]`, `[API_READY]`,
+`[API_LOG]`) are suppressed by default. Set `ECOS_API_LOG_LEVEL=info` to show
+them, or pass `--log-level info` to `run_server.py`:
+
+```bash
+# Show API server startup phases
+ECOS_API_LOG_LEVEL=info cd ecos/server && python run_server.py
+
+# Equivalent via CLI flag
+cd ecos/server && python run_server.py --log-level info
+```
+
 ### DreamPlace Development
 
 DreamPlace C++ operators are compiled by Bazel and installed as `.so` files into the source tree for venv-based development:

--- a/ecos/README.md
+++ b/ecos/README.md
@@ -46,6 +46,17 @@ make dev
 cd ecos/gui && pnpm tauri dev
 ```
 
+Rust-side GUI logs default to warnings and errors. Use `RUST_LOG` when you need
+more detail while debugging the Tauri shell:
+
+```bash
+# GUI lifecycle diagnostics
+cd ecos/gui && RUST_LOG=ecos_studio=info pnpm tauri dev
+
+# More detailed API server startup diagnostics
+cd ecos/gui && RUST_LOG=ecos_studio::api_server=debug pnpm tauri dev
+```
+
 ### DreamPlace Development
 
 DreamPlace C++ operators are compiled by Bazel and installed as `.so` files into the source tree for venv-based development:

--- a/ecos/docs/FAQ.md
+++ b/ecos/docs/FAQ.md
@@ -46,19 +46,6 @@ See the [User Guide](user-guide.md) for detailed instructions on creating worksp
 
 ## Troubleshooting
 
-**Q: How do I enable GUI Rust diagnostic logs?**
-
-By default, the GUI prints Rust warnings and errors only. Launch the AppImage
-from a terminal with `RUST_LOG` to enable more detailed Rust-side diagnostics:
-
-```bash
-# GUI lifecycle diagnostics
-RUST_LOG=ecos_studio=info ./ECOS-Studio_*.AppImage
-
-# More detailed API server startup diagnostics
-RUST_LOG=ecos_studio::api_server=debug ./ECOS-Studio_*.AppImage
-```
-
 **Q: AppImage fails to launch on a virtual machine (GL / GVFS / ATK errors)**
 
 Errors such as `undefined symbol: g_task_set_static_name` or `Failed to load module: /usr/lib/x86_64-linux-gnu/gio/modules/libgvfsdbus.so`.
@@ -86,3 +73,35 @@ Large or complex designs may exceed the 10-minute synthesis timeout. Use a small
 **Q: DreamPlace placement fails with "overflow is significant" or HPWL is infinity/nan**
 
 The core utilization or target density is too high for the placer to converge. Try reducing Core Utilization and Target Density, increasing Cell Padding, or enabling the Routability Opt Flag in the Configuration page. See [#50](https://github.com/openecos-projects/ecos-studio/issues/50) for details.
+
+**Q: How do I enable GUI Rust diagnostic logs?**
+
+By default, the GUI prints Rust warnings and errors only. Launch the AppImage
+from a terminal with `RUST_LOG` to enable more detailed Rust-side diagnostics:
+
+```bash
+# GUI lifecycle diagnostics
+RUST_LOG=ecos_studio=info ./ECOS-Studio_*.AppImage
+
+# More detailed API server startup diagnostics
+RUST_LOG=ecos_studio::api_server=debug ./ECOS-Studio_*.AppImage
+```
+
+**Q: How do I enable Python API server startup logs?**
+
+The Python API server emits startup phase markers (`[API_PHASE]`, `[API_START]`,
+`[API_READY]`, `[API_LOG]`) that are hidden by default (log level `warning`).
+Set `ECOS_API_LOG_LEVEL=info` to show them:
+
+```bash
+# AppImage: show API server startup phases
+ECOS_API_LOG_LEVEL=info ./ECOS-Studio_*.AppImage
+
+# Development: show API server startup phases
+ECOS_API_LOG_LEVEL=info python ecos/server/run_server.py
+
+# Or pass the CLI flag directly
+python ecos/server/run_server.py --log-level info
+```
+
+Available levels: `debug`, `info`, `warning` (default), `error`, `critical`.

--- a/ecos/docs/FAQ.md
+++ b/ecos/docs/FAQ.md
@@ -46,6 +46,19 @@ See the [User Guide](user-guide.md) for detailed instructions on creating worksp
 
 ## Troubleshooting
 
+**Q: How do I enable GUI Rust diagnostic logs?**
+
+By default, the GUI prints Rust warnings and errors only. Launch the AppImage
+from a terminal with `RUST_LOG` to enable more detailed Rust-side diagnostics:
+
+```bash
+# GUI lifecycle diagnostics
+RUST_LOG=ecos_studio=info ./ECOS-Studio_*.AppImage
+
+# More detailed API server startup diagnostics
+RUST_LOG=ecos_studio::api_server=debug ./ECOS-Studio_*.AppImage
+```
+
 **Q: AppImage fails to launch on a virtual machine (GL / GVFS / ATK errors)**
 
 Errors such as `undefined symbol: g_task_set_static_name` or `Failed to load module: /usr/lib/x86_64-linux-gnu/gio/modules/libgvfsdbus.so`.

--- a/ecos/gui/src-tauri/src/main.rs
+++ b/ecos/gui/src-tauri/src/main.rs
@@ -26,13 +26,9 @@ use tile_cache::{
 use window_commands::{clamp_window_to_monitor, window_close, window_maximize, window_minimize};
 
 fn main() {
-    // Default: third-party crates stay at `warn`, but our own crate emits `info`
-    // so key lifecycle logs (API server spawn / readiness / timing) are visible
-    // in the terminal when running the packaged AppImage. `RUST_LOG` still wins.
-    env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("warn,ecos_studio=info"),
-    )
-    .init();
+    // Default to warnings/errors. Users can opt into more detail with RUST_LOG,
+    // for example: RUST_LOG=ecos_studio=info or RUST_LOG=ecos_studio::api_server=debug.
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
 
     // Shared state for the API server process and discovered port
     let api_server: ApiServerProcess = Arc::new(Mutex::new(None));

--- a/ecos/server/ecos_server/__init__.py
+++ b/ecos/server/ecos_server/__init__.py
@@ -1,3 +1,9 @@
-from .main import app
+def __getattr__(name):
+    if name == "app":
+        from .main import app
+
+        return app
+    raise AttributeError(name)
+
 
 __all__ = ["app"]

--- a/ecos/server/ecos_server/_log.py
+++ b/ecos/server/ecos_server/_log.py
@@ -1,0 +1,18 @@
+import logging
+import os
+import sys
+
+
+def ensure_api_logger() -> logging.Logger:
+    log = logging.getLogger("ecos.api")
+    if not log.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        log.addHandler(handler)
+        log.propagate = False
+        level = os.environ.get("ECOS_API_LOG_LEVEL", "warning").upper()
+        try:
+            log.setLevel(level)
+        except ValueError:
+            log.setLevel(logging.WARNING)
+    return log

--- a/ecos/server/ecos_server/main.py
+++ b/ecos/server/ecos_server/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import sys
 import time
 from contextlib import asynccontextmanager
 from functools import lru_cache
@@ -11,6 +10,7 @@ from importlib.metadata import version as distribution_version
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from ._log import ensure_api_logger
 from .ecc import sse_router, workspace_router
 
 
@@ -41,16 +41,13 @@ def _elapsed_since_process_start() -> float:
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    """Emit a single-line readiness marker so the Tauri host can see when
-    the FastAPI app is actually serving requests (not just when uvicorn.run
-    was invoked). Written unconditionally to stderr so it survives any uvicorn
-    log-level configuration."""
+    log = ensure_api_logger()
     elapsed = _elapsed_since_process_start()
-    print(
-        f"[API_READY] pid={os.getpid()} elapsed={elapsed:.2f}s "
-        f"token={os.environ.get('ECOS_SERVER_INSTANCE_TOKEN', '')[:8]}",
-        file=sys.stderr,
-        flush=True,
+    log.info(
+        "[API_READY] pid=%d elapsed=%.2fs token=%s",
+        os.getpid(),
+        elapsed,
+        os.environ.get("ECOS_SERVER_INSTANCE_TOKEN", "")[:8],
     )
     yield
 

--- a/ecos/server/run_server.py
+++ b/ecos/server/run_server.py
@@ -5,39 +5,39 @@ Standalone script to run the FastAPI server.
 This script is intended to be spawned by Tauri at application startup.
 """
 
+import logging
 import os
 import sys
 import time
 
-# Track startup phases so a packaged binary can be diagnosed purely from stdout.
-# These prints are unconditional (independent of log level) and cheap.
 _STARTUP_T0 = time.monotonic()
 
-
-def _phase(label: str) -> None:
-    print(
-        f"[API_PHASE] t={time.monotonic() - _STARTUP_T0:.2f}s {label}",
-        file=sys.stderr,
-        flush=True,
-    )
-
-
-_phase("process_started")
-
-# In PyInstaller onefile mode, native C++ code (e.g. FLUTE) opens files via
-# relative paths anchored at _MEIPASS. Switch CWD so those paths resolve.
+# MEIPASS CWD fix must happen before any native code opens files by relative path.
 if hasattr(sys, "_MEIPASS"):
     os.chdir(sys._MEIPASS)
-    _phase("meipass_extracted_and_cwd_set")
 
-# Add project root to path for imports
+# Make ecos_server importable so we can import the shared logger helper
+# without triggering heavy imports (ecos_server.__init__ is lazy).
 script_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.abspath(os.path.join(script_dir, "../.."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
+from ecos_server._log import ensure_api_logger
+
+_log = ensure_api_logger()
+
+
+def _phase(label: str) -> None:
+    _log.info("[API_PHASE] t=%.2fs %s", time.monotonic() - _STARTUP_T0, label)
+
+
+_phase("process_started")
+
+if hasattr(sys, "_MEIPASS"):
+    _phase("meipass_extracted_and_cwd_set")
+
 import argparse
-import logging
 
 _phase("import_uvicorn_start")
 import uvicorn
@@ -63,9 +63,7 @@ def _setup_logging(args) -> str:
         log_file = build_timestamped_log_file(log_file=log_file, pid=os.getpid())
 
     if args.disable_stdio_redirect:
-        print(
-            "[API_LOG] stdio redirect disabled; logs stay on console.", file=sys.stderr, flush=True
-        )
+        _log.info("[API_LOG] stdio redirect disabled; logs stay on console.")
         logging.getLogger("ecos_server").setLevel(logging.INFO)
         return log_file
 
@@ -75,7 +73,7 @@ def _setup_logging(args) -> str:
         backup_count=args.log_backup_count,
     )
 
-    print(f"[API_LOG] log -> {log_file} (tail -f {log_file})", file=sys.stderr, flush=True)
+    _log.info("[API_LOG] log -> %s (tail -f %s)", log_file, log_file)
 
     return log_file
 
@@ -137,6 +135,14 @@ def main():
     )
 
     args = parser.parse_args()
+    raw_level = args.log_level.upper()
+    try:
+        _log.setLevel(raw_level)
+    except ValueError:
+        _log.setLevel(logging.DEBUG if raw_level == "TRACE" else logging.WARNING)
+    # Mirror the resolved level into env so the Uvicorn reload child
+    # picks up the same effective level (it does not re-execute run_server.py).
+    os.environ["ECOS_API_LOG_LEVEL"] = logging.getLevelName(_log.level)
     log_file = _setup_logging(args)
 
     reload_dirs = [
@@ -145,11 +151,14 @@ def main():
         if path and path.strip()
     ]
 
-    print(
-        f"[API_START] pid={os.getpid()} {args.host}:{args.port} "
-        f"reload={args.reload} reload_dirs={reload_dirs or 'default'} "
-        f"log={'console' if args.disable_stdio_redirect else log_file}",
-        flush=True,
+    _log.info(
+        "[API_START] pid=%d %s:%d reload=%s reload_dirs=%s log=%s",
+        os.getpid(),
+        args.host,
+        args.port,
+        args.reload,
+        reload_dirs or "default",
+        "console" if args.disable_stdio_redirect else log_file,
     )
 
     # Expose the anchor timestamp so ecos_server.main can emit [API_READY] with


### PR DESCRIPTION
## Summary

Make Rust GUI and Python API server log output quieter by default, with opt-in verbosity controls.

### Rust GUI (`RUST_LOG`)

- Restore default `env_logger` filter from `warn,ecos_studio=info` to `warn`.
- Opt into diagnostics with `RUST_LOG=ecos_studio=info` or `RUST_LOG=ecos_studio::api_server=debug`.

### Python API server (`ECOS_API_LOG_LEVEL` / `--log-level`)

- Replace unconditional `print()` startup markers (`[API_PHASE]`, `[API_LOG]`, `[API_START]`, `[API_READY]`) with `logging.info()` on a named `ecos.api` logger.
- Default level is `warning`; markers appear only when `ECOS_API_LOG_LEVEL=info` or `--log-level info` is set.
- Extract shared `ensure_api_logger()` into `ecos_server/_log.py`; make `ecos_server/__init__.py` lazy (PEP 562) so the import doesn't trigger heavy FastAPI loads during early startup.
- Mirror resolved `--log-level` back to `ECOS_API_LOG_LEVEL` env var so Uvicorn reload children inherit the correct level.
- Handle non-stdlib level names gracefully (e.g. uvicorn's `TRACE` → downgraded to `DEBUG`).