### PR TITLE
fix(gui): pass oss cad root to ecc

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.test.ts
@@ -191,6 +191,184 @@ describe('createEccCliRuntimeEnv', () => {
     expect(env.PATH).toBe(`${join(resourcesPath, 'binaries')}:/usr/bin`)
   })
 
+  it('injects bundled OSS CAD env when packaged resources include yosys', () => {
+    const fixture = createRepoFixture()
+    const resourcesPath = join(fixture.repoRoot, 'packaged-resources')
+    const ossCadRoot = join(resourcesPath, 'resources', 'oss-cad-suite')
+    mkdirSync(join(resourcesPath, 'binaries'), { recursive: true })
+    mkdirSync(join(ossCadRoot, 'bin'), { recursive: true })
+    writeFileSync(join(resourcesPath, 'binaries', 'ecc'), '#!/usr/bin/env bash\n')
+    writeFileSync(join(ossCadRoot, 'bin', 'yosys'), '#!/usr/bin/env bash\n')
+
+    const env = createEccCliRuntimeEnv({
+      appPath: fixture.appPath,
+      cwd: fixture.appPath,
+      env: {
+        ECOS_ELECTRON_RESOURCES_PATH: resourcesPath,
+        PATH: '/usr/bin',
+      },
+      isPackaged: true,
+      platform: 'linux',
+      userDataPath: fixture.userDataPath,
+    })
+
+    expect(env.PATH).toBe(`${join(resourcesPath, 'binaries')}:/usr/bin`)
+    expect(env.CHIPCOMPILER_OSS_CAD_DIR).toBe(ossCadRoot)
+    expect(env.ECOS_ELECTRON_OSS_CAD_DIR).toBe(ossCadRoot)
+  })
+
+  it('prefers bundled OSS CAD over an inherited host OSS CAD path', () => {
+    const fixture = createRepoFixture()
+    const resourcesPath = join(fixture.repoRoot, 'packaged-resources')
+    const ossCadRoot = join(resourcesPath, 'resources', 'oss-cad-suite')
+    mkdirSync(join(resourcesPath, 'binaries'), { recursive: true })
+    mkdirSync(join(ossCadRoot, 'bin'), { recursive: true })
+    writeFileSync(join(resourcesPath, 'binaries', 'ecc'), '#!/usr/bin/env bash\n')
+    writeFileSync(join(ossCadRoot, 'bin', 'yosys'), '#!/usr/bin/env bash\n')
+
+    const env = createEccCliRuntimeEnv({
+      appPath: fixture.appPath,
+      cwd: fixture.appPath,
+      env: {
+        CHIPCOMPILER_OSS_CAD_DIR: '/host/oss-cad-suite',
+        ECOS_ELECTRON_RESOURCES_PATH: resourcesPath,
+        PATH: '/usr/bin',
+      },
+      isPackaged: true,
+      platform: 'linux',
+      userDataPath: fixture.userDataPath,
+    })
+
+    expect(env.CHIPCOMPILER_OSS_CAD_DIR).toBe(ossCadRoot)
+  })
+
+  it('does not inject OSS CAD env when packaged yosys is missing', () => {
+    const fixture = createRepoFixture()
+    const resourcesPath = join(fixture.repoRoot, 'packaged-resources')
+    const ossCadRoot = join(resourcesPath, 'resources', 'oss-cad-suite')
+    mkdirSync(join(resourcesPath, 'binaries'), { recursive: true })
+    mkdirSync(ossCadRoot, { recursive: true })
+    writeFileSync(join(resourcesPath, 'binaries', 'ecc'), '#!/usr/bin/env bash\n')
+    writeFileSync(join(ossCadRoot, 'placeholder.txt'), '')
+
+    const env = createEccCliRuntimeEnv({
+      appPath: fixture.appPath,
+      cwd: fixture.appPath,
+      env: {
+        ECOS_ELECTRON_RESOURCES_PATH: resourcesPath,
+        PATH: '/usr/bin',
+      },
+      isPackaged: true,
+      platform: 'linux',
+      userDataPath: fixture.userDataPath,
+    })
+
+    expect(env.CHIPCOMPILER_OSS_CAD_DIR).toBeUndefined()
+    expect(env.ECOS_ELECTRON_OSS_CAD_DIR).toBeUndefined()
+  })
+
+  it('leaves development env unchanged even when a source-tree OSS CAD fixture exists', () => {
+    const fixture = createRepoFixture()
+    const sourceOssCadRoot = join(
+      fixture.appPath,
+      'resources',
+      'resources',
+      'oss-cad-suite',
+    )
+    mkdirSync(join(sourceOssCadRoot, 'bin'), { recursive: true })
+    writeFileSync(join(sourceOssCadRoot, 'bin', 'yosys'), '#!/usr/bin/env bash\n')
+
+    const env = createEccCliRuntimeEnv({
+      appPath: fixture.appPath,
+      cwd: fixture.appPath,
+      env: {
+        PATH: '/usr/bin',
+      },
+      isPackaged: false,
+      platform: 'linux',
+      userDataPath: fixture.userDataPath,
+    })
+
+    expect(env).toEqual({ PATH: '/usr/bin' })
+  })
+
+  it('uses ECOS_ELECTRON_OSS_CAD_DIR when it points at a usable OSS CAD root', () => {
+    const fixture = createRepoFixture()
+    const resourcesPath = join(fixture.repoRoot, 'packaged-resources')
+    const customOssCadRoot = join(fixture.repoRoot, 'custom-oss-cad-suite')
+    mkdirSync(join(resourcesPath, 'binaries'), { recursive: true })
+    mkdirSync(join(customOssCadRoot, 'bin'), { recursive: true })
+    writeFileSync(join(resourcesPath, 'binaries', 'ecc'), '#!/usr/bin/env bash\n')
+    writeFileSync(join(customOssCadRoot, 'bin', 'yosys'), '#!/usr/bin/env bash\n')
+
+    const env = createEccCliRuntimeEnv({
+      appPath: fixture.appPath,
+      cwd: fixture.appPath,
+      env: {
+        ECOS_ELECTRON_OSS_CAD_DIR: customOssCadRoot,
+        ECOS_ELECTRON_RESOURCES_PATH: resourcesPath,
+        PATH: '/usr/bin',
+      },
+      isPackaged: true,
+      platform: 'linux',
+      userDataPath: fixture.userDataPath,
+    })
+
+    expect(env.CHIPCOMPILER_OSS_CAD_DIR).toBe(customOssCadRoot)
+    expect(env.ECOS_ELECTRON_OSS_CAD_DIR).toBe(customOssCadRoot)
+  })
+
+  it('does not preserve ECOS_ELECTRON_OSS_CAD_DIR when it points at an unusable root', () => {
+    const fixture = createRepoFixture()
+    const resourcesPath = join(fixture.repoRoot, 'packaged-resources')
+    const customOssCadRoot = join(fixture.repoRoot, 'custom-oss-cad-suite')
+    mkdirSync(join(resourcesPath, 'binaries'), { recursive: true })
+    mkdirSync(customOssCadRoot, { recursive: true })
+    writeFileSync(join(resourcesPath, 'binaries', 'ecc'), '#!/usr/bin/env bash\n')
+
+    const env = createEccCliRuntimeEnv({
+      appPath: fixture.appPath,
+      cwd: fixture.appPath,
+      env: {
+        ECOS_ELECTRON_OSS_CAD_DIR: customOssCadRoot,
+        ECOS_ELECTRON_RESOURCES_PATH: resourcesPath,
+        PATH: '/usr/bin',
+      },
+      isPackaged: true,
+      platform: 'linux',
+      userDataPath: fixture.userDataPath,
+    })
+
+    expect(env.CHIPCOMPILER_OSS_CAD_DIR).toBeUndefined()
+    expect(env.ECOS_ELECTRON_OSS_CAD_DIR).toBeUndefined()
+  })
+
+  it('checks for yosys.exe when resolving packaged OSS CAD on Windows', () => {
+    const fixture = createRepoFixture()
+    const resourcesPath = join(fixture.repoRoot, 'packaged-resources')
+    const ossCadRoot = join(resourcesPath, 'resources', 'oss-cad-suite')
+    mkdirSync(join(resourcesPath, 'binaries'), { recursive: true })
+    mkdirSync(join(ossCadRoot, 'bin'), { recursive: true })
+    writeFileSync(join(resourcesPath, 'binaries', 'ecc.cmd'), '@echo off\r\n')
+    writeFileSync(join(ossCadRoot, 'bin', 'yosys.exe'), '')
+
+    const env = createEccCliRuntimeEnv({
+      appPath: fixture.appPath,
+      cwd: fixture.appPath,
+      env: {
+        ECOS_ELECTRON_RESOURCES_PATH: resourcesPath,
+        Path: 'C:\\Windows\\System32',
+      },
+      isPackaged: true,
+      platform: 'win32',
+      userDataPath: fixture.userDataPath,
+    })
+
+    expect(env.Path).toBe(`${join(resourcesPath, 'binaries')};C:\\Windows\\System32`)
+    expect(env.CHIPCOMPILER_OSS_CAD_DIR).toBe(ossCadRoot)
+    expect(env.ECOS_ELECTRON_OSS_CAD_DIR).toBe(ossCadRoot)
+  })
+
   it('does not inject the development wrapper in packaged mode without bundled ecc', () => {
     const fixture = createRepoFixture()
     writeFileSync(join(fixture.repoRoot, 'ecc', 'pyproject.toml'), '')

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.test.ts
@@ -343,6 +343,34 @@ describe('createEccCliRuntimeEnv', () => {
     expect(env.ECOS_ELECTRON_OSS_CAD_DIR).toBeUndefined()
   })
 
+  it('falls back to bundled OSS CAD when ECOS_ELECTRON_OSS_CAD_DIR is unusable', () => {
+    const fixture = createRepoFixture()
+    const resourcesPath = join(fixture.repoRoot, 'packaged-resources')
+    const customOssCadRoot = join(fixture.repoRoot, 'custom-oss-cad-suite')
+    const bundledOssCadRoot = join(resourcesPath, 'resources', 'oss-cad-suite')
+    mkdirSync(join(resourcesPath, 'binaries'), { recursive: true })
+    mkdirSync(customOssCadRoot, { recursive: true })
+    mkdirSync(join(bundledOssCadRoot, 'bin'), { recursive: true })
+    writeFileSync(join(resourcesPath, 'binaries', 'ecc'), '#!/usr/bin/env bash\n')
+    writeFileSync(join(bundledOssCadRoot, 'bin', 'yosys'), '#!/usr/bin/env bash\n')
+
+    const env = createEccCliRuntimeEnv({
+      appPath: fixture.appPath,
+      cwd: fixture.appPath,
+      env: {
+        ECOS_ELECTRON_OSS_CAD_DIR: customOssCadRoot,
+        ECOS_ELECTRON_RESOURCES_PATH: resourcesPath,
+        PATH: '/usr/bin',
+      },
+      isPackaged: true,
+      platform: 'linux',
+      userDataPath: fixture.userDataPath,
+    })
+
+    expect(env.CHIPCOMPILER_OSS_CAD_DIR).toBe(bundledOssCadRoot)
+    expect(env.ECOS_ELECTRON_OSS_CAD_DIR).toBe(bundledOssCadRoot)
+  })
+
   it('checks for yosys.exe when resolving packaged OSS CAD on Windows', () => {
     const fixture = createRepoFixture()
     const resourcesPath = join(fixture.repoRoot, 'packaged-resources')

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.ts
@@ -40,18 +40,45 @@ function resolvePackagedRuntimeBin(options: EccCliRuntimeEnvOptions): string | n
   return existsSync(join(binariesPath, executableName)) ? binariesPath : null
 }
 
+function resolvePackagedResourcesPath(options: EccCliRuntimeEnvOptions): string {
+  return options.env.ECOS_ELECTRON_RESOURCES_PATH
+    ?? join(options.appPath, 'resources')
+}
+
+function resolvePackagedOssCadRoot(options: EccCliRuntimeEnvOptions): string | null {
+  const resourcesPath = resolvePackagedResourcesPath(options)
+  const ossCadRoot = options.env.ECOS_ELECTRON_OSS_CAD_DIR
+    ?? join(resourcesPath, 'resources', 'oss-cad-suite')
+  const yosysExecutable = options.platform === 'win32' ? 'yosys.exe' : 'yosys'
+
+  return existsSync(join(ossCadRoot, 'bin', yosysExecutable)) ? ossCadRoot : null
+}
+
 export function createEccCliRuntimeEnv(
   options: EccCliRuntimeEnvOptions,
 ): NodeJS.ProcessEnv {
   if (options.isPackaged) {
     const packagedRuntimeBin = resolvePackagedRuntimeBin(options)
+    const resourcesPath = resolvePackagedResourcesPath(options)
+    const ossCadRoot = resolvePackagedOssCadRoot(options)
+
     if (packagedRuntimeBin) {
       const nextPath = prependPath(options.env, packagedRuntimeBin, options.platform)
+      const {
+        CHIPCOMPILER_OSS_CAD_DIR: _inheritedOssCadDir,
+        ECOS_ELECTRON_OSS_CAD_DIR: _inheritedElectronOssCadDir,
+        ...baseEnv
+      } = options.env
 
       return {
-        ...options.env,
-        ECOS_ELECTRON_RESOURCES_PATH: options.env.ECOS_ELECTRON_RESOURCES_PATH
-          ?? join(options.appPath, 'resources'),
+        ...baseEnv,
+        ECOS_ELECTRON_RESOURCES_PATH: resourcesPath,
+        ...(ossCadRoot
+          ? {
+              CHIPCOMPILER_OSS_CAD_DIR: ossCadRoot,
+              ECOS_ELECTRON_OSS_CAD_DIR: ossCadRoot,
+            }
+          : {}),
         [nextPath.key]: nextPath.value,
       }
     }

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.ts
@@ -47,11 +47,14 @@ function resolvePackagedResourcesPath(options: EccCliRuntimeEnvOptions): string 
 
 function resolvePackagedOssCadRoot(options: EccCliRuntimeEnvOptions): string | null {
   const resourcesPath = resolvePackagedResourcesPath(options)
-  const ossCadRoot = options.env.ECOS_ELECTRON_OSS_CAD_DIR
-    ?? join(resourcesPath, 'resources', 'oss-cad-suite')
   const yosysExecutable = options.platform === 'win32' ? 'yosys.exe' : 'yosys'
+  const candidateRoots = [
+    options.env.ECOS_ELECTRON_OSS_CAD_DIR,
+    join(resourcesPath, 'resources', 'oss-cad-suite'),
+  ].filter((root): root is string => Boolean(root))
 
-  return existsSync(join(ossCadRoot, 'bin', yosysExecutable)) ? ossCadRoot : null
+  return candidateRoots.find((root) => existsSync(join(root, 'bin', yosysExecutable)))
+    ?? null
 }
 
 export function createEccCliRuntimeEnv(


### PR DESCRIPTION
## Summary

- Inject the packaged OSS CAD Suite root into the Electron main runtime environment as `CHIPCOMPILER_OSS_CAD_DIR`.
- Mirror the same path through `ECOS_ELECTRON_OSS_CAD_DIR` when the packaged bundle contains `resources/oss-cad-suite/bin/yosys`.
- Preserve existing packaged `ecc` discovery through `resources/binaries` and keep development mode unchanged.

## Why

The packaged GUI can find the bundled `ecc` executable, but ECC resolves Yosys only from `CHIPCOMPILER_OSS_CAD_DIR/bin/yosys` or system `PATH`. When AppImage is launched without host Yosys on `PATH`, `workspace create` fails while building the `Synthesis_yosys` step because the GUI never maps `process.resourcesPath/resources/oss-cad-suite` into ECC's expected environment.

## Testing

- [ ] `cd ecos/gui && ./node_modules/.bin/vitest run apps/desktop-electron/electron/services/eccCliRuntime.test.ts`
- [x] Manual AppImage smoke: create a workspace with no host `yosys` on `PATH`
