### PR TITLE
feat(gui): add resource path inject

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/main/index.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/index.ts
@@ -95,13 +95,19 @@ function getDesktopServices() {
     projectScopeProvider: projectScopeService,
   })
   const resourceManagerService = new ResourceManagerService()
+  const runtimeEnvProvider = () =>
+    resourceManagerService.createRuntimeEnv(runtimeEnv, {
+      platform: process.platform,
+    })
   const desktopRuntimeManager = new DesktopRuntimeManager({
     adapter: new EccCliAdapter({
       env: runtimeEnv,
+      envProvider: runtimeEnvProvider,
     }),
   })
   const shellService = new ShellPtyService({
     env: runtimeEnv,
+    envProvider: runtimeEnvProvider,
   })
   const tileService = new TileService({
     projectRootProvider: projectScopeService,

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.test.ts
@@ -59,6 +59,14 @@ function complete(
   child.emit('close', exitCode, null)
 }
 
+async function waitForSpawn(harness: ReturnType<typeof createSpawnHarness>, index: number): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if (harness.children[index]) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error(`Timed out waiting for spawn ${index}`)
+}
+
 describe('EccCliAdapter', () => {
   const tempDirs: string[] = []
 
@@ -184,6 +192,105 @@ describe('EccCliAdapter', () => {
       'load_workspace',
       'success',
       expect.any(Number),
+    )
+  })
+
+  it('resolves envProvider for each spawned command and uses it for logging and spawn env', async () => {
+    const firstTempDir = createTempDir()
+    const secondTempDir = createTempDir()
+    const firstBin = join(firstTempDir, 'bin')
+    const secondBin = join(secondTempDir, 'bin')
+    mkdirSync(firstBin, { recursive: true })
+    mkdirSync(secondBin, { recursive: true })
+    writeFileSync(join(firstBin, 'ecc'), '#!/usr/bin/env bash\n')
+    writeFileSync(join(secondBin, 'ecc'), '#!/usr/bin/env bash\n')
+    chmodSync(join(firstBin, 'ecc'), 0o755)
+    chmodSync(join(secondBin, 'ecc'), 0o755)
+
+    const loggerDebug = vi.spyOn(electronLogger, 'debug').mockImplementation(() => undefined)
+    const harness = createSpawnHarness()
+    const envProvider = vi.fn()
+      .mockResolvedValueOnce({ PATH: `${firstBin}:/usr/bin`, ECOS_DYNAMIC: 'first' })
+      .mockResolvedValueOnce({ PATH: `${secondBin}:/usr/bin`, ECOS_DYNAMIC: 'second' })
+    const adapter = new EccCliAdapter({
+      env: { PATH: '/static/bin:/usr/bin', ECOS_STATIC: 'yes' },
+      envProvider,
+      spawn: harness.spawn,
+    })
+
+    const firstPromise = adapter.execute(request('load_workspace', {
+      directory: '/work/one',
+    }), { emit: vi.fn() })
+    await waitForSpawn(harness, 0)
+    complete(harness.children[0], {
+      cmd: 'load_workspace',
+      data: { directory: '/work/one' },
+      message: ['loaded'],
+      response: 'success',
+    })
+    await firstPromise
+
+    const secondPromise = adapter.execute(request('load_workspace', {
+      directory: '/work/two',
+    }), { emit: vi.fn() })
+    await waitForSpawn(harness, 1)
+    complete(harness.children[1], {
+      cmd: 'load_workspace',
+      data: { directory: '/work/two' },
+      message: ['loaded'],
+      response: 'success',
+    })
+    await secondPromise
+
+    expect(envProvider).toHaveBeenCalledTimes(2)
+    expect(harness.calls[0].options.env).toMatchObject({ ECOS_DYNAMIC: 'first' })
+    expect(harness.calls[1].options.env).toMatchObject({ ECOS_DYNAMIC: 'second' })
+    expect(loggerDebug).toHaveBeenCalledWith(
+      '[ECC CLI] spawn command=%s resolved=%s args=%s pathHead=%s',
+      'ecc',
+      join(firstBin, 'ecc'),
+      'workspace load --directory /work/one --json',
+      `${firstBin}:/usr/bin`,
+    )
+    expect(loggerDebug).toHaveBeenCalledWith(
+      '[ECC CLI] spawn command=%s resolved=%s args=%s pathHead=%s',
+      'ecc',
+      join(secondBin, 'ecc'),
+      'workspace load --directory /work/two --json',
+      `${secondBin}:/usr/bin`,
+    )
+  })
+
+  it('falls back to static env when envProvider fails', async () => {
+    const harness = createSpawnHarness()
+    const loggerDebug = vi.spyOn(electronLogger, 'debug').mockImplementation(() => undefined)
+    const adapter = new EccCliAdapter({
+      env: { PATH: '/static/bin:/usr/bin', ECOS_STATIC: 'yes' },
+      envProvider: vi.fn(async () => {
+        throw new Error('manifest unavailable')
+      }),
+      spawn: harness.spawn,
+    })
+
+    const loadPromise = adapter.execute(request('load_workspace', {
+      directory: '/work/demo',
+    }), { emit: vi.fn() })
+    await waitForSpawn(harness, 0)
+
+    expect(harness.calls[0].options.env).toMatchObject({
+      PATH: '/static/bin:/usr/bin',
+      ECOS_STATIC: 'yes',
+    })
+    complete(harness.children[0], {
+      cmd: 'load_workspace',
+      data: { directory: '/work/demo' },
+      message: ['loaded'],
+      response: 'success',
+    })
+    await expect(loadPromise).resolves.toMatchObject({ ok: true })
+    expect(loggerDebug).toHaveBeenCalledWith(
+      '[ECC CLI] env provider failed: %s',
+      'manifest unavailable',
     )
   })
 

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.ts
@@ -13,10 +13,12 @@ import type { DesktopRuntimeAdapterContext } from './desktopRuntimeManager'
 import { electronLogger } from './logger'
 
 type SpawnLike = typeof spawnChild
+type RuntimeEnvProvider = () => Promise<NodeJS.ProcessEnv> | NodeJS.ProcessEnv
 
 export interface EccCliAdapterOptions {
   command?: string
   env?: NodeJS.ProcessEnv
+  envProvider?: RuntimeEnvProvider
   spawn?: SpawnLike
   tempDir?: string
 }
@@ -206,7 +208,8 @@ function resolveCommandFromPath(command: string, env: NodeJS.ProcessEnv): string
 
 export class EccCliAdapter {
   private readonly command: string
-  private env: NodeJS.ProcessEnv
+  private readonly env: NodeJS.ProcessEnv
+  private readonly envProvider?: RuntimeEnvProvider
   private readonly spawnImpl: SpawnLike
   private readonly tempDir: string
   private activeWorkspace: string | null = null
@@ -214,6 +217,7 @@ export class EccCliAdapter {
   constructor(options: EccCliAdapterOptions = {}) {
     this.command = options.command ?? 'ecc'
     this.env = { ...(options.env ?? process.env) }
+    this.envProvider = options.envProvider
     this.spawnImpl = options.spawn ?? spawnChild
     this.tempDir = options.tempDir ?? tmpdir()
   }
@@ -341,6 +345,8 @@ export class EccCliAdapter {
     prepared: PreparedCommand,
     context: DesktopRuntimeAdapterContext,
   ): Promise<DesktopCliCommandResult> {
+    const env = this.envProvider ? await this.resolveProvidedEnv() : this.env
+
     return await new Promise((resolve) => {
       let finalResult: DesktopCliCommandResult | null = null
       let stdoutBuffer = ''
@@ -351,13 +357,13 @@ export class EccCliAdapter {
       electronLogger.debug(
         '[ECC CLI] spawn command=%s resolved=%s args=%s pathHead=%s',
         this.command,
-        resolveCommandFromPath(this.command, this.env),
+        resolveCommandFromPath(this.command, env),
         prepared.args.join(' '),
-        pathHeadForEnv(this.env),
+        pathHeadForEnv(env),
       )
 
       const child = this.spawnImpl(this.command, prepared.args, {
-        env: this.env,
+        env,
         stdio: ['ignore', 'pipe', 'pipe'],
       })
 
@@ -495,6 +501,18 @@ export class EccCliAdapter {
         resolve(result)
       })
     })
+  }
+
+  private async resolveProvidedEnv(): Promise<NodeJS.ProcessEnv> {
+    try {
+      return await this.envProvider?.() ?? this.env
+    } catch (error) {
+      electronLogger.debug(
+        '[ECC CLI] env provider failed: %s',
+        error instanceof Error ? error.message : String(error),
+      )
+      return this.env
+    }
   }
 
 }

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -165,6 +165,139 @@ describe('ResourceManagerService', () => {
     ]))
   })
 
+  it('builds a runtime env from active healthy Resource Manager resources', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const resourcesDir = join(root, 'state', 'resources')
+    const toolsDir = join(root, 'data', 'tools')
+    const pdksDir = join(root, 'data', 'pdks')
+    const packagedBin = join(root, 'packaged', 'binaries')
+    const yosysRoot = join(toolsDir, 'yosys', '2026-05-13')
+    const duplicateRoot = join(toolsDir, 'duplicate', '1.0')
+    const inactiveRoot = join(toolsDir, 'inactive', '1.0')
+    const missingRoot = join(toolsDir, 'missing', '1.0')
+    const ics55Root = join(pdksDir, 'ics55', '1.10.100')
+    await mkdir(join(yosysRoot, 'bin'), { recursive: true })
+    await mkdir(join(duplicateRoot, 'bin'), { recursive: true })
+    await mkdir(join(inactiveRoot, 'bin'), { recursive: true })
+    await mkdir(ics55Root, { recursive: true })
+    await mkdir(resourcesDir, { recursive: true })
+    await writeFile(join(yosysRoot, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await writeFile(join(duplicateRoot, 'bin', 'duplicate'), '#!/bin/sh\n', 'utf8')
+    await writeFile(join(inactiveRoot, 'bin', 'inactive'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(yosysRoot, 'bin', 'yosys'), 0o755)
+    await chmod(join(duplicateRoot, 'bin', 'duplicate'), 0o755)
+    await chmod(join(inactiveRoot, 'bin', 'inactive'), 0o755)
+    await writeFile(join(resourcesDir, 'manifest.json'), JSON.stringify({
+      schema_version: 1,
+      installed: {
+        'tool:yosys': {
+          type: 'tool',
+          name: 'yosys',
+          version: '2026-05-13',
+          path: yosysRoot,
+          executable: 'bin/yosys',
+          active: true,
+          managed: true,
+        },
+        'tool:duplicate': {
+          type: 'tool',
+          name: 'duplicate',
+          version: '1.0',
+          path: duplicateRoot,
+          executable: 'bin/duplicate',
+          active: true,
+          managed: true,
+        },
+        'tool:inactive': {
+          type: 'tool',
+          name: 'inactive',
+          version: '1.0',
+          path: inactiveRoot,
+          executable: 'bin/inactive',
+          active: false,
+          managed: true,
+        },
+        'tool:missing': {
+          type: 'tool',
+          name: 'missing',
+          version: '1.0',
+          path: missingRoot,
+          executable: 'bin/missing',
+          active: true,
+          managed: true,
+        },
+        'pdk:ics55': {
+          type: 'pdk',
+          id: 'ics55',
+          name: 'ICsprout 55nm',
+          pdk_id: 'ics55',
+          version: '1.10.100',
+          path: ics55Root,
+          canonical_path: ics55Root,
+          active: true,
+          managed: true,
+          health: 'ok',
+        },
+      },
+    }), 'utf8')
+    const service = new ResourceManagerService({
+      resourcesDir,
+      toolsDir,
+      pdksDir,
+    })
+    const baseEnv = {
+      PATH: [
+        packagedBin,
+        join(duplicateRoot, 'bin'),
+        '/usr/bin',
+        join(yosysRoot, 'bin'),
+      ].join(':'),
+      ECOS_ELECTRON_OSS_CAD_DIR: '/packaged/oss-cad-suite',
+      KEEP_ME: 'yes',
+    }
+
+    const env = await service.createRuntimeEnv(baseEnv, { platform: 'linux' })
+
+    expect(baseEnv.PATH).toBe([
+      packagedBin,
+      join(duplicateRoot, 'bin'),
+      '/usr/bin',
+      join(yosysRoot, 'bin'),
+    ].join(':'))
+    expect(env).not.toBe(baseEnv)
+    expect(env.PATH?.split(':')).toEqual([
+      packagedBin,
+      join(yosysRoot, 'bin'),
+      join(duplicateRoot, 'bin'),
+      '/usr/bin',
+    ])
+    expect(env.CHIPCOMPILER_OSS_CAD_DIR).toBe(yosysRoot)
+    expect(env.ECOS_ELECTRON_OSS_CAD_DIR).toBe(yosysRoot)
+    expect(env.CHIPCOMPILER_ICS55_PDK_ROOT).toBe(ics55Root)
+    expect(env.ICS55_PDK_ROOT).toBe(ics55Root)
+    expect(env.KEEP_ME).toBe('yes')
+    expect(env.PATH).not.toContain(join(inactiveRoot, 'bin'))
+    expect(env.PATH).not.toContain(join(missingRoot, 'bin'))
+  })
+
+  it('returns a copied base env when no Resource Manager manifest exists', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const service = new ResourceManagerService({
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+    })
+    const baseEnv = {
+      PATH: '/usr/bin',
+      ECOS_ELECTRON_OSS_CAD_DIR: '/packaged/oss-cad-suite',
+    }
+
+    const env = await service.createRuntimeEnv(baseEnv, { platform: 'linux' })
+
+    expect(env).toEqual(baseEnv)
+    expect(env).not.toBe(baseEnv)
+  })
+
   it('installs a managed tool and emits progress without using the legacy server', async () => {
     const root = await createTempDir('ecos-resources-')
     const archive = await createFixtureArchive(root)

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { createReadStream } from 'node:fs'
+import { constants, createReadStream } from 'node:fs'
 import { access, copyFile, mkdir, open, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { spawn } from 'node:child_process'
 import { electronLogger } from './logger'
@@ -153,6 +153,10 @@ export interface ResourceManagerServiceOptions {
   toolsDir?: string
 }
 
+export interface RuntimeEnvOptions {
+  platform: NodeJS.Platform
+}
+
 export class ResourceManagerService {
   private readonly archiveExtractor: ArchiveExtractor
   private readonly cacheDir: string
@@ -217,6 +221,65 @@ export class ResourceManagerService {
       throw new Error(`Resource '${resourceId}' not found`)
     }
     return resource
+  }
+
+  async createRuntimeEnv(
+    baseEnv: NodeJS.ProcessEnv,
+    options: RuntimeEnvOptions,
+  ): Promise<NodeJS.ProcessEnv> {
+    const env = { ...baseEnv }
+    const manifest = await this.readRuntimeManifest()
+    const toolBinDirs: string[] = []
+    let activeYosysRoot: string | null = null
+
+    for (const entry of Object.values(manifest.installed)) {
+      if (!isToolEntry(entry) || !entry.active) continue
+
+      const executablePath = join(entry.path, entry.executable)
+      if (!await isUsableExecutable(executablePath, options.platform)) {
+        electronLogger.debug(
+          '[resources] Skipping runtime tool %s: executable is missing or not executable at %s',
+          entry.name,
+          executablePath,
+        )
+        continue
+      }
+
+      toolBinDirs.push(dirname(executablePath))
+      if (entry.name === 'yosys') {
+        activeYosysRoot = entry.path
+      }
+    }
+
+    if (toolBinDirs.length > 0) {
+      const pathKey = pathKeyForRuntimeEnv(env)
+      env[pathKey] = mergeRuntimePath(env[pathKey] ?? '', toolBinDirs, options.platform)
+    }
+
+    if (activeYosysRoot) {
+      env.CHIPCOMPILER_OSS_CAD_DIR = activeYosysRoot
+      env.ECOS_ELECTRON_OSS_CAD_DIR = activeYosysRoot
+    }
+
+    for (const entry of Object.values(manifest.installed)) {
+      if (!isPdkEntry(entry) || !entry.active || entry.health !== 'ok') continue
+      if (!await isExistingDirectory(entry.canonical_path)) {
+        electronLogger.debug(
+          '[resources] Skipping runtime PDK %s: canonical path is missing at %s',
+          entry.id,
+          entry.canonical_path,
+        )
+        continue
+      }
+
+      const pdkId = (entry.pdk_id || entry.id).toUpperCase().replace(/[^A-Z0-9]/g, '_')
+      env[`CHIPCOMPILER_${pdkId}_PDK_ROOT`] = entry.canonical_path
+      if (pdkId === 'ICS55') {
+        env.ICS55_PDK_ROOT = entry.canonical_path
+      }
+    }
+
+    return env
   }
 
   async installResource(
@@ -807,6 +870,20 @@ export class ResourceManagerService {
     }
   }
 
+  private async readRuntimeManifest(): Promise<ResourceManifest> {
+    try {
+      return parseManifest(JSON.parse(await readFile(this.manifestPath, 'utf8')), this.resourcesDir, this.toolsDir, this.pdksDir)
+    } catch (error) {
+      if (!isFileNotFoundError(error)) {
+        electronLogger.debug(
+          '[resources] Failed to read runtime manifest: %s',
+          error instanceof Error ? error.message : String(error),
+        )
+      }
+      return this.emptyManifest()
+    }
+  }
+
   private async writeManifest(manifest: ResourceManifest): Promise<void> {
     manifest.resources_dir = this.resourcesDir
     manifest.tools_dir = this.toolsDir
@@ -1227,6 +1304,66 @@ function readNumber(value: unknown): number {
 
 function readStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.map((item) => String(item)) : []
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code?: unknown }).code === 'ENOENT'
+}
+
+function pathKeyForRuntimeEnv(env: NodeJS.ProcessEnv): string {
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
+}
+
+function runtimePathSeparator(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? ';' : ':'
+}
+
+function splitRuntimePath(value: string, platform: NodeJS.Platform): string[] {
+  return value.split(runtimePathSeparator(platform)).filter(Boolean)
+}
+
+function mergeRuntimePath(
+  basePath: string,
+  resourceManagerDirs: string[],
+  platform: NodeJS.Platform,
+): string {
+  const baseEntries = splitRuntimePath(basePath, platform)
+  const packagedBin = baseEntries[0] && basename(baseEntries[0]).toLowerCase() === 'binaries'
+    ? baseEntries[0]
+    : null
+  const orderedEntries = [
+    ...(packagedBin ? [packagedBin] : []),
+    ...resourceManagerDirs,
+    ...baseEntries.filter((entry) => entry !== packagedBin),
+  ]
+  const seen = new Set<string>()
+  return orderedEntries
+    .filter((entry) => {
+      if (seen.has(entry)) return false
+      seen.add(entry)
+      return true
+    })
+    .join(runtimePathSeparator(platform))
+}
+
+async function isUsableExecutable(path: string, platform: NodeJS.Platform): Promise<boolean> {
+  try {
+    await access(path, platform === 'win32' ? constants.F_OK : constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function isExistingDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory()
+  } catch {
+    return false
+  }
 }
 
 async function readRegistryFromUrl(url: string, fetchImpl: typeof fetch): Promise<ResourceRegistry> {

--- a/ecos/gui/apps/desktop-electron/electron/services/shellPtyService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/shellPtyService.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { electronLogger } from './logger'
 import { ShellPtyService } from './shellPtyService'
 
 interface FakePtyEventDisposable {
@@ -123,6 +124,96 @@ describe('ShellPtyService', () => {
         PROMPT_COMMAND: 'history -a',
       }),
     }))
+  })
+
+  it('resolves envProvider for each new session and uses it for shell, cwd, and spawn env', async () => {
+    const firstPty = new FakePty()
+    const secondPty = new FakePty()
+    const ptyBackend = {
+      spawn: vi.fn()
+        .mockReturnValueOnce(firstPty)
+        .mockReturnValueOnce(secondPty),
+    }
+    const envProvider = vi.fn()
+      .mockResolvedValueOnce({
+        HOME: '/home/first',
+        PATH: '/dynamic/first/bin',
+        SHELL: '/bin/zsh',
+      })
+      .mockResolvedValueOnce({
+        HOME: '/home/second',
+        PATH: '/dynamic/second/bin',
+        SHELL: '/bin/fish',
+      })
+    const service = new ShellPtyService({
+      env: {
+        HOME: '/home/static',
+        PATH: '/static/bin',
+        SHELL: '/bin/bash',
+      },
+      envProvider,
+      platform: 'linux',
+      ptyBackend,
+    })
+
+    const firstSession = await service.createSession({ cols: 80, rows: 24 }, vi.fn())
+    const secondSession = await service.createSession({ cols: 100, rows: 30 }, vi.fn())
+
+    expect(envProvider).toHaveBeenCalledTimes(2)
+    expect(firstSession.shell).toBe('/bin/zsh')
+    expect(secondSession.shell).toBe('/bin/fish')
+    expect(ptyBackend.spawn).toHaveBeenNthCalledWith(1, '/bin/zsh', [], expect.objectContaining({
+      cwd: '/home/first',
+      env: expect.objectContaining({
+        HOME: '/home/first',
+        PATH: '/dynamic/first/bin',
+        TERM: 'xterm-256color',
+      }),
+    }))
+    expect(ptyBackend.spawn).toHaveBeenNthCalledWith(2, '/bin/fish', [], expect.objectContaining({
+      cwd: '/home/second',
+      env: expect.objectContaining({
+        HOME: '/home/second',
+        PATH: '/dynamic/second/bin',
+        TERM: 'xterm-256color',
+      }),
+    }))
+  })
+
+  it('falls back to static env when envProvider fails', async () => {
+    const fakePty = new FakePty()
+    const ptyBackend = {
+      spawn: vi.fn(() => fakePty),
+    }
+    const loggerDebug = vi.spyOn(electronLogger, 'debug').mockImplementation(() => undefined)
+    const service = new ShellPtyService({
+      env: {
+        HOME: '/home/static',
+        PATH: '/static/bin',
+        SHELL: '/bin/bash',
+      },
+      envProvider: vi.fn(async () => {
+        throw new Error('manifest unavailable')
+      }),
+      platform: 'linux',
+      ptyBackend,
+    })
+
+    const session = await service.createSession({ cols: 80, rows: 24 }, vi.fn())
+
+    expect(session.shell).toBe('/bin/bash')
+    expect(ptyBackend.spawn).toHaveBeenCalledWith('/bin/bash', [], expect.objectContaining({
+      cwd: '/home/static',
+      env: expect.objectContaining({
+        HOME: '/home/static',
+        PATH: '/static/bin',
+        TERM: 'xterm-256color',
+      }),
+    }))
+    expect(loggerDebug).toHaveBeenCalledWith(
+      '[shell] env provider failed: %s',
+      'manifest unavailable',
+    )
   })
 
   it('rejects operations for unknown or exited sessions', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/services/shellPtyService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/shellPtyService.ts
@@ -7,8 +7,10 @@ import type {
   DesktopShellSessionOptions,
 } from '@ecos-studio/shared'
 import { spawn as spawnPty } from 'node-pty'
+import { electronLogger } from './logger'
 
 type ShellPlatform = NodeJS.Platform | 'linux' | 'darwin' | 'win32'
+type RuntimeEnvProvider = () => Promise<NodeJS.ProcessEnv> | NodeJS.ProcessEnv
 
 interface PtyEventDisposable {
   dispose(): void
@@ -43,6 +45,7 @@ export type ShellPtyEventListener = (
 
 export interface ShellPtyServiceOptions {
   env?: NodeJS.ProcessEnv
+  envProvider?: RuntimeEnvProvider
   platform?: ShellPlatform
   ptyBackend?: PtyBackend
 }
@@ -75,12 +78,14 @@ function normalizePositiveInteger(value: number, fallback: number): number {
 
 export class ShellPtyService {
   private readonly env: NodeJS.ProcessEnv
+  private readonly envProvider?: RuntimeEnvProvider
   private readonly platform: ShellPlatform
   private readonly ptyBackend: PtyBackend
   private readonly sessions = new Map<string, ShellSessionRecord>()
 
   constructor(options: ShellPtyServiceOptions = {}) {
     this.env = options.env ?? process.env
+    this.envProvider = options.envProvider
     this.platform = options.platform ?? process.platform
     this.ptyBackend = options.ptyBackend ?? { spawn: spawnPty }
   }
@@ -89,14 +94,15 @@ export class ShellPtyService {
     options: DesktopShellSessionOptions,
     listener: ShellPtyEventListener,
   ): Promise<DesktopShellSession> {
+    const env = await this.resolveEnv()
     const sessionId = randomUUID()
-    const shell = getDefaultShell(this.platform, this.env)
-    const cwd = options.cwd || getDefaultCwd(this.env)
+    const shell = getDefaultShell(this.platform, env)
+    const cwd = options.cwd || getDefaultCwd(env)
     const pty = this.ptyBackend.spawn(shell, [], {
       cols: normalizePositiveInteger(options.cols, 80),
       cwd,
       env: {
-        ...this.env,
+        ...env,
         TERM: 'xterm-256color',
       },
       name: 'xterm-256color',
@@ -157,5 +163,21 @@ export class ShellPtyService {
     }
 
     return session
+  }
+
+  private async resolveEnv(): Promise<NodeJS.ProcessEnv> {
+    if (!this.envProvider) {
+      return this.env
+    }
+
+    try {
+      return await this.envProvider()
+    } catch (error) {
+      electronLogger.debug(
+        '[shell] env provider failed: %s',
+        error instanceof Error ? error.message : String(error),
+      )
+      return this.env
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add ResourceManagerService runtime env construction from active Resource Manager tools and PDKs
- Inject dynamic runtime env into ECC CLI commands and new integrated terminal sessions
- Preserve packaged `binaries/` precedence while allowing active Resource Manager tools like `yosys` to override host PATH tools
- Add focused coverage for runtime env merging, env provider fallback, CLI spawn env, and PTY session env

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [x] `cd ecos/gui && pnpm run build`
- [x] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [x] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
