### PR TITLE
feat(gui): improve home layout preview and message controls

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -363,7 +363,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "nvW/NrBXlAmiQw99EMGKkLaD2KbNp2mQDlxdfpr+0Ls=",
+        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -427,7 +427,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "9cZw51LLMu2V/jKcxvnA1pBg58ZgQEDuMni3CbNZSRg=",
+        "bzlTransitiveDigest": "W97kKxM+lW7l/kO0rQa7Jm31CA1j+W1bNHGKjwX5xMg=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -662,7 +662,7 @@
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
+        "bzlTransitiveDigest": "zyNsrbgVKwpA0B3zI84imAfuC424VSzYNPgjr/HJy5M=",
         "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/ecos/gui/src/App.vue
+++ b/ecos/gui/src/App.vue
@@ -22,7 +22,7 @@
     </div>
 
     <!-- 全局 Toast 通知 -->
-    <Toast position="top-right" />
+    <Toast position="top-right" class="app-toast" />
 
     <!-- 全局新建工程向导 -->
     <NewProjectWizard v-if="showNewProjectWizard" @close="showNewProjectWizard = false" @create="handleWizardCreate" />
@@ -136,14 +136,14 @@ let unlistenWindowResized: (() => void) | undefined
  * `.window-maximized` 的权威来源是 `isMaximized()`，但它是一次 IPC 往返、
  * 往往要几 ~ 几十 ms 才 resolve。而最大化在屏幕上是瞬时发生的，这段 IPC
  * 窗口期里 WebKitGTK 的 transparent 已失效（最大化关闭透明），app-container
- * 的圆角 + 边框又还没被 `.window-maximized` 消掉 —— 圆角/边框位置就露出
- * 了 webview 的白画布，即用户看到的"最大化白闪"。
+ * 的边框又还没被 `.window-maximized` 消掉，边缘位置就可能露出 webview
+ * 的白画布，即用户看到的"最大化白闪"。
  *
  * 对策：在 onResized 事件回调里同步读 `window.innerWidth/innerHeight` 与
  * `screen.availWidth/availHeight` 比较，视口接近铺满屏幕就直接乐观地挂上
  * `.window-maximized`；随后 `isMaximized()` 的权威结果再由 `syncMaximizedClass`
- * 做修正。边缘拖拽缩放时启发式判为 false，`.window-maximized` 不挂，透明圆角
- * 浮岛视觉完整保留。
+ * 做修正。边缘拖拽缩放时启发式判为 false，`.window-maximized` 不挂，窗口
+ * 常态视觉完整保留。
  *
  * `- 2` 的余量是为了兼容某些 WM（KDE / Hyprland 等）把窗口最大化到不含面板
  * 的工作区时，视口比 availWidth 少 1 ~ 2 px 的 off-by-one。
@@ -161,7 +161,7 @@ const markResizing = () => {
   // 广播全局状态，组件（如 HomeView 的 ECharts）可据此跳过昂贵重绘
   setWindowResizing(true)
   // 同步快路径：视口已经铺满屏幕就立刻挂 `.window-maximized`，
-  // 不等 `isMaximized()` IPC 回来，消除最大化瞬间的圆角/边框白闪。
+  // 不等 `isMaximized()` IPC 回来，消除最大化瞬间的边框白闪。
   if (detectLikelyMaximized()) {
     document.body.classList.add('window-maximized')
   }
@@ -188,7 +188,7 @@ const startResize = async (direction: ResizeDirection) => {
  * 同步窗口最大化状态到 body.window-maximized。
  *
  * 目的：Linux (WebKitGTK) 下「透明 + 无装饰 + 最大化」组合会让 webview
- * 露出白色画布，因此最大化时需要把根层背景改成主题色、去掉圆角边框，
+ * 露出白色画布，因此最大化时需要把根层背景改成主题色、去掉边框，
  * 见 styles/index.css 与本文件 scoped 样式中的 `.window-maximized` 规则。
  */
 async function syncMaximizedClass() {
@@ -362,6 +362,49 @@ onUnmounted(() => {
 .window-resizing {
   cursor: default;
 }
+
+/*
+ * PrimeVue Toast is rendered by this root component and its internal markup is
+ * not scoped. Keep long backend errors, paths, and command output inside the
+ * notification bubble instead of letting them spill past the rounded panel.
+ */
+.app-toast.p-toast {
+  width: min(420px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+}
+
+.app-toast .p-toast-message {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.app-toast .p-toast-message-content {
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.app-toast .p-toast-message-icon,
+.app-toast .p-toast-close-button {
+  flex: 0 0 auto;
+}
+
+.app-toast .p-toast-message-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.app-toast .p-toast-summary,
+.app-toast .p-toast-detail {
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.app-toast .p-toast-detail {
+  line-height: 1.45;
+}
 </style>
 
 <style scoped>
@@ -378,17 +421,16 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  /* 圆角窗口效果 */
-  border-radius: 10px;
+  border-radius: 0;
   background: var(--bg-primary);
   /* 边框 - 微弱的亮色边框 */
   border: 1px solid rgba(128, 128, 128, 0.3);
 }
 
 /*
- * 最大化时取消圆角 + 边框：
- * 最大化后窗口占满屏幕，圆角外露出的就是 webview 白画布（也就是截图里
- * 那片白屏）。把圆角去掉后 .app-container 能贴住窗口四边，彻底没处可露。
+ * 最大化时取消边框：
+ * 最大化后窗口占满屏幕，边框外露出的可能是 webview 白画布（也就是截图里
+ * 那片白屏）。去掉边框后 .app-container 能贴住窗口四边，彻底没处可露。
  * body 不会被 scoped 加 data-v 属性（它是 ancestor），`.app-container`
  * 是本组件自身元素，scoped 转换后选择器仍能正确命中。
  */

--- a/ecos/gui/src/components/AIChatPanel.vue
+++ b/ecos/gui/src/components/AIChatPanel.vue
@@ -13,7 +13,7 @@
       </div>
       <div v-else class="messages-container py-4 space-y-4 min-w-0 w-full max-w-full overflow-hidden">
         <MessageItem v-for="msg in messages" :key="msg.id" :message="msg" @img-load="onImageLoad"
-          class="message-item w-full min-w-0 max-w-full" />
+          @close="messageStore.removeMessage(msg.id)" class="message-item w-full min-w-0 max-w-full" />
       </div>
     </div>
 
@@ -67,11 +67,12 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onUnmounted, onActivated } from 'vue'
+import { storeToRefs } from 'pinia'
 import MessageItem from './MessageItem.vue'
 import { useMessageStore } from '../stores/messageStore'
 
 const messageStore = useMessageStore()
-const { messages } = messageStore
+const { messages } = storeToRefs(messageStore)
 
 const inputValue = ref('')
 const scrollContainerRef = ref<HTMLDivElement | null>(null)
@@ -182,9 +183,11 @@ const onImageLoad = () => {
 }
 
 // 监听消息变化，自动滚动到底部
-watch(() => messages.length, () => {
-  // 新消息到来时强制滚动到底部
-  scrollToBottomIfNeeded(true)
+watch(() => messages.value.length, (newLength, oldLength) => {
+  // 新消息到来时强制滚动到底部；删除消息时保持用户当前浏览位置
+  if (newLength > oldLength) {
+    scrollToBottomIfNeeded(true)
+  }
 })
 
 const handleSubmit = () => {

--- a/ecos/gui/src/components/MessageItem.vue
+++ b/ecos/gui/src/components/MessageItem.vue
@@ -24,6 +24,10 @@
           aria-label="查阅" @click.stop="openImageLightbox(message.mapData.title, message.mapData.imageUrl)">
           <i class="ri-fullscreen-fill"></i>
         </button>
+        <button type="button" class="info-report-header-close-btn info-report-header-close-btn--sm shrink-0"
+          title="关闭" aria-label="关闭" @click.stop="emit('close')">
+          <i class="ri-close-line"></i>
+        </button>
       </div>
 
       <!-- 统计信息 -->
@@ -99,6 +103,10 @@
           aria-label="查阅" @click.stop="openHeaderReportLightbox">
           <i class="ri-fullscreen-fill"></i>
         </button>
+        <button type="button" class="info-report-header-close-btn" title="关闭" aria-label="关闭"
+          @click.stop="emit('close')">
+          <i class="ri-close-line"></i>
+        </button>
       </div>
 
       <!-- 数据内容 - 直接显示表格 -->
@@ -119,11 +127,13 @@
         <!-- JSON 格式 - 复杂对象 -->
         <div v-else-if="item.format === 'json'" class="p-3 overflow-hidden">
           <pre
-            class="text-[11px] bg-(--bg-primary) p-3 rounded whitespace-pre overflow-auto max-h-[400px] font-mono text-content-pre"><code>{{ JSON.stringify(item.content, null, 2) }}</code></pre>
+            class="nested-report-scroll text-[11px] bg-(--bg-primary) p-3 rounded whitespace-pre overflow-auto max-h-[400px] font-mono text-content-pre"
+            @wheel="onNestedReportWheel"><code>{{ JSON.stringify(item.content, null, 2) }}</code></pre>
         </div>
 
         <!-- CSV 格式 - 表格显示 -->
-        <div v-else-if="item.format === 'csv'" class="overflow-auto max-h-[400px]">
+        <div v-else-if="item.format === 'csv'" class="nested-report-scroll overflow-auto max-h-[400px]"
+          @wheel="onNestedReportWheel">
           <table class="w-full text-xs border-collapse">
             <thead v-if="csvHeaders(item.content).length > 0" class="sticky top-0">
               <tr class="bg-(--bg-primary)">
@@ -147,7 +157,8 @@
         <!-- HTML 报告：嵌入区缩小字号；全屏查阅见标题栏按钮 -->
         <div v-else-if="item.format === 'html'" class="p-3 overflow-hidden">
           <div class="rounded-lg overflow-hidden bg-(--bg-primary) border border-(--border-color)/30 max-h-[350px]">
-            <div class="info-html-embed markdown-body info-html-embed--compact overflow-auto max-h-[350px] p-3"
+            <div class="nested-report-scroll info-html-embed markdown-body info-html-embed--compact overflow-auto max-h-[350px] p-3"
+              @wheel="onNestedReportWheel"
               v-html="coerceHtmlString(item.content)"></div>
           </div>
         </div>
@@ -156,7 +167,8 @@
         <div v-else class="p-3 overflow-hidden">
           <div class="rounded-lg overflow-hidden bg-(--bg-primary) border border-(--border-color)/30 max-h-[350px]">
             <pre
-              class="info-text-embed-compact bg-(--bg-primary) p-3 rounded-none whitespace-pre overflow-auto max-h-[350px] font-mono text-content-pre"><code>{{ item.content }}</code></pre>
+              class="nested-report-scroll info-text-embed-compact bg-(--bg-primary) p-3 rounded-none whitespace-pre overflow-auto max-h-[350px] font-mono text-content-pre"
+              @wheel="onNestedReportWheel"><code>{{ item.content }}</code></pre>
           </div>
         </div>
       </div>
@@ -164,11 +176,16 @@
 
     <!-- 其他消息类型 -->
     <div v-else :class="[
-      'max-w-[85%] rounded-lg text-sm',
+      'message-bubble group relative max-w-[85%] rounded-lg text-sm',
       message.role === 'user'
         ? 'bg-(--accent-color) text-(--accent-text)'
         : 'bg-(--bg-secondary) text-(--text-primary) border border-(--border-color)'
     ]">
+      <button type="button" class="message-close-btn" title="删除" aria-label="删除"
+        @click.stop="emit('close')">
+        <i class="ri-close-line"></i>
+      </button>
+
       <!-- 图片消息 -->
       <div v-if="message.type === 'image' && message.image" class="p-2">
         <p class="text-xs opacity-90">{{ message.image.label }}:</p>
@@ -182,11 +199,15 @@
             @click.stop="openImageLightbox(message.image.label || 'Image', message.image.url)">
             <i class="ri-fullscreen-fill"></i>
           </button>
+          <button type="button" class="image-close-overlay-btn" title="关闭" aria-label="关闭"
+            @click.stop="emit('close')">
+            <i class="ri-close-line"></i>
+          </button>
         </div>
       </div>
 
       <!-- 文本消息 -->
-      <div v-else class="px-4 py-2">
+      <div v-else class="px-4 py-2 pr-8">
         <!-- 加载状态 -->
         <div v-if="message.status === 'loading' && !message.content" class="flex items-center gap-2">
           <div class="loading-dots flex gap-1">
@@ -241,7 +262,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import MarkdownIt from 'markdown-it'
 import type { Message } from '../types'
 import { sanitizeHtml } from '@/utils/sanitizeHtml'
@@ -252,6 +273,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'img-load'): void
+  (e: 'close'): void
 }>()
 
 const md = new MarkdownIt({
@@ -319,6 +341,37 @@ function openReportLightbox(title: string, content: unknown, mode: 'html' | 'tex
 
 function closeReportLightbox() {
   reportLightbox.value.visible = false
+}
+
+function onDocumentKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && reportLightbox.value.visible) {
+    closeReportLightbox()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', onDocumentKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', onDocumentKeydown)
+})
+
+function onNestedReportWheel(e: WheelEvent) {
+  const el = e.currentTarget as HTMLElement | null
+  if (!el) return
+  const canScroll = el.scrollHeight > el.clientHeight
+  if (!canScroll) return
+
+  const atTop = el.scrollTop <= 0
+  const atBottom = Math.ceil(el.scrollTop + el.clientHeight) >= el.scrollHeight
+  const scrollingUp = e.deltaY < 0
+  const scrollingDown = e.deltaY > 0
+
+  if ((scrollingUp && atTop) || (scrollingDown && atBottom)) {
+    e.preventDefault()
+    el.closest('.custom-scrollbar')?.scrollBy({ top: e.deltaY })
+  }
 }
 
 function openImageLightbox(title: string, url: string) {
@@ -576,6 +629,38 @@ function csvRows(content: string): string[][] {
   display: block;
 }
 
+.message-close-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 5px;
+  background: rgba(0, 0, 0, 0.18);
+  color: currentColor;
+  cursor: pointer;
+  font-size: 12px;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: opacity 0.15s ease, transform 0.15s ease, background-color 0.15s ease;
+}
+
+.message-bubble:hover .message-close-btn,
+.message-close-btn:focus-visible {
+  opacity: 0.72;
+  transform: translateY(0);
+}
+
+.message-close-btn:hover {
+  opacity: 1;
+  background: rgba(239, 68, 68, 0.18);
+}
+
 /* 加载动画 */
 .loading-dots span {
   animation: bounce 1s infinite;
@@ -650,8 +735,9 @@ function csvRows(content: string): string[][] {
   font-weight: 600;
 }
 
-/* Info 卡片标题栏：全屏查阅（与内嵌报告区分离，避免挡内容） */
-.info-report-header-fs-btn {
+/* Info 卡片标题栏：查阅 / 关闭（与内嵌报告区分离，避免挡内容） */
+.info-report-header-fs-btn,
+.info-report-header-close-btn {
   flex-shrink: 0;
   width: 32px;
   height: 32px;
@@ -666,21 +752,31 @@ function csvRows(content: string): string[][] {
   font-size: 16px;
 }
 
-.info-report-header-fs-btn:hover {
+.info-report-header-fs-btn:hover,
+.info-report-header-close-btn:hover {
   background: var(--bg-secondary);
+}
+
+.info-report-header-fs-btn:hover {
   color: var(--accent-color);
 }
 
+.info-report-header-close-btn:hover {
+  color: #ef4444;
+}
+
 /* Map 标题栏更紧凑的尺寸 */
-.info-report-header-fs-btn--sm {
+.info-report-header-fs-btn--sm,
+.info-report-header-close-btn--sm {
   width: 24px;
   height: 24px;
   font-size: 13px;
   border-radius: 5px;
 }
 
-/* 图片消息：右上角浮动全屏按钮 */
-.image-fs-overlay-btn {
+/* 图片消息：右上角浮动操作按钮 */
+.image-fs-overlay-btn,
+.image-close-overlay-btn {
   position: absolute;
   top: 6px;
   right: 6px;
@@ -701,14 +797,25 @@ function csvRows(content: string): string[][] {
   backdrop-filter: blur(4px);
 }
 
+.image-close-overlay-btn {
+  right: 40px;
+}
+
 .group:hover .image-fs-overlay-btn,
-.image-fs-overlay-btn:focus-visible {
+.group:hover .image-close-overlay-btn,
+.image-fs-overlay-btn:focus-visible,
+.image-close-overlay-btn:focus-visible {
   opacity: 1;
   transform: translateY(0);
 }
 
-.image-fs-overlay-btn:hover {
+.image-fs-overlay-btn:hover,
+.image-close-overlay-btn:hover {
   background: rgba(0, 0, 0, 0.75);
+}
+
+.image-close-overlay-btn:hover {
+  color: #fecaca;
 }
 
 /* HTML 报告查阅 Lightbox（与 HomeView 图表预览一致） */

--- a/ecos/gui/src/components/TopBar.vue
+++ b/ecos/gui/src/components/TopBar.vue
@@ -276,7 +276,6 @@ const handleMouseDown = async (event: MouseEvent) => {
   user-select: none;
   -webkit-user-select: none;
   background: var(--topbar-bg);
-  border-radius: 9px 9px 0 0;
   border-bottom: 1px solid var(--border-color);
   position: relative;
   cursor: default;
@@ -505,7 +504,7 @@ const handleMouseDown = async (event: MouseEvent) => {
 }
 
 .window-btn-close {
-  border-radius: 0 10px 0 0;
+  border-radius: 0;
 }
 
 .window-btn-close:hover {
@@ -513,14 +512,6 @@ const handleMouseDown = async (event: MouseEvent) => {
   color: white;
 }
 
-/*
- * 最大化时贴边：
- * 窗口最大化后 `.app-container` 已经去掉圆角（见 App.vue 里的
- * `body.window-maximized .app-container`），但顶栏自身和关闭按钮的圆角
- * 仍然存在，导致右上角被"削"掉一块 —— 用户按费茨定律把鼠标甩到屏幕
- * 最右上角时，那块视觉透明区域让按钮看起来点不到。最大化时一并去掉
- * 这两处圆角，让关闭按钮正好贴到屏幕右上角像素。
- */
 body.window-maximized .topbar {
   border-radius: 0;
 }

--- a/ecos/gui/src/stores/messageStore.ts
+++ b/ecos/gui/src/stores/messageStore.ts
@@ -123,7 +123,17 @@ export const useMessageStore = defineStore('messages', () => {
    * 清空所有消息
    */
   const clearMessages = () => {
-    messages.value = []
+    messages.value.splice(0, messages.value.length)
+  }
+
+  /**
+   * 删除单条消息
+   */
+  const removeMessage = (id: string): void => {
+    const index = messages.value.findIndex(message => message.id === id)
+    if (index !== -1) {
+      messages.value.splice(index, 1)
+    }
   }
 
   return {
@@ -135,6 +145,7 @@ export const useMessageStore = defineStore('messages', () => {
     addImageMessage,
     addInfoMessage,
     addMapMessage,
+    removeMessage,
     clearMessages
   }
 })

--- a/ecos/gui/src/views/HomeView.vue
+++ b/ecos/gui/src/views/HomeView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="home-view">
+  <div :class="['home-view', { 'layout-fullscreen-active': isLayoutFullscreen }]">
     <!-- 背景装饰 -->
     <div class="bg-grid"></div>
 
@@ -102,34 +102,36 @@
         >
           <SplitterPanel :size="45" :minSize="15" class="dashboard-cell">
       <!-- ========== Row 2 Left+Center: Layout Preview ========== -->
-      <section ref="layoutSectionRef" :class="['section-card layout-area', { 'is-fullscreen': isLayoutFullscreen }]">
-        <div class="section-header">
-          <div class="header-icon layout"><i class="ri-layout-masonry-line"></i></div>
-          <h2>Layout</h2>
-          <span class="header-hint">Displays the final step of the layout after the run is completed.</span>
-          <div class="header-actions">
-            <button class="action-btn" @click="toggleLayoutFullscreen"
-              :title="isLayoutFullscreen ? 'Exit full screen' : 'full screen'">
-              <i :class="isLayoutFullscreen ? 'ri-fullscreen-exit-line' : 'ri-fullscreen-line'"></i>
-            </button>
+      <Teleport to="body" :disabled="!isLayoutFullscreen">
+        <section ref="layoutSectionRef" :class="['section-card layout-area', { 'is-fullscreen': isLayoutFullscreen }]">
+          <div class="section-header">
+            <div class="header-icon layout"><i class="ri-layout-masonry-line"></i></div>
+            <h2>Layout</h2>
+            <span class="header-hint">Displays the final step of the layout after the run is completed.</span>
+            <div class="header-actions">
+              <button class="action-btn" @click="toggleLayoutFullscreen"
+                :title="isLayoutFullscreen ? 'Exit full screen' : 'full screen'">
+                <i :class="isLayoutFullscreen ? 'ri-fullscreen-exit-line' : 'ri-fullscreen-line'"></i>
+              </button>
+            </div>
           </div>
-        </div>
-        <div ref="layoutContentRef" class="layout-content" @wheel.prevent="onLayoutWheel" @mousedown="onLayoutMouseDown"
-          @mousemove="onLayoutMouseMove" @mouseup="onLayoutMouseUp" @mouseleave="onLayoutMouseUp">
-          <img v-if="layoutBlobUrl" :src="layoutBlobUrl" alt="Layout Preview" class="layout-image"
-            :style="layoutImageTransform" draggable="false" />
-          <!-- 科技感扫描线 -->
-          <!-- <div v-if="layoutBlobUrl && !isLayoutFullscreen" class="scanner-line"></div> -->
-          <div v-else-if="!layoutBlobUrl" class="layout-placeholder">
-            <i class="ri-image-2-line"></i>
-            <p>Layout Preview</p>
-            <span>Waiting for layout data...</span>
+          <div ref="layoutContentRef" class="layout-content" @wheel.prevent="onLayoutWheel" @mousedown="onLayoutMouseDown"
+            @mousemove="onLayoutMouseMove" @mouseup="onLayoutMouseUp" @mouseleave="onLayoutMouseUp">
+            <img v-if="layoutBlobUrl" :src="layoutBlobUrl" alt="Layout Preview" class="layout-image"
+              :style="layoutImageTransform" draggable="false" />
+            <!-- 科技感扫描线 -->
+            <!-- <div v-if="layoutBlobUrl && !isLayoutFullscreen" class="scanner-line"></div> -->
+            <div v-else-if="!layoutBlobUrl" class="layout-placeholder">
+              <i class="ri-image-2-line"></i>
+              <p>Layout Preview</p>
+              <span>Waiting for layout data...</span>
+            </div>
+            <div v-if="isLayoutFullscreen && layoutBlobUrl" class="zoom-indicator">
+              {{ Math.round(layoutScale * 100) }}%
+            </div>
           </div>
-          <div v-if="isLayoutFullscreen && layoutBlobUrl" class="zoom-indicator">
-            {{ Math.round(layoutScale * 100) }}%
-          </div>
-        </div>
-      </section>
+        </section>
+      </Teleport>
 
           </SplitterPanel>
 
@@ -1016,6 +1018,10 @@ function stateClass(state: string): string {
   background: var(--bg-primary);
 }
 
+.home-view.layout-fullscreen-active {
+  z-index: 10050;
+}
+
 .bg-grid {
   position: absolute;
   inset: 0;
@@ -1153,13 +1159,13 @@ function stateClass(state: string): string {
 
 .layout-area.is-fullscreen {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  z-index: 9999;
+  inset: 0;
+  width: auto;
+  height: auto;
+  z-index: 20020;
   border-radius: 0;
   background: var(--bg-primary);
+  box-sizing: border-box;
 }
 
 .layout-area.is-fullscreen .layout-content {

--- a/ecos/scripts/build-gui.sh
+++ b/ecos/scripts/build-gui.sh
@@ -134,8 +134,30 @@ mkdir -p "$GUI_DIR"
 
 # Bazel sandbox exposes source files as symlinks. Vite/Rollup may resolve
 # realpaths outside the workspace root and reject emitted asset names.
-# Copy with dereference to build from a physical tree.
-cp -RL "$GUI_SRC_DIR/." "$GUI_DIR/"
+# Copy with dereference to build from a physical tree, while leaving local
+# dependency trees and generated bundles behind. Those directories may contain
+# stale pnpm symlinks after switching branches.
+(
+    cd "$GUI_SRC_DIR"
+    tar \
+        --create \
+        --dereference \
+        --exclude='./node_modules' \
+        --exclude='*/node_modules' \
+        --exclude='./dist' \
+        --exclude='*/dist' \
+        --exclude='./dist-ssr' \
+        --exclude='*/dist-ssr' \
+        --exclude='./release' \
+        --exclude='*/release' \
+        --exclude='./src-tauri/target' \
+        --exclude='./src-tauri/resources/oss-cad-suite' \
+        -f - \
+        .
+) | (
+    cd "$GUI_DIR"
+    tar -xf -
+)
 
 mkdir -p "$GUI_DIR/src-tauri/binaries"
 cp -f "$API_SERVER_BIN" "$GUI_DIR/src-tauri/binaries/api-server-$TARGET_TRIPLE"


### PR DESCRIPTION
## Summary
- Move the HomeView layout preview fullscreen mode through a body Teleport so it overlays the full app reliably.
- Add message deletion controls and keep chat scrolling stable when messages are removed.
- Tighten toast/window edge styling and GUI build copy behavior for the included UI changes.

## Test Plan
- [x] `pnpm test` in `ecos/gui` with Node 23.11.0: 9 files, 66 tests passed
- [x] `pnpm build` in `ecos/gui` with Node 23.11.0: `vue-tsc && vite build` completed successfully