### PR TITLE
feat(gui): add version info

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/appInfoService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/appInfoService.test.ts
@@ -21,8 +21,12 @@ function createSpawnHarness() {
   }
 }
 
+async function flushAsyncWork(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
 describe('AppInfoService', () => {
-  it('returns local GUI, runtime, and ECC versions without asking a server', async () => {
+  it('returns local GUI and structured ECC component versions without asking a server', async () => {
     const harness = createSpawnHarness()
     const service = new AppInfoService({
       appVersionProvider: () => '0.1.0-alpha.5',
@@ -31,22 +35,29 @@ describe('AppInfoService', () => {
     })
     const promise = service.getVersions()
 
-    expect(harness.spawn).toHaveBeenCalledWith('ecc', ['--version'], expect.objectContaining({
+    expect(harness.spawn).toHaveBeenCalledWith('ecc', ['version', '--json'], expect.objectContaining({
       env: { PATH: '/usr/bin' },
     }))
 
-    harness.children[0].stdout.emit('data', 'ecc 0.1.0a5\n')
+    harness.children[0].stdout.emit('data', JSON.stringify({
+      schema_version: 1,
+      runtime: 'ECC CLI',
+      ecc: '0.1.0a5',
+      dreamplace: '0.1.0a3',
+      ecc_tools: '0.1.0a2',
+    }))
     harness.children[0].emit('close', 0, null)
 
     await expect(promise).resolves.toEqual({
-      dreamplace: 'unknown',
-      ecc: 'ecc 0.1.0a5',
+      dreamplace: '0.1.0a3',
+      ecc: '0.1.0a5',
+      eccTools: '0.1.0a2',
       gui: '0.1.0-alpha.5',
       runtime: 'ECC CLI',
     })
   })
 
-  it('falls back to unknown when ecc --version fails', async () => {
+  it('falls back to legacy ecc --version when structured discovery fails', async () => {
     const harness = createSpawnHarness()
     const service = new AppInfoService({
       appVersionProvider: () => '0.1.0-alpha.5',
@@ -54,11 +65,107 @@ describe('AppInfoService', () => {
     })
     const promise = service.getVersions()
 
-    harness.children[0].stderr.emit('data', 'not found\n')
-    harness.children[0].emit('close', 127, null)
+    harness.children[0].emit('close', 2, null)
+    await flushAsyncWork()
+
+    expect(harness.spawn).toHaveBeenLastCalledWith('ecc', ['--version'], expect.any(Object))
+
+    harness.children[1].stdout.emit('data', 'ecc 0.1.0a5\n')
+    harness.children[1].emit('close', 0, null)
 
     await expect(promise).resolves.toMatchObject({
+      dreamplace: 'unknown',
+      ecc: '0.1.0a5',
+      eccTools: 'unknown',
+      runtime: 'ECC CLI',
+    })
+  })
+
+  it('falls back to legacy ecc --version when structured stdout is invalid JSON', async () => {
+    const harness = createSpawnHarness()
+    const service = new AppInfoService({
+      appVersionProvider: () => '0.1.0-alpha.5',
+      spawn: harness.spawn,
+    })
+    const promise = service.getVersions()
+
+    harness.children[0].stdout.emit('data', 'not json\n')
+    harness.children[0].emit('close', 0, null)
+    await flushAsyncWork()
+
+    expect(harness.spawn).toHaveBeenLastCalledWith('ecc', ['--version'], expect.any(Object))
+
+    harness.children[1].stdout.emit('data', 'ecc 0.1.0a5\n')
+    harness.children[1].emit('close', 0, null)
+
+    await expect(promise).resolves.toMatchObject({
+      ecc: '0.1.0a5',
+      runtime: 'ECC CLI',
+    })
+  })
+
+  it('falls back to legacy ecc --version when structured stdout is not an object', async () => {
+    const harness = createSpawnHarness()
+    const service = new AppInfoService({
+      appVersionProvider: () => '0.1.0-alpha.5',
+      spawn: harness.spawn,
+    })
+    const promise = service.getVersions()
+
+    harness.children[0].stdout.emit('data', '[]')
+    harness.children[0].emit('close', 0, null)
+    await flushAsyncWork()
+
+    expect(harness.spawn).toHaveBeenLastCalledWith('ecc', ['--version'], expect.any(Object))
+
+    harness.children[1].stdout.emit('data', 'ecc 0.1.0a5\n')
+    harness.children[1].emit('close', 0, null)
+
+    await expect(promise).resolves.toMatchObject({
+      ecc: '0.1.0a5',
+      runtime: 'ECC CLI',
+    })
+  })
+
+  it('defaults missing structured fields without rejecting version discovery', async () => {
+    const harness = createSpawnHarness()
+    const service = new AppInfoService({
+      appVersionProvider: () => '0.1.0-alpha.5',
+      spawn: harness.spawn,
+    })
+    const promise = service.getVersions()
+
+    harness.children[0].stdout.emit('data', JSON.stringify({
+      schema_version: 1,
+      ecc: '0.1.0a5',
+    }))
+    harness.children[0].emit('close', 0, null)
+
+    await expect(promise).resolves.toEqual({
+      dreamplace: 'unknown',
+      ecc: '0.1.0a5',
+      eccTools: 'unknown',
+      gui: '0.1.0-alpha.5',
+      runtime: 'ECC CLI',
+    })
+  })
+
+  it('returns unknown component versions when structured and legacy discovery fail', async () => {
+    const harness = createSpawnHarness()
+    const service = new AppInfoService({
+      appVersionProvider: () => '0.1.0-alpha.5',
+      spawn: harness.spawn,
+    })
+    const promise = service.getVersions()
+
+    harness.children[0].emit('error', new Error('not found'))
+    await flushAsyncWork()
+    harness.children[1].emit('close', 127, null)
+
+    await expect(promise).resolves.toMatchObject({
+      dreamplace: 'unknown',
       ecc: 'unknown',
+      eccTools: 'unknown',
       runtime: 'ECC CLI',
     })
   })

--- a/ecos/gui/apps/desktop-electron/electron/services/appInfoService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/appInfoService.ts
@@ -2,6 +2,7 @@ import { spawn as spawnChild } from 'node:child_process'
 import type { VersionInfo } from '@ecos-studio/shared'
 
 type SpawnLike = typeof spawnChild
+type EccComponentVersions = Pick<VersionInfo, 'runtime' | 'ecc' | 'dreamplace' | 'eccTools'>
 
 export interface AppInfoServiceOptions {
   appVersionProvider: () => string
@@ -11,9 +12,23 @@ export interface AppInfoServiceOptions {
 }
 
 const UNKNOWN_VERSION = 'unknown'
+const DEFAULT_RUNTIME = 'ECC CLI'
 
 function dataToString(data: unknown): string {
   return Buffer.isBuffer(data) ? data.toString('utf8') : String(data)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value ? value : fallback
+}
+
+function parseLegacyEccVersion(stdout: string): string {
+  const version = stdout.trim()
+  return version.startsWith('ecc ') ? version.slice(4).trim() : version
 }
 
 export class AppInfoService {
@@ -30,18 +45,66 @@ export class AppInfoService {
   }
 
   async getVersions(): Promise<VersionInfo> {
+    const eccVersions = await this.getEccVersions()
+
     return {
-      dreamplace: UNKNOWN_VERSION,
-      ecc: await this.getEccVersion(),
+      ...eccVersions,
       gui: this.appVersionProvider(),
-      runtime: 'ECC CLI',
     }
   }
 
-  private async getEccVersion(): Promise<string> {
+  private async getEccVersions(): Promise<EccComponentVersions> {
+    const structuredVersions = await this.getStructuredEccVersions()
+    if (structuredVersions !== null) {
+      return structuredVersions
+    }
+
+    return {
+      dreamplace: UNKNOWN_VERSION,
+      ecc: await this.getLegacyEccVersion(),
+      eccTools: UNKNOWN_VERSION,
+      runtime: DEFAULT_RUNTIME,
+    }
+  }
+
+  private async getStructuredEccVersions(): Promise<EccComponentVersions | null> {
+    const stdout = await this.runEccCommand(['version', '--json'])
+    if (stdout === null || !stdout.trim()) {
+      return null
+    }
+
+    let payload: unknown
+    try {
+      payload = JSON.parse(stdout)
+    } catch {
+      return null
+    }
+
+    if (!isRecord(payload)) {
+      return null
+    }
+
+    return {
+      dreamplace: stringValue(payload.dreamplace, UNKNOWN_VERSION),
+      ecc: stringValue(payload.ecc, UNKNOWN_VERSION),
+      eccTools: stringValue(payload.ecc_tools, UNKNOWN_VERSION),
+      runtime: stringValue(payload.runtime, DEFAULT_RUNTIME),
+    }
+  }
+
+  private async getLegacyEccVersion(): Promise<string> {
+    const stdout = await this.runEccCommand(['--version'])
+    if (stdout === null) {
+      return UNKNOWN_VERSION
+    }
+
+    return parseLegacyEccVersion(stdout) || UNKNOWN_VERSION
+  }
+
+  private async runEccCommand(args: string[]): Promise<string | null> {
     return await new Promise((resolve) => {
       let stdout = ''
-      const child = this.spawnImpl(this.command, ['--version'], {
+      const child = this.spawnImpl(this.command, args, {
         env: this.env,
         stdio: ['ignore', 'pipe', 'pipe'],
       })
@@ -51,12 +114,11 @@ export class AppInfoService {
       })
 
       child.once('error', () => {
-        resolve(UNKNOWN_VERSION)
+        resolve(null)
       })
 
       child.once('close', (code) => {
-        const version = stdout.trim()
-        resolve(code === 0 && version ? version : UNKNOWN_VERSION)
+        resolve(code === 0 ? stdout : null)
       })
     })
   }

--- a/ecos/gui/apps/desktop-electron/electron/services/logger.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/logger.test.ts
@@ -27,6 +27,10 @@ function stripAnsi(value: string): string {
   return value.replace(/\x1b\[[0-9;]*m/g, '')
 }
 
+function localTestDate(): Date {
+  return new Date(2026, 4, 12, 16, 36, 17, 209)
+}
+
 describe('createElectronLogger', () => {
   const tempDirectories: string[] = []
 
@@ -46,7 +50,7 @@ describe('createElectronLogger', () => {
         ECOS_LOG_COLOR: 'auto',
       },
       isTty: true,
-      now: () => new Date('2026-05-12T08:36:17.209Z'),
+      now: localTestDate,
     })
 
     logger.warn('[tile] Missing layout JSON: /tmp/project/route.json')
@@ -67,7 +71,7 @@ describe('createElectronLogger', () => {
         consoleSink,
         env,
         isTty: true,
-        now: () => new Date('2026-05-12T08:36:17.209Z'),
+        now: localTestDate,
       })
 
       logger.warn('[tile] Missing layout JSON: /tmp/project/route.json')
@@ -85,7 +89,7 @@ describe('createElectronLogger', () => {
         ECOS_LOG_COLOR: 'auto',
       },
       isTty: false,
-      now: () => new Date('2026-05-12T08:36:17.209Z'),
+      now: localTestDate,
     })
 
     logger.warn('[tile] Missing layout JSON: /tmp/project/route.json')
@@ -135,7 +139,7 @@ describe('createElectronLogger', () => {
       consoleSink,
       env: {},
       isTty: false,
-      now: () => new Date('2026-05-12T08:36:17.209Z'),
+      now: localTestDate,
     })
 
     logger.info('[api] Hidden by default')

--- a/ecos/gui/apps/renderer/src/components/AboutDialog.vue
+++ b/ecos/gui/apps/renderer/src/components/AboutDialog.vue
@@ -22,9 +22,9 @@
 
       <table class="version-table">
         <tbody>
-          <tr v-for="(label, key) in componentLabels" :key="key">
-            <td class="label-cell">{{ label }}</td>
-            <td class="version-cell">{{ versionText(key) }}</td>
+          <tr v-for="row in versionRows" :key="row.key">
+            <td class="label-cell">{{ row.label }}</td>
+            <td class="version-cell">{{ row.version }}</td>
           </tr>
         </tbody>
       </table>
@@ -38,34 +38,19 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import Dialog from 'primevue/dialog'
 import { useVersion } from '@/composables/useVersion'
+import { aboutVersionRows, buildAboutVersionText } from './aboutDialogVersions'
 
 const visible = defineModel<boolean>({ required: true })
 const { versions } = useVersion()
 
-const componentLabels: Record<string, string> = {
-  gui: 'GUI',
-  runtime: 'Runtime',
-  ecc: 'ECC-Tools',
-  dreamplace: 'ECC-DreamPlace',
-}
-
-function versionText(key: string): string {
-  if (key === 'runtime') {
-    return versions.value?.runtime ?? versions.value?.server ?? 'unknown'
-  }
-
-  return versions.value?.[key as keyof typeof versions.value] ?? 'unknown'
-}
+const versionRows = computed(() => aboutVersionRows(versions.value))
 
 const copied = ref(false)
 async function copyVersions(): Promise<void> {
-  const lines = Object.entries(componentLabels)
-    .map(([key, label]) => `${label}: ${versionText(key)}`)
-    .join('\n')
-  const text = `ECOS Studio\n${lines}`
+  const text = buildAboutVersionText(versions.value)
   await navigator.clipboard.writeText(text)
   copied.value = true
   setTimeout(() => { copied.value = false }, 2000)

--- a/ecos/gui/apps/renderer/src/components/aboutDialogVersions.test.ts
+++ b/ecos/gui/apps/renderer/src/components/aboutDialogVersions.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { VersionInfo } from '@ecos-studio/shared'
+import { aboutVersionRows, buildAboutVersionText } from './aboutDialogVersions'
+
+describe('aboutDialogVersions', () => {
+  it('shows ECC and ECC-Tools as distinct component versions', () => {
+    const versions: VersionInfo = {
+      gui: '0.1.0-alpha.5',
+      runtime: 'ECC CLI',
+      ecc: '0.1.0a5',
+      dreamplace: '0.1.0a3',
+      eccTools: '0.1.0a2',
+    }
+
+    expect(aboutVersionRows(versions)).toEqual([
+      { key: 'gui', label: 'GUI', version: '0.1.0-alpha.5' },
+      { key: 'runtime', label: 'Runtime', version: 'ECC CLI' },
+      { key: 'ecc', label: 'ECC', version: '0.1.0a5' },
+      { key: 'eccTools', label: 'ECC-Tools', version: '0.1.0a2' },
+      { key: 'dreamplace', label: 'ECC-DreamPlace', version: '0.1.0a3' },
+    ])
+  })
+
+  it('keeps old VersionInfo bridge responses compatible', () => {
+    const versions: VersionInfo = {
+      gui: '0.1.0-alpha.5',
+      runtime: 'ECC CLI',
+      ecc: '0.1.0a5',
+      dreamplace: '0.1.0a3',
+    }
+
+    expect(aboutVersionRows(versions).find((row) => row.key === 'eccTools')).toEqual({
+      key: 'eccTools',
+      label: 'ECC-Tools',
+      version: 'unknown',
+    })
+  })
+
+  it('copies the same rows shown in the dialog', () => {
+    const versions: VersionInfo = {
+      gui: '0.1.0-alpha.5',
+      runtime: 'ECC CLI',
+      ecc: '0.1.0a5',
+      dreamplace: '0.1.0a3',
+      eccTools: '0.1.0a2',
+    }
+
+    expect(buildAboutVersionText(versions)).toBe([
+      'ECOS Studio',
+      'GUI: 0.1.0-alpha.5',
+      'Runtime: ECC CLI',
+      'ECC: 0.1.0a5',
+      'ECC-Tools: 0.1.0a2',
+      'ECC-DreamPlace: 0.1.0a3',
+    ].join('\n'))
+  })
+})

--- a/ecos/gui/apps/renderer/src/components/aboutDialogVersions.ts
+++ b/ecos/gui/apps/renderer/src/components/aboutDialogVersions.ts
@@ -1,0 +1,47 @@
+import type { VersionInfo } from '@ecos-studio/shared'
+
+export interface AboutVersionRow {
+  key: 'gui' | 'runtime' | 'ecc' | 'eccTools' | 'dreamplace'
+  label: string
+  version: string
+}
+
+const UNKNOWN_VERSION = 'unknown'
+
+export function aboutVersionRows(versions?: VersionInfo | null): AboutVersionRow[] {
+  return [
+    {
+      key: 'gui',
+      label: 'GUI',
+      version: versions?.gui ?? UNKNOWN_VERSION,
+    },
+    {
+      key: 'runtime',
+      label: 'Runtime',
+      version: versions?.runtime ?? versions?.server ?? UNKNOWN_VERSION,
+    },
+    {
+      key: 'ecc',
+      label: 'ECC',
+      version: versions?.ecc ?? UNKNOWN_VERSION,
+    },
+    {
+      key: 'eccTools',
+      label: 'ECC-Tools',
+      version: versions?.eccTools ?? UNKNOWN_VERSION,
+    },
+    {
+      key: 'dreamplace',
+      label: 'ECC-DreamPlace',
+      version: versions?.dreamplace ?? UNKNOWN_VERSION,
+    },
+  ]
+}
+
+export function buildAboutVersionText(versions?: VersionInfo | null): string {
+  const lines = aboutVersionRows(versions)
+    .map(({ label, version }) => `${label}: ${version}`)
+    .join('\n')
+
+  return `ECOS Studio\n${lines}`
+}

--- a/ecos/gui/packages/shared/src/contracts/desktopApi.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopApi.ts
@@ -68,6 +68,7 @@ export interface VersionInfo {
   server?: string
   ecc: string
   dreamplace: string
+  eccTools?: string
 }
 
 export interface DesktopProjectTextFileTail {


### PR DESCRIPTION
## Summary

This PR updates the desktop GUI version discovery flow to use ECC’s structured version command instead of parsing only the legacy root version output. (Introduced in [ecc#92](https://github.com/openecos-projects/ecc/pull/92))

The Electron main process now calls:

```sh
ecc version --json
```

and uses the returned component metadata to populate the About dialog with separate versions for:

  - GUI
  - Runtime
  - ECC
  - ECC-Tools
  - ECC-DreamPlace

## Version Discovery Behavior

The new flow expects ECC to return a JSON payload like:

```
{
  "schema_version": 1,
  "runtime": "ECC CLI",
  "ecc": "0.1.0a5",
  "dreamplace": "0.1.0a3",
  "ecc_tools": "0.1.0a2"
}
```

The GUI maps ecc_tools to the shared `VersionInfo.eccTools` field and keeps missing component versions as unknown.

For compatibility with older ECC builds, the implementation falls back to:

```
ecc --version
```

when `ecc version --json` fails, returns invalid JSON, returns an empty response, or returns a non-object payload.

## UI Changes

The About dialog now shows ECC and ECC-Tools as separate rows, instead of conflating ECC with ECC-Tools. The “Copy version info” action uses the same row data shown in the dialog, so copied output stays consistent with the UI.

The status bar remains unchanged and continues to show only the GUI version.

## Verification

- pnpm test
- pnpm typecheck
- codex review --base ekko/feat-desktop-cli-bridge