### PR TITLE
feat(gui): add desktop resource manager ipc

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createHash } from 'node:crypto'
+import { execFile } from 'node:child_process'
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -21,6 +23,55 @@ async function createFixtureArchive(root: string): Promise<{ path: string; sha25
     sha256: 'fixture-sha',
     size: Buffer.byteLength(payload),
   }
+}
+
+async function runFixtureCommand(command: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = execFile(command, args, (error, _stdout, stderr) => {
+      if (error) {
+        reject(new Error(`${command} failed: ${stderr || error.message}`))
+        return
+      }
+      resolve()
+    })
+    child.on('error', reject)
+  })
+}
+
+async function createPdkArchive(
+  root: string,
+  options: { makefileContent?: string } = {},
+): Promise<{ path: string; sha256: string; size: number }> {
+  const sourceRoot = join(root, 'pdk-source')
+  const sourceDir = join(sourceRoot, 'icsprout55-pdk-1.10.100')
+  const archive = join(root, 'ics55.tar')
+  await mkdir(join(sourceDir, 'IP'), { recursive: true })
+  await mkdir(join(sourceDir, 'prtech'), { recursive: true })
+  await writeFile(join(sourceDir, 'README.md'), 'fixture pdk\n', 'utf8')
+  if (options.makefileContent) {
+    await writeFile(join(sourceDir, 'Makefile'), options.makefileContent, 'utf8')
+  }
+  await runFixtureCommand('tar', ['-cf', archive, '-C', sourceRoot, 'icsprout55-pdk-1.10.100'])
+  const size = Buffer.byteLength(await readFile(archive))
+  return {
+    path: archive,
+    sha256: 'fixture-pdk-sha',
+    size,
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return await Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) => {
+      setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs)
+    }),
+  ])
+}
+
+function testRegistryCachePath(cacheDir: string, registryUrl: string): string {
+  const key = createHash('sha256').update(registryUrl).digest('hex').slice(0, 12)
+  return join(cacheDir, `resource-registry-${key}.json`)
 }
 
 describe('ResourceManagerService', () => {
@@ -193,5 +244,514 @@ describe('ResourceManagerService', () => {
       version: '0.61',
       managed: true,
     })
+  })
+
+  it('streams remote downloads and emits byte progress while downloading a managed tool', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const registryPath = join(root, 'registry.json')
+    await writeFile(registryPath, JSON.stringify({
+      schema_version: 2,
+      tools: [
+        {
+          name: 'yosys',
+          display_name: 'Yosys',
+          description: 'RTL synthesis',
+          category: 'synthesis',
+          homepage: '',
+          versions: [
+            {
+              version: '0.61',
+              platforms: {
+                'all-platform': {
+                  url: 'https://example.com/yosys.tar',
+                  sha256: 'fixture-sha',
+                  size: 9,
+                },
+              },
+            },
+          ],
+        },
+      ],
+      pdks: [],
+    }), 'utf8')
+    const chunks = [
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array([4, 5, 6]),
+      new Uint8Array([7, 8, 9]),
+    ]
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      expect(String(url)).toBe('https://example.com/yosys.tar')
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (const chunk of chunks) {
+              controller.enqueue(chunk)
+            }
+            controller.close()
+          },
+        }),
+        {
+          status: 200,
+        },
+      )
+    })
+    const extract = vi.fn(async (_archivePath: string, destination: string) => {
+      await mkdir(join(destination, 'bin'), { recursive: true })
+      const executable = join(destination, 'bin', 'yosys')
+      await writeFile(executable, '#!/bin/sh\n', 'utf8')
+      await chmod(executable, 0o755)
+    })
+    const verifySha256 = vi.fn(async () => true)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+      archiveExtractor: extract,
+      fetchImpl: fetchImpl as typeof fetch,
+      sha256Verifier: verifySha256,
+    })
+    const progress = vi.fn()
+
+    await service.installResource('tool:yosys', '0.61', progress)
+
+    const extractingEvents = progress.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.phase === 'extracting')
+    expect(extractingEvents).not.toContainEqual(expect.objectContaining({
+      progress: 0,
+    }))
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({
+      phase: 'downloading',
+      progress: 1 / 3,
+    }))
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({
+      phase: 'downloading',
+      progress: 2 / 3,
+    }))
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({
+      phase: 'downloading',
+      progress: 1,
+    }))
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({
+      phase: 'extracting',
+      progress: 0.05,
+    }))
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({
+      phase: 'extracting',
+      progress: 0.98,
+    }))
+  })
+
+  it('returns cached registry data immediately and refreshes the registry in the background', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const cacheDir = join(root, 'cache')
+    const registryUrl = 'https://example.com/registry.json'
+    await mkdir(cacheDir, { recursive: true })
+    await writeFile(testRegistryCachePath(cacheDir, registryUrl), JSON.stringify({
+      schema_version: 2,
+      tools: [
+        {
+          name: 'cached-yosys',
+          display_name: 'Cached Yosys',
+          description: 'Cached synthesis tool',
+          category: 'synthesis',
+          homepage: '',
+          versions: [
+            {
+              version: '0.61',
+              platforms: {
+                'all-platform': {
+                  url: 'file:///tmp/cached-yosys.tar',
+                  sha256: 'fixture-sha',
+                  size: 9,
+                },
+              },
+            },
+          ],
+        },
+      ],
+      pdks: [],
+    }), 'utf8')
+    const fetchImpl = vi.fn(() => new Promise<Response>(() => {}))
+    const service = new ResourceManagerService({
+      registryUrl,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+      cacheDir,
+      fetchImpl: fetchImpl as typeof fetch,
+    })
+
+    const result = await withTimeout(service.listResources(), 100)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(result.diagnostics).toContain('Using cached registry data while refreshing in background')
+    expect(result.resources).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'tool:cached-yosys',
+        display_name: 'Cached Yosys',
+      }),
+    ]))
+  })
+
+  it('installs a managed registry PDK with strip prefix and post-install steps', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const archive = await createPdkArchive(root)
+    const registryPath = join(root, 'registry.json')
+    const postInstallRunner = vi.fn(async (command: string, args: string[], options?: { cwd?: string }) => {
+      expect(command).toBe('make')
+      expect(args).toEqual(['unzip'])
+      expect(options?.cwd).toContain(`${join('data', 'pdks', 'ics55')}`)
+      await writeFile(join(options?.cwd ?? root, 'post-install-ran.txt'), 'ok\n', 'utf8')
+    })
+    await writeFile(registryPath, JSON.stringify({
+      schema_version: 2,
+      tools: [],
+      pdks: [
+        {
+          id: 'ics55',
+          display_name: 'ICsprout 55nm PDK',
+          description: 'ICsprout 55nm open-source process design kit.',
+          category: 'pdk',
+          homepage: 'https://example.com/ics55',
+          versions: [
+            {
+              version: '1.10.100',
+              platforms: {
+                'all-platform': {
+                  url: `file://${archive.path}`,
+                  sha256: archive.sha256,
+                  size: archive.size,
+                  strip_prefix: 'icsprout55-pdk-1.10.100',
+                  post_install: [
+                    {
+                      command: ['make', 'unzip'],
+                      cwd: '.',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    }), 'utf8')
+    const verifySha256 = vi.fn(async () => true)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+      commandRunner: postInstallRunner,
+      sha256Verifier: verifySha256,
+    })
+    const progress = vi.fn()
+
+    await expect(service.installResource('pdk:ics55', '1.10.100', progress)).resolves.toEqual({
+      status: 'started',
+      resource_id: 'pdk:ics55',
+      version: '1.10.100',
+    })
+
+    const destination = join(root, 'data', 'pdks', 'ics55', '1.10.100')
+    const installed = await service.getResource('pdk:ics55')
+    expect(installed).toMatchObject({
+      id: 'pdk:ics55',
+      type: 'pdk',
+      status: 'installed',
+      installed_version: '1.10.100',
+      active: true,
+      active_version: '1.10.100',
+      path: destination,
+      managed_root: join(root, 'data', 'pdks'),
+      source: 'registry',
+      actions: ['validate', 'uninstall'],
+      health: expect.objectContaining({
+        managed: true,
+        source: 'registry',
+        source_url: `file://${archive.path}`,
+        sha256: archive.sha256,
+      }),
+    })
+    await expect(readFile(join(destination, 'post-install-ran.txt'), 'utf8')).resolves.toBe('ok\n')
+    expect(postInstallRunner).toHaveBeenCalledWith(
+      'make',
+      ['unzip'],
+      expect.objectContaining({ cwd: expect.stringContaining(`${join('data', 'pdks', 'ics55')}`) }),
+    )
+    expect(verifySha256).toHaveBeenCalledTimes(1)
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({
+      resource_id: 'pdk:ics55',
+      phase: 'post_install',
+    }))
+    expect(progress).toHaveBeenLastCalledWith(expect.objectContaining({
+      resource_id: 'pdk:ics55',
+      phase: 'done',
+      progress: 1,
+    }))
+
+    const manifest = JSON.parse(
+      await readFile(join(root, 'state', 'resources', 'manifest.json'), 'utf8'),
+    ) as { installed: Record<string, unknown> }
+    expect(manifest.installed['pdk:ics55']).toMatchObject({
+      type: 'pdk',
+      id: 'ics55',
+      name: 'ics55',
+      pdk_id: 'ics55',
+      version: '1.10.100',
+      sha256: archive.sha256,
+      source: 'registry',
+      source_url: `file://${archive.path}`,
+      canonical_path: destination,
+      path: destination,
+      active: true,
+      managed: true,
+      health: 'ok',
+      detected_file_groups: {
+        directories: ['IP', 'prtech'],
+        files: ['README.md', 'post-install-ran.txt'],
+      },
+    })
+  })
+
+  it('marks managed registry PDKs updateable and updates them through the PDK install path', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const archive = await createPdkArchive(root)
+    const registryPath = join(root, 'registry.json')
+    await writeFile(registryPath, JSON.stringify({
+      schema_version: 2,
+      tools: [],
+      pdks: [
+        {
+          id: 'ics55',
+          display_name: 'ICsprout 55nm PDK',
+          description: 'ICsprout 55nm open-source process design kit.',
+          category: 'pdk',
+          homepage: 'https://example.com/ics55',
+          versions: [
+            {
+              version: '1.10.101',
+              platforms: {
+                'all-platform': {
+                  url: `file://${archive.path}`,
+                  sha256: archive.sha256,
+                  size: archive.size,
+                  strip_prefix: 'icsprout55-pdk-1.10.100',
+                },
+              },
+            },
+            {
+              version: '1.10.100',
+              platforms: {
+                'all-platform': {
+                  url: `file://${archive.path}`,
+                  sha256: archive.sha256,
+                  size: archive.size,
+                  strip_prefix: 'icsprout55-pdk-1.10.100',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    }), 'utf8')
+    await mkdir(join(root, 'state', 'resources'), { recursive: true })
+    await writeFile(join(root, 'state', 'resources', 'manifest.json'), JSON.stringify({
+      schema_version: 1,
+      resources_dir: join(root, 'state', 'resources'),
+      tools_dir: join(root, 'data', 'tools'),
+      pdks_dir: join(root, 'data', 'pdks'),
+      installed: {
+        'pdk:ics55': {
+          type: 'pdk',
+          id: 'ics55',
+          name: 'ics55',
+          pdk_id: 'ics55',
+          version: '1.10.100',
+          sha256: 'old-sha',
+          source: 'registry',
+          source_url: 'file:///old/ics55.tar',
+          canonical_path: join(root, 'data', 'pdks', 'ics55', '1.10.100'),
+          path: join(root, 'data', 'pdks', 'ics55', '1.10.100'),
+          detected_files: ['IP', 'prtech'],
+          detected_file_groups: {
+            directories: ['IP', 'prtech'],
+            files: [],
+          },
+          imported_at: '2026-01-01T00:00:00Z',
+          active: true,
+          managed: true,
+          health: 'ok',
+        },
+      },
+    }), 'utf8')
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+      sha256Verifier: vi.fn(async () => true),
+    })
+
+    await expect(service.getResource('pdk:ics55')).resolves.toMatchObject({
+      status: 'update_available',
+      installed_version: '1.10.100',
+      available_versions: ['1.10.101', '1.10.100'],
+      active: true,
+      actions: ['validate', 'update', 'uninstall'],
+    })
+    await expect(service.updateResource('pdk:ics55')).resolves.toEqual({
+      status: 'started',
+      resource_id: 'pdk:ics55',
+      version: '1.10.101',
+    })
+    await expect(service.getResource('pdk:ics55')).resolves.toMatchObject({
+      status: 'installed',
+      installed_version: '1.10.101',
+      active: true,
+      active_version: '1.10.101',
+      actions: ['validate', 'uninstall'],
+    })
+  })
+
+  it('pre-downloads PDK release assets before running Makefile post-install steps', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const archive = await createPdkArchive(root, {
+      makefileContent: [
+        'RELEASE_FILE_LIB := ics55_mock_liberty.tar.bz2 \\',
+        '                    ics55_mock_gds.tar.bz2',
+        'RELEASE_FILE := $(RELEASE_FILE_LIB)',
+        '',
+        'unzip:',
+        '\t@echo unzip',
+        '',
+      ].join('\n'),
+    })
+    const archiveBytes = await readFile(archive.path)
+    const registryPath = join(root, 'registry.json')
+    const archiveUrl = 'https://github.com/openecos-projects/icsprout55-pdk/archive/refs/tags/v1.10.100.tar.gz'
+    const fetchedUrls: string[] = []
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url)
+      fetchedUrls.push(requestUrl)
+      if (requestUrl === archiveUrl) {
+        return new Response(archiveBytes)
+      }
+      return new Response(new TextEncoder().encode(`payload for ${requestUrl}`))
+    })
+    const postInstallRunner = vi.fn(async (_command: string, _args: string[], options?: { cwd?: string }) => {
+      const cwd = options?.cwd ?? root
+      await expect(readFile(join(cwd, 'ics55_mock_liberty.tar.bz2'), 'utf8')).resolves.toContain('payload for')
+      await expect(readFile(join(cwd, 'ics55_mock_gds.tar.bz2'), 'utf8')).resolves.toContain('payload for')
+    })
+    await writeFile(registryPath, JSON.stringify({
+      schema_version: 2,
+      tools: [],
+      pdks: [
+        {
+          id: 'ics55',
+          display_name: 'ICsprout 55nm PDK',
+          versions: [
+            {
+              version: '1.10.100',
+              platforms: {
+                'all-platform': {
+                  url: archiveUrl,
+                  sha256: 'fixture-pdk-sha',
+                  size: archiveBytes.byteLength,
+                  strip_prefix: 'icsprout55-pdk-1.10.100',
+                  post_install: [
+                    {
+                      command: ['make', 'unzip'],
+                      cwd: '.',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    }), 'utf8')
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+      commandRunner: postInstallRunner,
+      fetchImpl: fetchImpl as typeof fetch,
+      sha256Verifier: vi.fn(async () => true),
+    })
+
+    await service.installResource('pdk:ics55', '1.10.100')
+
+    expect(fetchedUrls).toEqual(expect.arrayContaining([
+      archiveUrl,
+      'https://github.com/openecos-projects/icsprout55-pdk/releases/download/v1.10.100/ics55_mock_liberty.tar.bz2',
+      'https://github.com/openecos-projects/icsprout55-pdk/releases/download/v1.10.100/ics55_mock_gds.tar.bz2',
+    ]))
+    expect(postInstallRunner).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps post-install command failures concise when commands emit large output', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const archive = await createPdkArchive(root)
+    const registryPath = join(root, 'registry.json')
+    await writeFile(registryPath, JSON.stringify({
+      schema_version: 2,
+      tools: [],
+      pdks: [
+        {
+          id: 'ics55',
+          display_name: 'ICsprout 55nm PDK',
+          versions: [
+            {
+              version: '1.10.100',
+              platforms: {
+                'all-platform': {
+                  url: `file://${archive.path}`,
+                  sha256: archive.sha256,
+                  size: archive.size,
+                  strip_prefix: 'icsprout55-pdk-1.10.100',
+                  post_install: [
+                    {
+                      command: [
+                        process.execPath,
+                        '-e',
+                        "process.stderr.write('x'.repeat(12000)); process.exit(7)",
+                      ],
+                      cwd: '.',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    }), 'utf8')
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+      sha256Verifier: vi.fn(async () => true),
+    })
+
+    try {
+      await service.installResource('pdk:ics55', '1.10.100')
+      throw new Error('Expected post-install command to fail')
+    } catch (error) {
+      expect(error).toEqual(expect.objectContaining({
+        message: expect.stringMatching(/failed with exit code 7/),
+      }))
+      expect(error).toEqual(expect.objectContaining({
+        message: expect.not.stringMatching(/x{10000}/),
+      }))
+      expect(error).toEqual(expect.objectContaining({
+        message: expect.not.stringMatching(/x{3000}/),
+      }))
+    }
   })
 })

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -1,9 +1,10 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { access, copyFile, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { access, copyFile, mkdir, open, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { spawn } from 'node:child_process'
+import { electronLogger } from './logger'
 import type {
   ResourceAction,
   ResourceInfo,
@@ -16,16 +17,35 @@ import type {
 const DEFAULT_REGISTRY_URL = 'https://emin017.github.io/ecos-registry/tool-registry.json'
 const ALL_PLATFORM = 'all-platform'
 const TOP_LEVEL_ENTRY_LIMIT = 20
+const COMMAND_ERROR_OUTPUT_LIMIT = 2048
 
 type ResourceInventoryEntry = ToolInventoryEntry | PdkInventoryEntry
 type ArchiveExtractor = (archivePath: string, destination: string, stripPrefix?: string | null) => Promise<void>
+type CommandRunner = (command: string, args: string[], options?: CommandRunnerOptions) => Promise<void>
+type DownloadProgressListener = (progress: DownloadProgress) => void
 type Sha256Verifier = (filePath: string, expected: string) => Promise<boolean>
+
+interface CommandRunnerOptions {
+  cwd?: string
+}
+
+interface DownloadProgress {
+  downloadedBytes: number
+  progress: number
+  totalBytes: number | null
+}
 
 interface PlatformAsset {
   url: string
   sha256: string
   size: number
   strip_prefix?: string | null
+  post_install: RegistryPostInstallStep[]
+}
+
+interface RegistryPostInstallStep {
+  command: string[]
+  cwd: string
 }
 
 interface RegistryToolVersion {
@@ -110,9 +130,15 @@ interface RegistryState {
   diagnostics: string[]
 }
 
+interface RegistryCacheResult {
+  registry: ResourceRegistry | null
+  diagnostics: string[]
+}
+
 export interface ResourceManagerServiceOptions {
   archiveExtractor?: ArchiveExtractor
   cacheDir?: string
+  commandRunner?: CommandRunner
   fetchImpl?: typeof fetch
   pdksDir?: string
   registryUrl?: string
@@ -124,6 +150,7 @@ export interface ResourceManagerServiceOptions {
 export class ResourceManagerService {
   private readonly archiveExtractor: ArchiveExtractor
   private readonly cacheDir: string
+  private readonly commandRunner: CommandRunner
   private readonly fetchImpl: typeof fetch
   private readonly manifestPath: string
   private readonly pdksDir: string
@@ -133,6 +160,7 @@ export class ResourceManagerService {
   private readonly toolsDir: string
 
   private registryMemory: ResourceRegistry | null = null
+  private registryRefreshPromise: Promise<void> | null = null
   private activeJobs = new Set<string>()
 
   constructor(options: ResourceManagerServiceOptions = {}) {
@@ -142,6 +170,7 @@ export class ResourceManagerService {
     this.cacheDir = options.cacheDir ?? join(xdgCacheHome(), 'ecos-studio')
     this.manifestPath = join(this.resourcesDir, 'manifest.json')
     this.registryUrl = options.registryUrl ?? process.env.ECOS_REGISTRY_URL ?? DEFAULT_REGISTRY_URL
+    this.commandRunner = options.commandRunner ?? runCommand
     this.fetchImpl = options.fetchImpl ?? fetch
     this.archiveExtractor = options.archiveExtractor ?? extractArchive
     this.sha256Verifier = options.sha256Verifier ?? verifySha256
@@ -192,6 +221,9 @@ export class ResourceManagerService {
     if (resourceId.startsWith('tool:')) {
       return await this.installTool(resourceId.slice('tool:'.length), version, 'install', listener)
     }
+    if (resourceId.startsWith('pdk:')) {
+      return await this.installPdk(resourceId.slice('pdk:'.length), version, 'install', listener)
+    }
     throw new Error(`Install is not implemented for ${resourceId}`)
   }
 
@@ -201,6 +233,9 @@ export class ResourceManagerService {
   ): Promise<ResourceOperationResult> {
     if (resourceId.startsWith('tool:')) {
       return await this.installTool(resourceId.slice('tool:'.length), undefined, 'update', listener)
+    }
+    if (resourceId.startsWith('pdk:')) {
+      return await this.installPdk(resourceId.slice('pdk:'.length), undefined, 'update', listener)
     }
     throw new Error(`Update is not implemented for ${resourceId}`)
   }
@@ -343,24 +378,49 @@ export class ResourceManagerService {
       const tempExtract = join(this.toolsDir, name, `.extract-${version}-${randomUUID()}`)
 
       await mkdir(dirname(tempArchive), { recursive: true })
+      electronLogger.info(
+        '[resources] %s %s v%s on %s',
+        action === 'update' ? 'Updating' : 'Installing',
+        resourceId,
+        version,
+        platform,
+      )
+      electronLogger.debug(
+        '[resources] Download source for %s: %s -> %s (%d bytes)',
+        resourceId,
+        asset.url,
+        tempArchive,
+        asset.size,
+      )
       this.publish(listener, { resource_id: resourceId, action, phase: 'downloading', progress: 0, message: `Downloading ${name} v${version}...` })
-      await downloadAsset(asset.url, tempArchive, this.fetchImpl)
-      this.publish(listener, { resource_id: resourceId, action, phase: 'verifying', progress: 0, message: 'Verifying SHA256...' })
-      const verified = await this.sha256Verifier(tempArchive, asset.sha256)
-      if (!verified) {
+      await downloadAsset(asset.url, tempArchive, this.fetchImpl, asset.size, (progress) => {
+        const totalLabel = progress.totalBytes === null ? '?' : formatBytes(progress.totalBytes)
         this.publish(listener, {
           resource_id: resourceId,
           action,
-          phase: 'error',
-          progress: 0,
-          message: 'SHA256 verification failed',
-          error: 'SHA256 verification failed',
+          phase: 'downloading',
+          progress: progress.progress,
+          message: `Downloading ${name} v${version} (${formatBytes(progress.downloadedBytes)} / ${totalLabel})...`,
         })
+        electronLogger.debug(
+          '[resources] Download progress for %s: %d/%s bytes (%d%%)',
+          resourceId,
+          progress.downloadedBytes,
+          progress.totalBytes ?? '?',
+          Math.round(progress.progress * 100),
+        )
+      })
+      this.publish(listener, { resource_id: resourceId, action, phase: 'verifying', progress: 0, message: 'Verifying SHA256...' })
+      electronLogger.debug('[resources] Verifying %s with SHA256 %s', resourceId, asset.sha256 || '(not provided)')
+      const verified = await this.sha256Verifier(tempArchive, asset.sha256)
+      if (!verified) {
         throw new Error(`SHA256 verification failed for ${name}`)
       }
-      this.publish(listener, { resource_id: resourceId, action, phase: 'extracting', progress: 0, message: `Extracting to ${destination}...` })
+      electronLogger.debug('[resources] Extracting %s into %s', resourceId, destination)
       await rm(tempExtract, { force: true, recursive: true })
-      await this.archiveExtractor(tempArchive, tempExtract, asset.strip_prefix)
+      await this.withExtractProgress(resourceId, action, name, listener, async () => {
+        await this.archiveExtractor(tempArchive, tempExtract, asset.strip_prefix)
+      })
       await rm(destination, { force: true, recursive: true })
       await mkdir(dirname(destination), { recursive: true })
       await rm(destination, { force: true, recursive: true })
@@ -388,9 +448,211 @@ export class ResourceManagerService {
         progress: 1,
         message: `${name} v${version} installed successfully`,
       })
+      electronLogger.info('[resources] Installed %s v%s at %s', resourceId, version, destination)
       return { status: 'started', resource_id: resourceId, version }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      electronLogger.error('[resources] Failed to install %s: %s', resourceId, message)
+      this.publish(listener, {
+        resource_id: resourceId,
+        action,
+        phase: 'error',
+        progress: 0,
+        message,
+        error: message,
+      })
+      throw error
     } finally {
       this.activeJobs.delete(resourceId)
+    }
+  }
+
+  private async installPdk(
+    pdkId: string,
+    requestedVersion: string | undefined,
+    action: ResourceAction,
+    listener?: (event: ResourceJob) => void,
+  ): Promise<ResourceOperationResult> {
+    const resourceId = `pdk:${pdkId}`
+    if (this.activeJobs.has(resourceId)) {
+      throw new Error(`Job already active for ${resourceId}`)
+    }
+    this.activeJobs.add(resourceId)
+
+    try {
+      const state = await this.fetchRegistry()
+      const pdk = state.registry?.pdks.find((candidate) => candidate.id === pdkId)
+      if (!pdk) throw new Error(`PDK '${pdkId}' not found in registry`)
+      const versionEntry = requestedVersion
+        ? pdk.versions.find((candidate) => candidate.version === requestedVersion)
+        : pdk.versions[0]
+      if (!versionEntry) throw new Error(`Version not found for ${pdkId}`)
+      const { platform, asset } = selectPlatformAsset(versionEntry)
+      if (!asset) throw new Error(`No asset for ${pdkId} on ${platform}`)
+      const version = versionEntry.version
+      const displayName = pdk.display_name || pdkId
+      const destination = join(this.pdksDir, pdkId, version)
+      const tempArchive = join(this.resourcesDir, 'downloads', `${pdkId}-${version}-${randomUUID()}.archive`)
+      const tempExtract = join(this.pdksDir, pdkId, `.extract-${version}-${randomUUID()}`)
+
+      await mkdir(dirname(tempArchive), { recursive: true })
+      electronLogger.info(
+        '[resources] %s %s v%s on %s',
+        action === 'update' ? 'Updating' : 'Installing',
+        resourceId,
+        version,
+        platform,
+      )
+      electronLogger.debug(
+        '[resources] Download source for %s: %s -> %s (%d bytes)',
+        resourceId,
+        asset.url,
+        tempArchive,
+        asset.size,
+      )
+      this.publish(listener, { resource_id: resourceId, action, phase: 'downloading', progress: 0, message: `Downloading ${displayName} v${version}...` })
+      await downloadAsset(asset.url, tempArchive, this.fetchImpl, asset.size, (progress) => {
+        const totalLabel = progress.totalBytes === null ? '?' : formatBytes(progress.totalBytes)
+        this.publish(listener, {
+          resource_id: resourceId,
+          action,
+          phase: 'downloading',
+          progress: progress.progress,
+          message: `Downloading ${displayName} v${version} (${formatBytes(progress.downloadedBytes)} / ${totalLabel})...`,
+        })
+        electronLogger.debug(
+          '[resources] Download progress for %s: %d/%s bytes (%d%%)',
+          resourceId,
+          progress.downloadedBytes,
+          progress.totalBytes ?? '?',
+          Math.round(progress.progress * 100),
+        )
+      })
+      this.publish(listener, { resource_id: resourceId, action, phase: 'verifying', progress: 0, message: 'Verifying SHA256...' })
+      electronLogger.debug('[resources] Verifying %s with SHA256 %s', resourceId, asset.sha256 || '(not provided)')
+      const verified = await this.sha256Verifier(tempArchive, asset.sha256)
+      if (!verified) {
+        throw new Error(`SHA256 verification failed for ${pdkId}`)
+      }
+      electronLogger.debug('[resources] Extracting %s into %s', resourceId, destination)
+      await rm(tempExtract, { force: true, recursive: true })
+      await this.withExtractProgress(resourceId, action, displayName, listener, async () => {
+        await this.archiveExtractor(tempArchive, tempExtract, asset.strip_prefix)
+      })
+      await rm(destination, { force: true, recursive: true })
+      await mkdir(dirname(destination), { recursive: true })
+      await rename(tempExtract, destination)
+      await this.preDownloadPdkReleaseAssets(resourceId, action, displayName, destination, version, asset, listener)
+      await this.runPostInstallSteps(resourceId, action, displayName, destination, asset.post_install, listener)
+
+      const scanned = await scanPdkDirectory(destination)
+      const manifest = await this.readManifest()
+      const previous = manifest.installed[resourceId]
+      const hasOtherActivePdk = Object.entries(manifest.installed).some(([id, entry]) => {
+        return id !== resourceId && isPdkEntry(entry) && entry.active
+      })
+      const active = isPdkEntry(previous) ? previous.active || !hasOtherActivePdk : !hasOtherActivePdk
+      if (active) {
+        for (const [id, entry] of Object.entries(manifest.installed)) {
+          if (id !== resourceId && isPdkEntry(entry)) {
+            entry.active = false
+          }
+        }
+      }
+      manifest.installed[resourceId] = {
+        type: 'pdk',
+        id: pdkId,
+        name: scanned.name || displayName,
+        pdk_id: pdkId,
+        version,
+        sha256: asset.sha256,
+        source: 'registry',
+        source_url: asset.url,
+        canonical_path: destination,
+        path: destination,
+        detected_files: [...scanned.detectedFiles.directories, ...scanned.detectedFiles.files],
+        detected_file_groups: scanned.detectedFiles,
+        imported_at: utcNowIso(),
+        active,
+        managed: true,
+        health: 'ok',
+      }
+      await this.writeManifest(manifest)
+      this.publish(listener, {
+        resource_id: resourceId,
+        action,
+        phase: 'done',
+        progress: 1,
+        message: `${displayName} v${version} installed successfully`,
+      })
+      electronLogger.info('[resources] Installed %s v%s at %s', resourceId, version, destination)
+      return { status: 'started', resource_id: resourceId, version }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      electronLogger.error('[resources] Failed to install %s: %s', resourceId, message)
+      this.publish(listener, {
+        resource_id: resourceId,
+        action,
+        phase: 'error',
+        progress: 0,
+        message,
+        error: message,
+      })
+      throw error
+    } finally {
+      this.activeJobs.delete(resourceId)
+    }
+  }
+
+  private async runPostInstallSteps(
+    resourceId: string,
+    action: ResourceAction,
+    name: string,
+    destination: string,
+    steps: RegistryPostInstallStep[],
+    listener?: (event: ResourceJob) => void,
+  ): Promise<void> {
+    for (const [index, step] of steps.entries()) {
+      const [command, ...args] = step.command
+      if (!command) continue
+      const cwd = resolveInside(destination, step.cwd || '.')
+      this.publish(listener, {
+        resource_id: resourceId,
+        action,
+        phase: 'post_install',
+        progress: 0.98,
+        message: `Running post-install step ${index + 1}/${steps.length} for ${name}: ${command}`,
+      })
+      await this.commandRunner(command, args, { cwd })
+    }
+  }
+
+  private async preDownloadPdkReleaseAssets(
+    resourceId: string,
+    action: ResourceAction,
+    name: string,
+    destination: string,
+    version: string,
+    asset: PlatformAsset,
+    listener?: (event: ResourceJob) => void,
+  ): Promise<void> {
+    if (asset.post_install.length === 0) return
+    const assetNames = await readPdkReleaseAssetNames(destination)
+    const baseUrl = releaseDownloadBaseUrl(asset.url, version)
+    if (!baseUrl || assetNames.length === 0) return
+
+    for (const [index, assetName] of assetNames.entries()) {
+      const targetPath = join(destination, assetName)
+      if (await pathExists(targetPath)) continue
+      const downloadUrl = `${baseUrl}/${encodeURIComponent(assetName)}`
+      this.publish(listener, {
+        resource_id: resourceId,
+        action,
+        phase: 'post_install',
+        progress: 0.98,
+        message: `Downloading ${name} post-install asset ${index + 1}/${assetNames.length}: ${assetName}`,
+      })
+      await downloadAsset(downloadUrl, targetPath, this.fetchImpl, null)
     }
   }
 
@@ -413,7 +675,15 @@ export class ResourceManagerService {
       return { registry: this.registryMemory, diagnostics: [] }
     }
 
-    const cacheFile = join(this.cacheDir, 'resource-registry.json')
+    const cacheFile = registryCachePath(this.cacheDir, this.registryUrl)
+    if (!force) {
+      const cached = await this.readCachedRegistry(cacheFile)
+      if (cached.registry) {
+        this.refreshRegistryInBackground(cacheFile)
+        return cached
+      }
+    }
+
     const diagnostics: string[] = []
     try {
       const registry = await readRegistryFromUrl(this.registryUrl, this.fetchImpl)
@@ -434,6 +704,38 @@ export class ResourceManagerService {
       diagnostics.push('No registry data available')
       return { registry: null, diagnostics }
     }
+  }
+
+  private async readCachedRegistry(cacheFile: string): Promise<RegistryCacheResult> {
+    try {
+      const registry = parseRegistry(JSON.parse(await readFile(cacheFile, 'utf8')))
+      this.registryMemory = registry
+      return {
+        registry,
+        diagnostics: ['Using cached registry data while refreshing in background'],
+      }
+    } catch {
+      return { registry: null, diagnostics: [] }
+    }
+  }
+
+  private refreshRegistryInBackground(cacheFile: string): void {
+    if (this.registryRefreshPromise) return
+    this.registryRefreshPromise = (async () => {
+      try {
+        const registry = await readRegistryFromUrl(this.registryUrl, this.fetchImpl)
+        await mkdir(dirname(cacheFile), { recursive: true })
+        await writeFile(cacheFile, JSON.stringify(registry, null, 2), 'utf8')
+        this.registryMemory = registry
+      } catch (error) {
+        electronLogger.debug(
+          '[resources] Background registry refresh failed: %s',
+          error instanceof Error ? error.message : String(error),
+        )
+      } finally {
+        this.registryRefreshPromise = null
+      }
+    })()
   }
 
   private async readManifest(): Promise<ResourceManifest> {
@@ -537,14 +839,16 @@ export class ResourceManagerService {
   private registryPdkToResource(pdk: RegistryPdk): ResourceInfo {
     const latest = pdk.versions[0]
     const { platform, asset } = latest ? selectPlatformAsset(latest) : { platform: currentPlatform(), asset: null }
+    const resourceId = `pdk:${pdk.id}`
+    const isActive = this.activeJobs.has(resourceId)
     return {
-      id: `pdk:${pdk.id}`,
+      id: resourceId,
       type: 'pdk',
       name: pdk.id,
       display_name: pdk.display_name,
       description: pdk.description ?? '',
       category: pdk.category ?? 'pdk',
-      status: 'available',
+      status: isActive ? 'installing' : 'available',
       installed_version: null,
       available_versions: pdk.versions.map((version) => version.version),
       active_version: null,
@@ -555,25 +859,38 @@ export class ResourceManagerService {
       size: asset?.size ?? null,
       source: 'registry',
       homepage: pdk.homepage ?? '',
-      actions: ['install'],
+      actions: isActive ? [] : ['install'],
       health: {},
       error: null,
     }
   }
 
   private pdkEntryToResource(entry: PdkInventoryEntry, registryPdk?: RegistryPdk): ResourceInfo {
-    const status: ResourceStatus = entry.health === 'missing'
+    const resourceId = `pdk:${entry.id}`
+    const hasUpdate = entry.managed
+      && entry.health === 'ok'
+      && Boolean(entry.version)
+      && Boolean(registryPdk?.versions[0]?.version)
+      && registryPdk?.versions[0]?.version !== entry.version
+    const status: ResourceStatus = this.activeJobs.has(resourceId)
+      ? 'installing'
+      : entry.health === 'missing'
       ? 'missing'
       : entry.health === 'invalid'
         ? 'invalid'
-        : 'installed'
+        : hasUpdate
+          ? 'update_available'
+          : 'installed'
     const actions: ResourceAction[] = []
-    if (!entry.active) actions.push('activate')
-    actions.push('validate')
-    actions.push(entry.managed ? 'uninstall' : 'remove_reference')
+    if (status !== 'installing') {
+      if (!entry.active) actions.push('activate')
+      actions.push('validate')
+      if (hasUpdate) actions.push('update')
+      actions.push(entry.managed ? 'uninstall' : 'remove_reference')
+    }
 
     return {
-      id: `pdk:${entry.id}`,
+      id: resourceId,
       type: 'pdk',
       name: entry.id,
       display_name: entry.name || registryPdk?.display_name || entry.id,
@@ -600,6 +917,40 @@ export class ResourceManagerService {
     return registry?.pdks.find((pdk) => pdk.id === pdkId)
   }
 
+  private async withExtractProgress(
+    resourceId: string,
+    action: ResourceAction,
+    name: string,
+    listener: ((event: ResourceJob) => void) | undefined,
+    task: () => Promise<void>,
+  ): Promise<void> {
+    let progress = 0.05
+    let timer: NodeJS.Timeout | null = null
+    const publishExtracting = (value: number): void => {
+      progress = Math.max(progress, Math.min(value, 0.98))
+      this.publish(listener, {
+        resource_id: resourceId,
+        action,
+        phase: 'extracting',
+        progress,
+        message: `Extracting ${name} ${Math.round(progress * 100)}%...`,
+      })
+    }
+
+    publishExtracting(progress)
+    timer = setInterval(() => {
+      if (progress >= 0.95) return
+      publishExtracting(progress + 0.03)
+    }, 500)
+
+    try {
+      await task()
+      publishExtracting(0.98)
+    } finally {
+      if (timer) clearInterval(timer)
+    }
+  }
+
   private publish(
     listener: ((event: ResourceJob) => void) | undefined,
     event: Omit<ResourceJob, 'id' | 'error'> & { error?: string | null },
@@ -622,6 +973,14 @@ function xdgStateHome(): string {
 
 function xdgCacheHome(): string {
   return process.env.XDG_CACHE_HOME || join(homedir(), '.cache')
+}
+
+function registryCachePath(cacheDir: string, registryUrl: string): string {
+  if (registryUrl === DEFAULT_REGISTRY_URL) {
+    return join(cacheDir, 'resource-registry.json')
+  }
+  const key = createHash('sha256').update(registryUrl).digest('hex').slice(0, 12)
+  return join(cacheDir, `resource-registry-${key}.json`)
 }
 
 function utcNowIso(): string {
@@ -708,9 +1067,25 @@ function parsePlatformAssets(value: unknown): Record<string, PlatformAsset> {
       sha256: readString(asset.sha256),
       size: readNumber(asset.size),
       strip_prefix: typeof asset.strip_prefix === 'string' ? asset.strip_prefix : null,
+      post_install: parsePostInstallSteps(asset.post_install),
     }
   }
   return assets
+}
+
+function parsePostInstallSteps(value: unknown): RegistryPostInstallStep[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => {
+      const record = readRecord(item)
+      const command = readStringArray(record.command).filter(Boolean)
+      if (command.length === 0) return null
+      return {
+        command,
+        cwd: readString(record.cwd) || '.',
+      }
+    })
+    .filter((step): step is RegistryPostInstallStep => step !== null)
 }
 
 function parseManifest(
@@ -906,17 +1281,180 @@ async function scanPdkDirectory(path: string): Promise<{
   }
 }
 
-async function downloadAsset(url: string, destination: string, fetchImpl: typeof fetch): Promise<void> {
+function readContentLength(value: string | null): number | null {
+  if (!value) return null
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`
+  }
+  return `${bytes} B`
+}
+
+async function downloadAsset(
+  url: string,
+  destination: string,
+  fetchImpl: typeof fetch,
+  expectedSize: number | null,
+  onProgress?: DownloadProgressListener,
+): Promise<void> {
   if (url.startsWith('file://')) {
-    await copyFile(new URL(url), destination)
+    const fileUrl = new URL(url)
+    await copyFile(fileUrl, destination)
+    const size = await stat(fileUrl).then((value) => value.size).catch(() => 0)
+    onProgress?.({
+      downloadedBytes: size,
+      progress: 1,
+      totalBytes: size > 0 ? size : null,
+    })
     return
   }
   const response = await fetchImpl(url)
   if (!response.ok) {
     throw new Error(`Download failed with ${response.status}: ${url}`)
   }
-  const data = Buffer.from(await response.arrayBuffer())
-  await writeFile(destination, data)
+
+  const totalBytes = readContentLength(response.headers.get('content-length'))
+    ?? (expectedSize && expectedSize > 0 ? expectedSize : null)
+  if (!response.body) {
+    const data = Buffer.from(await response.arrayBuffer())
+    await writeFile(destination, data)
+    onProgress?.({
+      downloadedBytes: data.byteLength,
+      progress: 1,
+      totalBytes: totalBytes ?? data.byteLength,
+    })
+    return
+  }
+
+  const reader = response.body.getReader()
+  const file = await open(destination, 'w')
+  let downloadedBytes = 0
+  let lastPublishedBytes = 0
+  let lastPublishedProgress = 0
+
+  const publishProgress = (force = false): void => {
+    const progress = totalBytes === null
+      ? 0
+      : Math.min(downloadedBytes / totalBytes, 1)
+    const shouldPublishKnownTotal = totalBytes !== null
+      && (progress - lastPublishedProgress >= 0.01 || progress >= 1)
+    const shouldPublishUnknownTotal = totalBytes === null
+      && downloadedBytes - lastPublishedBytes >= 1024 * 1024
+    if (!force && !shouldPublishKnownTotal && !shouldPublishUnknownTotal) return
+    if (downloadedBytes === lastPublishedBytes && progress === lastPublishedProgress) return
+    lastPublishedBytes = downloadedBytes
+    lastPublishedProgress = progress
+    onProgress?.({
+      downloadedBytes,
+      progress,
+      totalBytes,
+    })
+  }
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!value) continue
+      await file.write(value)
+      downloadedBytes += value.byteLength
+      publishProgress()
+    }
+    publishProgress(true)
+  } finally {
+    reader.releaseLock()
+    await file.close()
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readPdkReleaseAssetNames(destination: string): Promise<string[]> {
+  const makefilePath = join(destination, 'Makefile')
+  const makefile = await readFile(makefilePath, 'utf8').catch(() => '')
+  if (!makefile) return []
+  return parseMakefileReleaseAssetNames(makefile)
+}
+
+function parseMakefileReleaseAssetNames(makefile: string): string[] {
+  const variables = new Map<string, string[]>()
+  const assignmentPattern = /^([A-Za-z0-9_]+)\s*(?::=|=)\s*(.*)$/
+  const lines = makefile.split(/\r?\n/)
+
+  for (let index = 0; index < lines.length; index += 1) {
+    let line = lines[index].replace(/#.*$/, '').trimEnd()
+    if (!assignmentPattern.test(line.trimStart())) continue
+    while (line.endsWith('\\') && index + 1 < lines.length) {
+      line = `${line.slice(0, -1)} ${lines[index + 1].replace(/#.*$/, '').trim()}`
+      index += 1
+    }
+    const match = line.trim().match(assignmentPattern)
+    if (!match) continue
+    const [, name, rawValue] = match
+    variables.set(name, expandMakefileWords(rawValue, variables))
+  }
+
+  const releaseFiles = variables.get('RELEASE_FILE')
+    ?? Array.from(variables.entries())
+      .filter(([name]) => name.startsWith('RELEASE_FILE'))
+      .flatMap(([, value]) => value)
+  return Array.from(new Set(releaseFiles.filter(isDownloadableReleaseAssetName)))
+}
+
+function expandMakefileWords(rawValue: string, variables: Map<string, string[]>): string[] {
+  const words: string[] = []
+  for (const token of rawValue.split(/\s+/).filter(Boolean)) {
+    const variableMatch = token.match(/^\$\(([^)]+)\)$/)
+    if (variableMatch) {
+      words.push(...(variables.get(variableMatch[1]) ?? []))
+      continue
+    }
+    words.push(token)
+  }
+  return words
+}
+
+function isDownloadableReleaseAssetName(name: string): boolean {
+  return /^[A-Za-z0-9._+-]+\.tar\.bz2$/.test(name)
+}
+
+function releaseDownloadBaseUrl(sourceUrl: string, version: string): string | null {
+  const parsed = parseGithubArchiveUrl(sourceUrl)
+  if (!parsed) return null
+  return `https://github.com/${parsed.owner}/${parsed.repo}/releases/download/${parsed.tag || `v${version}`}`
+}
+
+function parseGithubArchiveUrl(sourceUrl: string): { owner: string; repo: string; tag: string | null } | null {
+  let url: URL
+  try {
+    url = new URL(sourceUrl)
+  } catch {
+    return null
+  }
+  if (url.hostname !== 'github.com') return null
+  const parts = url.pathname.split('/').filter(Boolean)
+  if (parts.length < 2) return null
+  const [owner, repo] = parts
+  const refsIndex = parts.findIndex((part, index) => part === 'refs' && parts[index + 1] === 'tags')
+  const tag = refsIndex >= 0 ? parts[refsIndex + 2]?.replace(/\.tar\.gz$|\.zip$/, '') ?? null : null
+  return { owner, repo, tag }
 }
 
 async function verifySha256(filePath: string, expected: string): Promise<boolean> {
@@ -931,28 +1469,82 @@ async function verifySha256(filePath: string, expected: string): Promise<boolean
   return hash.digest('hex') === expected.toLowerCase()
 }
 
-async function extractArchive(archivePath: string, destination: string): Promise<void> {
-  await mkdir(destination, { recursive: true })
-  if (archivePath.endsWith('.zip')) {
+async function extractZipArchive(
+  archivePath: string,
+  destination: string,
+  stripPrefix?: string | null,
+): Promise<void> {
+  if (!stripPrefix) {
     await runCommand('unzip', ['-q', archivePath, '-d', destination])
     return
   }
-  await runCommand('tar', ['-xf', archivePath, '-C', destination])
+  const tempDestination = `${destination}.zip-${randomUUID()}`
+  await mkdir(tempDestination, { recursive: true })
+  try {
+    await runCommand('unzip', ['-q', archivePath, '-d', tempDestination])
+    await moveStrippedPrefix(tempDestination, destination, stripPrefix)
+  } finally {
+    await rm(tempDestination, { force: true, recursive: true })
+  }
 }
 
-async function runCommand(command: string, args: string[]): Promise<void> {
+async function extractArchive(
+  archivePath: string,
+  destination: string,
+  stripPrefix?: string | null,
+): Promise<void> {
+  await mkdir(destination, { recursive: true })
+  if (archivePath.endsWith('.zip')) {
+    await extractZipArchive(archivePath, destination, stripPrefix)
+    return
+  }
+  const args = ['-xf', archivePath, '-C', destination]
+  if (stripPrefix) {
+    args.push('--strip-components', '1')
+  }
+  await runCommand('tar', args)
+}
+
+async function moveStrippedPrefix(sourceRoot: string, destination: string, stripPrefix: string): Promise<void> {
+  const source = resolveInside(sourceRoot, stripPrefix)
+  const sourceStats = await stat(source)
+  if (!sourceStats.isDirectory()) {
+    throw new Error(`Archive strip_prefix is not a directory: ${stripPrefix}`)
+  }
+  await rm(destination, { force: true, recursive: true })
+  await mkdir(dirname(destination), { recursive: true })
+  await rename(source, destination)
+}
+
+function resolveInside(root: string, child: string): string {
+  const resolved = resolve(root, child || '.')
+  const relativePath = relative(root, resolved)
+  if (isAbsolute(relativePath) || relativePath.startsWith('..')) {
+    throw new Error(`Path escapes resource directory: ${child}`)
+  }
+  return resolved
+}
+
+async function runCommand(command: string, args: string[], options?: CommandRunnerOptions): Promise<void> {
   await new Promise<void>((resolvePromise, reject) => {
-    const child = spawn(command, args, { stdio: 'pipe' })
+    const child = spawn(command, args, { cwd: options?.cwd, stdio: 'pipe' })
     let stderr = ''
+    child.stdout?.on('data', () => {
+      // Consume noisy command output so verbose tools cannot block on pipe backpressure.
+    })
     child.stderr?.on('data', (chunk) => {
-      stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk)
+      stderr = `${stderr}${Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk)}`
+      if (stderr.length > COMMAND_ERROR_OUTPUT_LIMIT) {
+        stderr = stderr.slice(-COMMAND_ERROR_OUTPUT_LIMIT)
+      }
     })
     child.on('error', reject)
     child.on('close', (code) => {
       if (code === 0) {
         resolvePromise()
       } else {
-        reject(new Error(`${command} failed with exit code ${code}: ${stderr.trim()}`))
+        const details = stderr.trim()
+        reject(new Error(`${command} failed with exit code ${code}${details ? `: ${details}` : ''}`))
       }
     })
   })

--- a/ecos/gui/apps/renderer/src/stores/pluginStore.test.ts
+++ b/ecos/gui/apps/renderer/src/stores/pluginStore.test.ts
@@ -90,8 +90,14 @@ async function flushPromises(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 describe('pluginStore', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.mocked(installResourceApi).mockReset()
@@ -198,7 +204,7 @@ describe('pluginStore', () => {
       progress: 1,
       message: 'Done',
     })
-    await flushPromises()
+    await flushMicrotasks()
 
     expect(close).toHaveBeenCalledTimes(1)
     expect(store.resourceProgress['pdk:ics55']).toBeUndefined()
@@ -257,6 +263,69 @@ describe('pluginStore', () => {
       status: 'installed',
       installed_version: '1.01',
     })
+  })
+
+  it('throttles high-frequency resource progress updates while flushing terminal events immediately', async () => {
+    vi.useFakeTimers()
+    const availablePdk = makePdkResource()
+    let onProgress: ((progress: InstallProgress) => void) | undefined
+    const close = vi.fn()
+
+    vi.mocked(listResourcesApi).mockResolvedValue([availablePdk])
+    vi.mocked(installResourceApi).mockResolvedValue({
+      status: 'started',
+      resource_id: 'pdk:ics55',
+      version: '1.01',
+    })
+    vi.mocked(subscribeResourceProgress).mockImplementation((_resourceId, callback) => {
+      onProgress = callback
+      return { close }
+    })
+
+    const store = usePluginStore()
+    await store.fetchTools()
+    await store.installResource('pdk:ics55', '1.01')
+
+    onProgress?.({
+      resourceId: 'pdk:ics55',
+      resourceName: 'ics55',
+      tool: 'ics55',
+      phase: 'downloading',
+      progress: 0.1,
+      message: 'Downloading 10%',
+    })
+    onProgress?.({
+      resourceId: 'pdk:ics55',
+      resourceName: 'ics55',
+      tool: 'ics55',
+      phase: 'downloading',
+      progress: 0.2,
+      message: 'Downloading 20%',
+    })
+
+    expect(store.resourceProgress['pdk:ics55']).toMatchObject({
+      progress: 0.1,
+      message: 'Downloading 10%',
+    })
+
+    await vi.advanceTimersByTimeAsync(180)
+    expect(store.resourceProgress['pdk:ics55']).toMatchObject({
+      progress: 0.2,
+      message: 'Downloading 20%',
+    })
+
+    onProgress?.({
+      resourceId: 'pdk:ics55',
+      resourceName: 'ics55',
+      tool: 'ics55',
+      phase: 'done',
+      progress: 1,
+      message: 'Done',
+    })
+    await flushMicrotasks()
+
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(store.resourceProgress['pdk:ics55']).toBeUndefined()
   })
 
   it('updates a resource by resourceId and syncs legacy tool progress and errors', async () => {

--- a/ecos/gui/apps/renderer/src/stores/pluginStore.ts
+++ b/ecos/gui/apps/renderer/src/stores/pluginStore.ts
@@ -14,6 +14,8 @@ import {
 } from '@/api/plugin'
 import type { InstallProgress, ResourceItem, ToolInfo } from '@/api/plugin'
 
+const PROGRESS_UPDATE_INTERVAL_MS = 180
+
 export const usePluginStore = defineStore('plugin', () => {
   const resources = ref<ResourceItem[]>([])
   const tools = ref<ToolInfo[]>([])
@@ -27,6 +29,8 @@ export const usePluginStore = defineStore('plugin', () => {
   const resourceProgress = ref<Record<string, InstallProgress>>({})
 
   const _sseConnections = new Map<string, { close: () => void }>()
+  const _pendingProgress = new Map<string, InstallProgress>()
+  const _progressTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
   const categories = computed(() => {
     const cats = new Set(tools.value.map((t) => t.category))
@@ -84,6 +88,44 @@ export const usePluginStore = defineStore('plugin', () => {
     delete installProgress.value[toolName]
   }
 
+  function _applyResourceProgress(progress: InstallProgress): void {
+    resourceProgress.value[progress.resourceId] = progress
+    _syncLegacyToolProgress(progress.resourceId, progress)
+  }
+
+  function _clearProgressTimer(resourceId: string): void {
+    const timer = _progressTimers.get(resourceId)
+    if (timer) {
+      clearTimeout(timer)
+      _progressTimers.delete(resourceId)
+    }
+    _pendingProgress.delete(resourceId)
+  }
+
+  function _queueResourceProgress(progress: InstallProgress): void {
+    const resourceId = progress.resourceId
+    if (!_progressTimers.has(resourceId)) {
+      _applyResourceProgress(progress)
+      _progressTimers.set(resourceId, setTimeout(() => {
+        _progressTimers.delete(resourceId)
+        const pending = _pendingProgress.get(resourceId)
+        _pendingProgress.delete(resourceId)
+        if (pending) {
+          _queueResourceProgress(pending)
+        }
+      }, PROGRESS_UPDATE_INTERVAL_MS))
+      return
+    }
+
+    _pendingProgress.set(resourceId, progress)
+  }
+
+  function _clearResourceProgress(resourceId: string): void {
+    _clearProgressTimer(resourceId)
+    delete resourceProgress.value[resourceId]
+    _syncLegacyToolProgress(resourceId)
+  }
+
   function _setResourceStatus(resourceId: string, status: ResourceItem['status']): void {
     const resource = resources.value.find((item) => item.id === resourceId)
     if (!resource) {
@@ -134,14 +176,10 @@ export const usePluginStore = defineStore('plugin', () => {
     const conn = subscribeResourceProgress(
       resourceId,
       (progress) => {
-        resourceProgress.value[progress.resourceId] = progress
-        _syncLegacyToolProgress(progress.resourceId, progress)
-
         if (progress.phase === 'done' || progress.phase === 'error') {
           conn.close()
           _sseConnections.delete(resourceId)
-          delete resourceProgress.value[progress.resourceId]
-          _syncLegacyToolProgress(progress.resourceId)
+          _clearResourceProgress(progress.resourceId)
           if (progress.phase === 'done') {
             delete resourceErrors.value[progress.resourceId]
             _syncLegacyToolError(progress.resourceId)
@@ -149,9 +187,13 @@ export const usePluginStore = defineStore('plugin', () => {
             _setResourceError(progress.resourceId, progress.message || 'Installation failed')
           }
           void fetchTools({ silent: true })
+          return
         }
+
+        _queueResourceProgress(progress)
       },
       () => {
+        _clearProgressTimer(resourceId)
         _sseConnections.delete(resourceId)
       },
     )
@@ -168,8 +210,7 @@ export const usePluginStore = defineStore('plugin', () => {
     } catch (e) {
       _sseConnections.get(resourceId)?.close()
       _sseConnections.delete(resourceId)
-      delete resourceProgress.value[resourceId]
-      _syncLegacyToolProgress(resourceId)
+      _clearResourceProgress(resourceId)
       _setResourceError(
         resourceId,
         e instanceof Error ? e.message : `Failed to install ${_resourceName(resourceId)}`,
@@ -187,8 +228,7 @@ export const usePluginStore = defineStore('plugin', () => {
     } catch (e) {
       _sseConnections.get(resourceId)?.close()
       _sseConnections.delete(resourceId)
-      delete resourceProgress.value[resourceId]
-      _syncLegacyToolProgress(resourceId)
+      _clearResourceProgress(resourceId)
       _setResourceError(
         resourceId,
         e instanceof Error ? e.message : `Failed to update ${_resourceName(resourceId)}`,
@@ -265,6 +305,9 @@ export const usePluginStore = defineStore('plugin', () => {
       conn.close()
     }
     _sseConnections.clear()
+    for (const resourceId of _progressTimers.keys()) {
+      _clearProgressTimer(resourceId)
+    }
   }
 
   return {

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -8,4 +8,23 @@ describe('PluginToolsView resource table layout', () => {
     )
     expect(pluginToolsViewSource).not.toContain('.resource-table {\n  min-width: 680px;')
   })
+
+  it('renders mini progress with a transform driven by the row progress percent', () => {
+    expect(pluginToolsViewSource).toContain(
+      ":style=\"{ '--progress': row.progressPercent / 100 }\"",
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /\.mini-progress span\s*\{[\s\S]*transform:\s*scaleX\(var\(--progress,\s*0\)\);/,
+    )
+  })
+
+  it('uses only a lightweight background blur and avoids backdrop blur', () => {
+    expect(pluginToolsViewSource).toMatch(
+      /\.blurred-home\s*\{[\s\S]*filter:\s*blur\(1\.5px\)\s+brightness\(0\.82\);/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /\.blurred-home\s*\{[\s\S]*transform:\s*translateZ\(0\)\s+scale\(1\.006\);/,
+    )
+    expect(pluginToolsViewSource).not.toContain('backdrop-filter: blur(')
+  })
 })

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -173,12 +173,13 @@
                       v-if="row.progressPercent !== null"
                       class="mini-progress"
                       role="progressbar"
+                      :style="{ '--progress': row.progressPercent / 100 }"
                       :aria-valuenow="row.progressPercent"
                       aria-valuemin="0"
                       aria-valuemax="100"
                       :aria-label="`${row.name} installation progress`"
                     >
-                      <span :style="{ width: `${row.progressPercent}%` }"></span>
+                      <span></span>
                     </span>
                     <span v-if="rowError(row)" class="row-error-msg">{{ rowError(row) }}</span>
                   </span>
@@ -598,6 +599,14 @@ async function openDocs(): Promise<void> {
 <style scoped>
 /* ---- Layout ---- */
 .resource-manager-view {
+  --success-color: #2f9f6f;
+  --success-bg: color-mix(in srgb, var(--success-color) 14%, transparent);
+  --info-color: var(--accent-color);
+  --info-bg: color-mix(in srgb, var(--info-color) 14%, transparent);
+  --warn-color: #d99a2b;
+  --warn-bg: color-mix(in srgb, var(--warn-color) 14%, transparent);
+  --danger-color: #d85d5d;
+  --danger-bg: color-mix(in srgb, var(--danger-color) 14%, transparent);
   position: relative;
   display: flex;
   align-items: center;
@@ -614,8 +623,8 @@ async function openDocs(): Promise<void> {
   position: absolute;
   inset: 0;
   overflow: hidden;
-  filter: blur(2px);
-  transform: scale(1.015);
+  filter: blur(1.5px) brightness(0.82);
+  transform: translateZ(0) scale(1.006);
   transform-origin: center;
   background:
     radial-gradient(circle at 50% 16%, color-mix(in srgb, var(--accent-color) 12%, transparent), transparent 28%),
@@ -691,8 +700,7 @@ async function openDocs(): Promise<void> {
   position: absolute;
   inset: 0;
   z-index: 1;
-  background: rgba(17, 24, 39, 0.25);
-  backdrop-filter: blur(5px);
+  background: rgba(17, 24, 39, 0.32);
 }
 
 /* ---- Dialog ---- */
@@ -1198,20 +1206,33 @@ async function openDocs(): Promise<void> {
 }
 
 .mini-progress {
+  --progress: 0;
   display: block;
+  position: relative;
   width: 62px;
   height: 4px;
   margin-top: 5px;
   overflow: hidden;
   border-radius: 999px;
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--info-color) 16%, var(--bg-secondary));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--info-color) 10%, transparent);
 }
 
 .mini-progress span {
   display: block;
+  width: 100%;
   height: 100%;
   border-radius: inherit;
-  background: var(--info-color);
+  background: linear-gradient(
+    90deg,
+    var(--info-color),
+    color-mix(in srgb, var(--info-color) 70%, var(--accent-text))
+  );
+  box-shadow: 0 0 10px color-mix(in srgb, var(--info-color) 34%, transparent);
+  transform: scaleX(var(--progress, 0));
+  transform-origin: left center;
+  transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
 }
 
 .row-error-msg {


### PR DESCRIPTION
## Summary
- Port Resource Manager onto the Electron desktop bridge instead of the legacy FastAPI server.
- Add shared resource contracts, Electron resource IPC handlers, preload bridge APIs, and a desktop ResourceManagerService.
- Wire the renderer Resource Manager page, store, PDK sync, route, and home entry to the desktop resource API.

## Tests
- pnpm --filter @ecos-studio/desktop-electron run typecheck
- pnpm --filter @ecos-studio/renderer run typecheck
- pnpm --filter @ecos-studio/desktop-electron exec vitest run electron/main/registerIpc.test.ts electron/services/resourceManagerService.test.ts
- pnpm --filter @ecos-studio/renderer exec vitest run src/api/plugin.test.ts src/stores/pluginStore.test.ts src/views/pluginToolsRows.test.ts src/views/PluginToolsView.layout.test.ts src/composables/usePdkManager.test.ts src/composables/useDesktopRuntime.test.ts src/composables/useVersion.test.ts

## Notes
- This PR is based on ekko/feat-desktop-cli-bridge so it stays aligned with the no-server desktop runtime work.
- No ecos/server or build graph files are changed.