### PR TITLE
fix(gui): preserve workspace when open is canceled

### DIFF
--- a/ecos/gui/src/composables/useWorkspace.test.ts
+++ b/ecos/gui/src/composables/useWorkspace.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Project } from '@/types'
+
+const dialogOpen = vi.hoisted(() => vi.fn())
+const invokeMock = vi.hoisted(() => vi.fn())
+const loadWorkspaceApiMock = vi.hoisted(() => vi.fn())
+const waitForApiReadyMock = vi.hoisted(() => vi.fn())
+const createSSEClientMock = vi.hoisted(() => vi.fn())
+const storeData = vi.hoisted(() => new Map<string, unknown>())
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    isReady: vi.fn(async () => undefined),
+    currentRoute: { value: { path: '/' } },
+  }),
+}))
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: dialogOpen,
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    setTitle: vi.fn(async () => undefined),
+  }),
+}))
+
+vi.mock('@tauri-apps/plugin-store', () => ({
+  LazyStore: vi.fn(function () {
+    return {
+      get: vi.fn(async (key: string) => storeData.get(key)),
+      set: vi.fn(async (key: string, value: unknown) => {
+        storeData.set(key, value)
+      }),
+      delete: vi.fn(async (key: string) => {
+        storeData.delete(key)
+      }),
+      save: vi.fn(async () => undefined),
+    }
+  }),
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  readTextFile: vi.fn(async () => {
+    throw new Error('not available in test')
+  }),
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: vi.fn(),
+  }),
+}))
+
+vi.mock('@/api', () => ({
+  loadWorkspaceApi: loadWorkspaceApiMock,
+  createWorkspaceApi: vi.fn(),
+  waitForApiReady: waitForApiReadyMock,
+}))
+
+vi.mock('@/api/sse', () => ({
+  createSSEClient: createSSEClientMock,
+}))
+
+vi.mock('./useTauri', () => ({
+  isTauri: () => true,
+}))
+
+import { useWorkspace } from './useWorkspace'
+
+describe('useWorkspace openProject', () => {
+  beforeEach(() => {
+    const workspace = useWorkspace()
+    workspace.currentProject.value = null
+    workspace.recentProjects.value = []
+    workspace.sseClient.value?.close()
+    workspace.sseClient.value = null
+    workspace.sseMessages.value = []
+    workspace.stepRefreshCounter.value = 0
+    workspace.apiBackendConnecting.value = false
+
+    dialogOpen.mockReset()
+    invokeMock.mockReset()
+    loadWorkspaceApiMock.mockReset()
+    waitForApiReadyMock.mockReset()
+    createSSEClientMock.mockReset()
+    storeData.clear()
+
+    invokeMock.mockResolvedValue(true)
+    waitForApiReadyMock.mockResolvedValue(undefined)
+    createSSEClientMock.mockReturnValue({
+      onAll: vi.fn(),
+      connect: vi.fn(),
+      close: vi.fn(),
+    })
+  })
+
+  it('keeps the active workspace when the directory picker is canceled', async () => {
+    const workspace = useWorkspace()
+    const existingProject: Project = {
+      id: '/work/old',
+      name: 'old',
+      path: '/work/old',
+      lastOpened: new Date('2026-01-01T00:00:00.000Z'),
+    }
+
+    loadWorkspaceApiMock.mockResolvedValueOnce({
+      response: 'success',
+      data: {
+        directory: '/work/old',
+        workspace_id: '/work/old',
+      },
+    })
+
+    expect(await workspace.openProject(existingProject)).toBe(true)
+    expect(workspace.currentProject.value?.path).toBe('/work/old')
+
+    dialogOpen.mockResolvedValueOnce(null)
+
+    expect(await workspace.openProject()).toBeFalsy()
+    expect(workspace.currentProject.value?.path).toBe('/work/old')
+    expect(storeData.get('current_project_path')).toBe('/work/old')
+  })
+
+  it('keeps the active workspace when the selected workspace fails to load', async () => {
+    const workspace = useWorkspace()
+    const existingProject: Project = {
+      id: '/work/old',
+      name: 'old',
+      path: '/work/old',
+      lastOpened: new Date('2026-01-01T00:00:00.000Z'),
+    }
+
+    loadWorkspaceApiMock.mockResolvedValueOnce({
+      response: 'success',
+      data: {
+        directory: '/work/old',
+        workspace_id: '/work/old',
+      },
+    })
+
+    expect(await workspace.openProject(existingProject)).toBe(true)
+
+    dialogOpen.mockResolvedValueOnce('/work/bad')
+    loadWorkspaceApiMock.mockResolvedValueOnce({
+      response: 'error',
+      message: ['not an ECOS workspace'],
+      data: {},
+    })
+
+    expect(await workspace.openProject()).toBe(false)
+    expect(workspace.currentProject.value?.path).toBe('/work/old')
+    expect(storeData.get('current_project_path')).toBe('/work/old')
+  })
+})

--- a/ecos/gui/src/composables/useWorkspace.ts
+++ b/ecos/gui/src/composables/useWorkspace.ts
@@ -301,10 +301,6 @@ export function useWorkspace() {
   }
   const openProject = async (project?: Project) => {
     try {
-      if (currentProject.value) {
-        await closeProject()
-      }
-
       let selectedPath: string | null = null
 
       if (project) {
@@ -316,7 +312,7 @@ export function useWorkspace() {
           multiple: false,
           title: 'Select ECOS Studio Project Directory'
         })
-        if (!result) return
+        if (!result) return false
         selectedPath = result as string
       }
 
@@ -334,6 +330,7 @@ export function useWorkspace() {
           })
           return false
         }
+
         const existingProject = recentProjects.value.find(
           p => normalizePath(p.path) === resolvedPath
         )
@@ -345,6 +342,14 @@ export function useWorkspace() {
           name: resolvedName,
           path: resolvedPath,
           lastOpened: new Date()
+        }
+
+        if (currentProject.value) {
+          try {
+            await snapshotCurrentProject()
+          } catch (err) {
+            console.error('Failed to snapshot project data before switching:', err)
+          }
         }
 
         currentProject.value = loadedProject

--- a/ecos/gui/src/views/HomeView.vue
+++ b/ecos/gui/src/views/HomeView.vue
@@ -332,6 +332,7 @@ import SplitterPanel from 'primevue/splitterpanel'
 import { useParameters } from '@/composables/useParameters'
 import { useHomeData, type AnalysisChartItem, type FlowLogSegment } from '@/composables/useHomeData'
 import { isWindowResizing } from '@/composables/useWindowResizeState'
+import { ensureMonitorChartInstance } from './homeMonitorCharts'
 
 // 注册 ECharts 组件（按需引入）
 echarts.use([LineChart, GridComponent, TooltipComponent, CanvasRenderer])
@@ -804,13 +805,14 @@ function initOrUpdateCharts() {
     // 跳过尺寸为 0 的元素，等待 ResizeObserver 回调再初始化
     if (!el.clientWidth || !el.clientHeight) continue
 
-    let instance = chartInstances.get(cfg.key)
-    if (!instance) {
-      instance = echarts.init(el, undefined, { renderer: 'canvas' })
-      chartInstances.set(cfg.key, instance)
-      bindChartLinkEvents(instance)
-      newInstanceCreated = true
-    }
+    const { instance, created } = ensureMonitorChartInstance(
+      cfg.key,
+      el,
+      chartInstances,
+      (dom) => echarts.init(dom, undefined, { renderer: 'canvas' }),
+      bindChartLinkEvents,
+    )
+    if (created) newInstanceCreated = true
 
     if (!chartInitialized.has(instance)) {
       // 首次：全量 option + 触发入场动画

--- a/ecos/gui/src/views/homeMonitorCharts.test.ts
+++ b/ecos/gui/src/views/homeMonitorCharts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ensureMonitorChartInstance } from './homeMonitorCharts'
+
+describe('ensureMonitorChartInstance', () => {
+  it('recreates the chart when Vue replaces the DOM element for the same metric key', () => {
+    const firstEl = { id: 'first' } as unknown as HTMLDivElement
+    const secondEl = { id: 'second' } as unknown as HTMLDivElement
+    const firstInstance = {
+      getDom: vi.fn(() => firstEl),
+      dispose: vi.fn(),
+    }
+    const secondInstance = {
+      getDom: vi.fn(() => secondEl),
+      dispose: vi.fn(),
+    }
+    const init = vi.fn()
+      .mockReturnValueOnce(firstInstance)
+      .mockReturnValueOnce(secondInstance)
+    const instances = new Map<string, any>()
+    const bind = vi.fn()
+
+    const first = ensureMonitorChartInstance('memory', firstEl, instances, init, bind)
+    const second = ensureMonitorChartInstance('memory', secondEl, instances, init, bind)
+
+    expect(first.instance).toBe(firstInstance)
+    expect(first.created).toBe(true)
+    expect(second.instance).toBe(secondInstance)
+    expect(second.created).toBe(true)
+    expect(firstInstance.dispose).toHaveBeenCalledTimes(1)
+    expect(init).toHaveBeenNthCalledWith(1, firstEl)
+    expect(init).toHaveBeenNthCalledWith(2, secondEl)
+    expect(instances.get('memory')).toBe(secondInstance)
+    expect(bind).toHaveBeenCalledTimes(2)
+  })
+})

--- a/ecos/gui/src/views/homeMonitorCharts.ts
+++ b/ecos/gui/src/views/homeMonitorCharts.ts
@@ -1,0 +1,29 @@
+export interface MonitorChartInstance {
+  getDom: () => HTMLElement | null
+  dispose: () => void
+}
+
+export function ensureMonitorChartInstance<T extends MonitorChartInstance>(
+  key: string,
+  el: HTMLDivElement,
+  instances: Map<string, T>,
+  init: (el: HTMLDivElement) => T,
+  bind: (instance: T) => void,
+): { instance: T; created: boolean } {
+  let instance = instances.get(key)
+
+  if (instance && instance.getDom() !== el) {
+    instance.dispose()
+    instances.delete(key)
+    instance = undefined
+  }
+
+  if (!instance) {
+    instance = init(el)
+    instances.set(key, instance)
+    bind(instance)
+    return { instance, created: true }
+  }
+
+  return { instance, created: false }
+}


### PR DESCRIPTION
## Summary
- Delay closing the active workspace until a replacement workspace loads successfully.
- Keep the current workspace visible when the directory picker is canceled or the selected workspace fails to load.
- Recreate runtime monitor ECharts instances when Vue replaces chart DOM during workspace switches, so monitor lines render for the newly opened workspace.
- Add regression coverage for canceled/failed open-workspace flows and monitor chart DOM replacement.

## Test Plan
- [x] ./node_modules/.bin/vitest run
- [x] ./node_modules/.bin/vue-tsc --noEmit