### PR TITLE
feat(gui): sync workspace config and rerun artifacts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,8 +15,8 @@ git_override(
 # Pin the ECC CLI bundle input used by the Bazel release build.
 git_override(
     module_name = "ecc",
-    # workspace config sync and rerun artifact preparation companion PR
-    commit = "125e39c6559b4440d79505a3685b6b04a28519f9",
+    # workspace config sync and rerun artifact preparation
+    commit = "a853a1d213ee5eef18b5f8357f456ee1ff98d46d",
     init_submodules = True,
     remote = "https://github.com/openecos-projects/ecc.git",
 )
@@ -40,4 +40,3 @@ git_override(
 
 appimage_tool = use_extension("@ecos-bazel//rules:appimage-tool.bzl", "appimage_tool")
 use_repo(appimage_tool, "appimagetool_x86_64_linux")
-

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,8 +15,8 @@ git_override(
 # Pin the ECC CLI bundle input used by the Bazel release build.
 git_override(
     module_name = "ecc",
-    # v0.1.0-alpha.3-unstable-e2515dc
-    commit = "e2515dc1a97035c1221e3b954b3c66d38162a1a0",
+    # workspace config sync and rerun artifact preparation companion PR
+    commit = "125e39c6559b4440d79505a3685b6b04a28519f9",
     init_submodules = True,
     remote = "https://github.com/openecos-projects/ecc.git",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -166,7 +166,7 @@
   "moduleExtensions": {
     "@@buildifier_prebuilt+//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "RLgcFR7CQZcdQY0jjtq8gpqxhHTnuZL3H7smk0RNeyI=",
+        "bzlTransitiveDigest": "AiLhk8M3bYsCKureJxwsWsnViRPlVmt1v8pnOgBAUzw=",
         "usagesDigest": "m+RORtK3MOrJs2auGj/7mY7N11R7swVsHYHg1jls5hs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -521,7 +521,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "nvW/NrBXlAmiQw99EMGKkLaD2KbNp2mQDlxdfpr+0Ls=",
+        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -585,7 +585,7 @@
     },
     "@@rules_multitool+//multitool:extension.bzl%multitool": {
       "general": {
-        "bzlTransitiveDigest": "4sgFCqOYi5PKLD3JgbkSx9RNVoOeRM4EFrTJ16K/9iU=",
+        "bzlTransitiveDigest": "OmyUzwsloBp1uNITj7Bu1ytDkaGAuF0eMC4A0GZV/Kg=",
         "usagesDigest": "c47utchW8VdALOFAlCLb+lFsZsKF1XENuPRrctwHOfo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -681,7 +681,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "9cZw51LLMu2V/jKcxvnA1pBg58ZgQEDuMni3CbNZSRg=",
+        "bzlTransitiveDigest": "W97kKxM+lW7l/kO0rQa7Jm31CA1j+W1bNHGKjwX5xMg=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -916,7 +916,7 @@
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
+        "bzlTransitiveDigest": "zyNsrbgVKwpA0B3zI84imAfuC424VSzYNPgjr/HJy5M=",
         "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/ecos/gui/apps/desktop-electron/electron/main/index.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/index.ts
@@ -88,9 +88,6 @@ function getDesktopServices() {
     appVersionProvider: () => app.getVersion(),
     env: runtimeEnv,
   })
-  const workspaceService = new WorkspaceService({
-    projectScopeProvider: projectScopeService,
-  })
   const workspaceResourceService = new WorkspaceResourceService({
     projectScopeProvider: projectScopeService,
   })
@@ -104,6 +101,10 @@ function getDesktopServices() {
       env: runtimeEnv,
       envProvider: runtimeEnvProvider,
     }),
+  })
+  const workspaceService = new WorkspaceService({
+    projectScopeProvider: projectScopeService,
+    runtimeMutationGuard: desktopRuntimeManager,
   })
   const shellService = new ShellPtyService({
     env: runtimeEnv,

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts
@@ -91,6 +91,36 @@ describe('DesktopRuntimeManager', () => {
     expect(new Set(jobIds).size).toBe(1)
   })
 
+  it('includes request data on started events so renderers can react to rerun startup', async () => {
+    const listener = vi.fn()
+    const manager = createManager({
+      adapter: {
+        execute: vi.fn(async () => result({
+          cmd: 'rtl2gds',
+          data: { rerun: true },
+          message: ['ok'],
+        })),
+      },
+    })
+
+    await manager.execute({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo', rerun: true },
+      source: 'button',
+    }, listener)
+
+    expect(listener).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      cmd: 'rtl2gds',
+      data: expect.objectContaining({
+        directory: '/work/demo',
+        rerun: true,
+      }),
+      directory: '/work/demo',
+      stream: 'system',
+      type: 'started',
+    }))
+  })
+
   it('lets adapters emit normalized stdout and stderr events for the active job', async () => {
     const listener = vi.fn()
     const manager = createManager({

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts
@@ -269,6 +269,97 @@ describe('DesktopRuntimeManager', () => {
     }
   })
 
+  it('reports workspace runtime activity while a long-running command holds the lock', async () => {
+    const runtimeLockRoot = await mkdtemp(path.join(tmpdir(), 'ecos-runtime-lock-test-'))
+    try {
+      let release!: () => void
+      const adapterExecute = vi.fn((request) => new Promise<DesktopCliCommandResult>((resolve) => {
+        release = () => resolve(result({
+          cmd: request.cmd,
+          message: ['done'],
+        }))
+      }))
+      const manager = createManager({
+        adapter: { execute: adapterExecute },
+        runtimeLockRoot,
+      })
+      const observer = createManager({
+        adapter: { execute: vi.fn() },
+        runtimeLockRoot,
+      })
+
+      const running = manager.execute({
+        cmd: 'rtl2gds',
+        data: { directory: '/work/demo', rerun: false },
+        source: 'button',
+      })
+
+      await vi.waitFor(() => {
+        expect(adapterExecute).toHaveBeenCalledTimes(1)
+      })
+
+      await expect(manager.isWorkspaceRuntimeActive('/work/demo')).resolves.toBe(true)
+      await expect(observer.isWorkspaceRuntimeActive('/work/demo')).resolves.toBe(true)
+
+      release()
+      await expect(running).resolves.toMatchObject({ ok: true })
+      await expect(manager.isWorkspaceRuntimeActive('/work/demo')).resolves.toBe(false)
+    } finally {
+      await rm(runtimeLockRoot, { force: true, recursive: true })
+    }
+  })
+
+  it('blocks config refresh and sync while the same workspace runtime is active', async () => {
+    let release!: () => void
+    const adapterExecute = vi.fn((request) => new Promise<DesktopCliCommandResult>((resolve) => {
+      release = () => resolve(result({
+        cmd: request.cmd,
+        message: ['done'],
+      }))
+    }))
+    const manager = createManager({
+      adapter: {
+        execute: adapterExecute,
+      },
+    })
+
+    const running = manager.execute({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo', rerun: false },
+      source: 'button',
+    })
+
+    await vi.waitFor(() => {
+      expect(adapterExecute).toHaveBeenCalledTimes(1)
+    })
+
+    await expect(manager.execute({
+      cmd: 'refresh_config',
+      data: { directory: '/work/demo' },
+      source: 'button',
+    })).resolves.toMatchObject({
+      cmd: 'refresh_config',
+      ok: false,
+      response: 'warning',
+    })
+    await expect(manager.execute({
+      cmd: 'sync_config',
+      data: {
+        config_path: '/work/demo/config/rt_default_config.json',
+        directory: '/work/demo',
+      },
+      source: 'button',
+    })).resolves.toMatchObject({
+      cmd: 'sync_config',
+      ok: false,
+      response: 'warning',
+    })
+    expect(adapterExecute).toHaveBeenCalledTimes(1)
+
+    release()
+    await expect(running).resolves.toMatchObject({ ok: true })
+  })
+
   it('emits workspace metadata on long-running command lifecycle events', async () => {
     const listener = vi.fn()
     const manager = createManager({

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
@@ -306,6 +306,7 @@ export class DesktopRuntimeManager {
 
     this.emit({
       cmd: request.cmd,
+      data: { ...request.data },
       jobId,
       ...eventWorkspace,
       stream: 'system',

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
@@ -45,6 +45,8 @@ const longRunningCommands = new Set<DesktopCliCommandName>([
   'load_workspace',
   'run_step',
   'rtl2gds',
+  'refresh_config',
+  'sync_config',
 ])
 
 function isSupportedCommand(cmd: string): cmd is DesktopCliCommandName {
@@ -195,6 +197,24 @@ export class DesktopRuntimeManager {
     return () => {
       this.listeners.delete(listener)
     }
+  }
+
+  async isWorkspaceRuntimeActive(directory: string): Promise<boolean> {
+    const scope = normalizeDirectoryScope(directory)
+    if (!scope) return false
+
+    if (this.activeLongRunningJobsByScope.has(scope)) return true
+
+    const lockDirectory = path.join(this.runtimeLockRoot, `${runtimeLockName(scope)}.lock`)
+    const owner = await readRuntimeLockOwner(lockDirectory)
+    if (!owner) return false
+
+    if (!isProcessAlive(owner.pid)) {
+      await rm(lockDirectory, { force: true, recursive: true })
+      return false
+    }
+
+    return true
   }
 
   private emit(event: DesktopCliCommandEvent, listener?: DesktopRuntimeEventListener): void {

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
@@ -36,6 +36,8 @@ const supportedCommands = new Set<DesktopCliCommandName>([
   'rtl2gds',
   'get_info',
   'home_page',
+  'refresh_config',
+  'sync_config',
 ])
 
 const longRunningCommands = new Set<DesktopCliCommandName>([

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.test.ts
@@ -382,6 +382,57 @@ describe('EccCliAdapter', () => {
       cmd: 'home_page',
       ok: true,
     })
+
+    const refreshPromise = adapter.execute(request('refresh_config'), { emit: vi.fn() })
+    expect(harness.calls[4]?.args).toEqual([
+      'workspace',
+      'refresh-config',
+      '--directory',
+      '/work/loaded',
+      '--json',
+    ])
+    complete(harness.children[4], {
+      cmd: 'refresh_config',
+      data: { directory: '/work/loaded', refreshed: true },
+      message: ['refreshed'],
+      response: 'success',
+    })
+    await expect(refreshPromise).resolves.toMatchObject({
+      cmd: 'refresh_config',
+      ok: true,
+    })
+
+    const syncPromise = adapter.execute(request('sync_config', {
+      config_path: '/work/loaded/config/rt_default_config.json',
+    }), { emit: vi.fn() })
+    expect(harness.calls[5]?.args).toEqual([
+      'workspace',
+      'sync-config',
+      '--directory',
+      '/work/loaded',
+      '--config-path',
+      '/work/loaded/config/rt_default_config.json',
+      '--json',
+    ])
+    complete(harness.children[5], {
+      cmd: 'sync_config',
+      data: {
+        config_path: '/work/loaded/config/rt_default_config.json',
+        directory: '/work/loaded',
+        parameters_changed: true,
+        refreshed: true,
+      },
+      message: ['synced'],
+      response: 'success',
+    })
+    await expect(syncPromise).resolves.toMatchObject({
+      cmd: 'sync_config',
+      data: {
+        parameters_changed: true,
+        refreshed: true,
+      },
+      ok: true,
+    })
   })
 
   it('forwards stdout and stderr events while using JSON stdout as the final result', async () => {
@@ -501,6 +552,15 @@ describe('EccCliAdapter', () => {
       response: 'failed',
     })
     expect(harness.spawn).not.toHaveBeenCalled()
+
+    await expect(adapter.execute(request('sync_config', {
+      directory: '/work/demo',
+    }), { emit: vi.fn() })).resolves.toMatchObject({
+      cmd: 'sync_config',
+      message: ['missing required field: config_path'],
+      ok: false,
+      response: 'failed',
+    })
 
     const nonzero = adapter.execute(request('run_step', {
       directory: '/work/demo',

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.ts
@@ -164,6 +164,13 @@ function requiredString(
   return readString(request.data[field]).trim()
 }
 
+function configPathFromRequest(request: DesktopCliCommandRequest): string {
+  return (
+    readString(request.data.config_path).trim()
+    || readString(request.data.configPath).trim()
+  )
+}
+
 function isEnabled(value: unknown): boolean {
   return value === true || value === 'true' || value === 1 || value === '1'
 }
@@ -333,6 +340,30 @@ export class EccCliAdapter {
         if (!directory) return failed(request, 'missing required field: directory')
         return {
           args: ['workspace', 'get-home', '--directory', directory, '--json'],
+        }
+      }
+      case 'refresh_config': {
+        const directory = directoryFromRequest(request, this.activeWorkspace)
+        if (!directory) return failed(request, 'missing required field: directory')
+        return {
+          args: ['workspace', 'refresh-config', '--directory', directory, '--json'],
+        }
+      }
+      case 'sync_config': {
+        const directory = directoryFromRequest(request, this.activeWorkspace)
+        const configPath = configPathFromRequest(request)
+        if (!directory) return failed(request, 'missing required field: directory')
+        if (!configPath) return failed(request, 'missing required field: config_path')
+        return {
+          args: [
+            'workspace',
+            'sync-config',
+            '--directory',
+            directory,
+            '--config-path',
+            configPath,
+            '--json',
+          ],
         }
       }
       default:

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.test.ts
@@ -22,7 +22,7 @@ function createRepoFixture(): { appPath: string; repoRoot: string; userDataPath:
 }
 
 describe('createEccCliRuntimeEnv', () => {
-  it('leaves development env unchanged so global ecc from PATH is used', () => {
+  it('prepends the source-tree ECC venv in development mode when available', () => {
     const fixture = createRepoFixture()
     mkdirSync(join(fixture.repoRoot, 'ecc'), { recursive: true })
     const pyprojectPath = join(fixture.repoRoot, 'ecc', 'pyproject.toml')
@@ -48,7 +48,7 @@ describe('createEccCliRuntimeEnv', () => {
 
     expect(env).toEqual({
       HOME: '/home/ecos',
-      PATH: '/usr/bin',
+      PATH: `${venvBin}:/usr/bin`,
     })
     expect(existsSync(wrapperPath)).toBe(false)
   })

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliRuntime.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 type RuntimePlatform = NodeJS.Platform | 'linux' | 'darwin' | 'win32'
 
@@ -40,6 +40,29 @@ function resolvePackagedRuntimeBin(options: EccCliRuntimeEnvOptions): string | n
   return existsSync(join(binariesPath, executableName)) ? binariesPath : null
 }
 
+function findRepoRootFromAppPath(appPath: string): string | null {
+  let current = appPath
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(current, 'ecc', 'pyproject.toml'))) {
+      return current
+    }
+    const parent = dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  return null
+}
+
+function resolveDevelopmentRuntimeBin(options: EccCliRuntimeEnvOptions): string | null {
+  if (options.platform === 'win32') return null
+
+  const repoRoot = findRepoRootFromAppPath(options.appPath)
+  if (!repoRoot) return null
+
+  const venvBin = join(repoRoot, 'ecc', '.venv', 'bin')
+  return existsSync(join(venvBin, 'ecc')) ? venvBin : null
+}
+
 function resolvePackagedResourcesPath(options: EccCliRuntimeEnvOptions): string {
   return options.env.ECOS_ELECTRON_RESOURCES_PATH
     ?? join(options.appPath, 'resources')
@@ -70,6 +93,15 @@ export function createEccCliRuntimeEnv(
     }
 
     return { ...baseEnv }
+  }
+
+  const developmentRuntimeBin = resolveDevelopmentRuntimeBin(options)
+  if (developmentRuntimeBin) {
+    const nextPath = prependPath(options.env, developmentRuntimeBin, options.platform)
+    return {
+      ...options.env,
+      [nextPath.key]: nextPath.value,
+    }
   }
 
   return { ...options.env }

--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceService.test.ts
@@ -31,6 +31,9 @@ function createProjectScopeProvider(
 function createWorkspaceService(
   rootPath: string,
   canonicalPath: string,
+  options: {
+    runtimeMutationGuard?: ConstructorParameters<typeof WorkspaceService>[0]['runtimeMutationGuard']
+  } = {},
 ): {
   projectScopeProvider: ProjectScopeProviderDouble
   service: WorkspaceService
@@ -38,6 +41,7 @@ function createWorkspaceService(
   const projectScopeProvider = createProjectScopeProvider(rootPath, canonicalPath)
   const service = new WorkspaceService({
     projectScopeProvider,
+    ...options,
   })
 
   return {
@@ -223,6 +227,44 @@ describe('WorkspaceService', () => {
     expect(projectScopeProvider.requestProjectPathAccess).toHaveBeenCalledWith(
       '/workspace/home/parameters.json',
     )
+  })
+
+  it('blocks configuration writes while the workspace runtime is active', async () => {
+    const directory = await createTempDir('ecos-workspace-service-write-lock-')
+    const filePath = join(directory, 'home', 'parameters.json')
+    const runtimeMutationGuard = {
+      isWorkspaceRuntimeActive: vi.fn().mockReturnValue(true),
+    }
+
+    const { service } = createWorkspaceService(directory, filePath, {
+      runtimeMutationGuard,
+    })
+
+    await expect(
+      service.writeProjectTextFile('/workspace/home/parameters.json', '{"PDK":"ics55"}'),
+    ).rejects.toThrow('workspace flow is running')
+
+    await expect(readFile(filePath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(runtimeMutationGuard.isWorkspaceRuntimeActive).toHaveBeenCalledWith(directory)
+  })
+
+  it('blocks step config writes while the workspace runtime is active', async () => {
+    const directory = await createTempDir('ecos-workspace-service-step-config-lock-')
+    const filePath = join(directory, 'config', 'cts_default_config.json')
+    const runtimeMutationGuard = {
+      isWorkspaceRuntimeActive: vi.fn().mockReturnValue(true),
+    }
+
+    const { service } = createWorkspaceService(directory, filePath, {
+      runtimeMutationGuard,
+    })
+
+    await expect(
+      service.writeProjectTextFile('/workspace/config/cts_default_config.json', '{"skew_bound":0.1}'),
+    ).rejects.toThrow('workspace flow is running')
+
+    await expect(readFile(filePath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(runtimeMutationGuard.isWorkspaceRuntimeActive).toHaveBeenCalledWith(directory)
   })
 
   it('watches a project-scoped file through the validated canonical path', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceService.ts
@@ -21,9 +21,16 @@ export interface ProjectScopeProvider {
 
 export interface WorkspaceServiceOptions {
   projectScopeProvider: ProjectScopeProvider
+  runtimeMutationGuard?: RuntimeMutationGuard
+}
+
+export interface RuntimeMutationGuard {
+  isWorkspaceRuntimeActive(projectRoot: string): boolean | Promise<boolean>
 }
 
 const UTF8_MAX_BYTES_PER_CODE_UNIT = 4
+const WORKSPACE_RUNTIME_MUTATION_BLOCKED_MESSAGE =
+  'Cannot save workspace configuration while the workspace flow is running. Wait for it to finish before editing parameters or step config.'
 
 function boundedTextCharCount(maxChars: number): number {
   return Math.max(1, Math.min(Math.floor(maxChars), 2 * 1024 * 1024))
@@ -54,6 +61,18 @@ function isSameOrAncestorPath(path: string, descendantPath: string): boolean {
 
 function shouldIgnoreWatchPath(path: string, targetPath: string): boolean {
   return !isSameOrAncestorPath(path, targetPath)
+}
+
+function normalizeRelativePathForMatch(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
+function isRuntimeProtectedProjectPath(canonicalPath: string, projectRoot: string): boolean {
+  const relativePath = normalizeRelativePathForMatch(relative(projectRoot, canonicalPath))
+  return (
+    relativePath === 'home/parameters.json'
+    || (relativePath.startsWith('config/') && relativePath.endsWith('.json'))
+  )
 }
 
 async function findProjectFileWatchDirectory(
@@ -137,12 +156,14 @@ async function waitForWatcherReady(watcher: FSWatcher): Promise<void> {
 
 export class WorkspaceService {
   private readonly projectScopeProvider: ProjectScopeProvider
+  private readonly runtimeMutationGuard?: RuntimeMutationGuard
   private readonly logTailService: LogTailService
   private readonly projectFileWatchers = new Map<string, { close: () => Promise<void> }>()
   private nextProjectFileWatchId = 1
 
   constructor(options: WorkspaceServiceOptions) {
     this.projectScopeProvider = options.projectScopeProvider
+    this.runtimeMutationGuard = options.runtimeMutationGuard
     this.logTailService = new LogTailService({
       projectScopeProvider: this.projectScopeProvider,
       textReader: this,
@@ -293,6 +314,7 @@ export class WorkspaceService {
 
   async writeProjectTextFile(path: string, content: string): Promise<void> {
     const canonicalPath = await this.projectScopeProvider.requestProjectPathAccess(path)
+    await this.assertCanWriteProjectTextFile(canonicalPath)
     await writeFile(canonicalPath, content, 'utf8')
   }
 
@@ -400,5 +422,16 @@ export class WorkspaceService {
       }),
     )
     this.projectFileWatchers.clear()
+  }
+
+  private async assertCanWriteProjectTextFile(canonicalPath: string): Promise<void> {
+    if (!this.runtimeMutationGuard) return
+
+    const projectRoot = await this.projectScopeProvider.getProjectRoot()
+    if (!isRuntimeProtectedProjectPath(canonicalPath, projectRoot)) return
+
+    if (await this.runtimeMutationGuard.isWorkspaceRuntimeActive(projectRoot)) {
+      throw new Error(WORKSPACE_RUNTIME_MUTATION_BLOCKED_MESSAGE)
+    }
   }
 }

--- a/ecos/gui/apps/renderer/src/api/flow.desktop-ipc.test.ts
+++ b/ecos/gui/apps/renderer/src/api/flow.desktop-ipc.test.ts
@@ -47,7 +47,7 @@ describe('flow API desktop bridge payloads', () => {
       },
     })
 
-    const { getInfoApi, rtl2gdsApi, runStepApi } = await import('./flow')
+    const { getInfoApi, refreshConfigApi, rtl2gdsApi, runStepApi, syncConfigApi } = await import('./flow')
 
     await runStepApi(reactive({
       cmd: CMDEnum.run_step,
@@ -71,8 +71,21 @@ describe('flow API desktop bridge payloads', () => {
         step: StepEnum.ROUTING,
       },
     }))
+    await refreshConfigApi(reactive({
+      cmd: CMDEnum.refresh_config,
+      data: {
+        directory: '/work/demo',
+      },
+    }))
+    await syncConfigApi(reactive({
+      cmd: CMDEnum.sync_config,
+      data: {
+        config_path: '/work/demo/config/rt_default_config.json',
+        directory: '/work/demo',
+      },
+    }))
 
-    expect(execute).toHaveBeenCalledTimes(3)
+    expect(execute).toHaveBeenCalledTimes(5)
     expect(execute).toHaveBeenNthCalledWith(1, expect.objectContaining({
       cmd: 'run_step',
       data: {
@@ -93,6 +106,19 @@ describe('flow API desktop bridge payloads', () => {
       data: {
         id: InfoEnum.layout,
         step: StepEnum.ROUTING,
+      },
+    }))
+    expect(execute).toHaveBeenNthCalledWith(4, expect.objectContaining({
+      cmd: 'refresh_config',
+      data: {
+        directory: '/work/demo',
+      },
+    }))
+    expect(execute).toHaveBeenNthCalledWith(5, expect.objectContaining({
+      cmd: 'sync_config',
+      data: {
+        config_path: '/work/demo/config/rt_default_config.json',
+        directory: '/work/demo',
       },
     }))
   })

--- a/ecos/gui/apps/renderer/src/api/flow.ts
+++ b/ecos/gui/apps/renderer/src/api/flow.ts
@@ -59,6 +59,43 @@ export function runStepApi(request: RequestData<RunStepRequest>) {
   }) as unknown as Promise<ResponseData<RunStepResponse>>
 }
 
+export interface RefreshConfigRequest {
+  directory: string
+}
+
+export interface RefreshConfigResponse {
+  directory: string
+  refreshed: boolean
+}
+
+export function refreshConfigApi(request: RequestData<RefreshConfigRequest>) {
+  return getDesktopApi().cli.execute({
+    cmd: 'refresh_config',
+    data: toDesktopCliData(request.data as unknown as Record<string, unknown>),
+    source: 'button',
+  }) as unknown as Promise<ResponseData<RefreshConfigResponse>>
+}
+
+export interface SyncConfigRequest {
+  directory: string
+  config_path: string
+}
+
+export interface SyncConfigResponse {
+  directory: string
+  config_path: string
+  parameters_changed: boolean
+  refreshed: boolean
+}
+
+export function syncConfigApi(request: RequestData<SyncConfigRequest>) {
+  return getDesktopApi().cli.execute({
+    cmd: 'sync_config',
+    data: toDesktopCliData(request.data as unknown as Record<string, unknown>),
+    source: 'button',
+  }) as unknown as Promise<ResponseData<SyncConfigResponse>>
+}
+
 // ============ Home Page API ============
 
 export interface HomePageResponse {

--- a/ecos/gui/apps/renderer/src/api/runtimeEvents.desktop-cli.test.ts
+++ b/ecos/gui/apps/renderer/src/api/runtimeEvents.desktop-cli.test.ts
@@ -294,6 +294,50 @@ describe('createRuntimeEventClient desktop CLI events', () => {
     }))
   })
 
+  it('publishes rtl2gds started rerun request data as a lifecycle message', async () => {
+    const listeners: Array<(event: DesktopCliCommandEvent) => void> = []
+    setWindow({
+      ecosDesktop: {
+        cli: {
+          onEvent: (listener: (event: DesktopCliCommandEvent) => void) => {
+            listeners.push(listener)
+            return () => undefined
+          },
+        },
+      },
+    })
+
+    const { createRuntimeEventClient } = await import('./runtimeEvents')
+    const client = createRuntimeEventClient('/work/demo')
+    const allHandler = vi.fn()
+    client.onAll(allHandler)
+    client.connect()
+
+    listeners[0]({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo', rerun: true },
+      directory: '/work/demo',
+      jobId: 'job-flow',
+      stream: 'system',
+      text: 'Started rtl2gds',
+      type: 'started',
+      workspaceId: '/work/demo',
+    })
+
+    expect(allHandler).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        cmd: 'rtl2gds',
+        directory: '/work/demo',
+        jobId: 'job-flow',
+        rerun: true,
+        type: 'message',
+        workspaceId: '/work/demo',
+      }),
+      message: ['Started rtl2gds'],
+      response: 'success',
+    }))
+  })
+
   it('preserves structured lifecycle event data from the desktop bridge', async () => {
     const listeners: Array<(event: DesktopCliCommandEvent) => void> = []
     setWindow({

--- a/ecos/gui/apps/renderer/src/api/runtimeEvents.ts
+++ b/ecos/gui/apps/renderer/src/api/runtimeEvents.ts
@@ -130,6 +130,11 @@ export function createRuntimeEventClient(workspaceId: string, config: RuntimeEve
     if (id) data.id = id
     if (step) data.step = step
     if (event.stream) data.stream = event.stream
+    for (const [key, value] of Object.entries(event.data ?? {})) {
+      if (!(key in data)) {
+        data[key] = value
+      }
+    }
     for (const [key, value] of Object.entries(result?.data ?? {})) {
       if (!(key in data)) {
         data[key] = value

--- a/ecos/gui/apps/renderer/src/api/type.ts
+++ b/ecos/gui/apps/renderer/src/api/type.ts
@@ -4,7 +4,9 @@ export enum CMDEnum {
   rtl2gds = "rtl2gds",
   run_step = "run_step",
   get_info = "get_info",
-  home_page = "home_page"
+  home_page = "home_page",
+  refresh_config = "refresh_config",
+  sync_config = "sync_config"
 }
 
 // get_info command 的 id 枚举

--- a/ecos/gui/apps/renderer/src/components/LeftSidebar.vue
+++ b/ecos/gui/apps/renderer/src/components/LeftSidebar.vue
@@ -228,8 +228,8 @@
             <div class="mode-selector" @click.stop>
               <!-- 当前模式显示 + 触发器 -->
               <button class="mode-trigger" @click="showModeMenu = !showModeMenu" :disabled="flowRunControlBusy">
-                <i :class="runModes[runMode].icon" class="mode-trigger-icon"></i>
-                <span>{{ runModes[runMode].label }}</span>
+                <i :class="runModes[activeRunMode].icon" class="mode-trigger-icon"></i>
+                <span>{{ runModes[activeRunMode].label }}</span>
                 <i class="ri-arrow-down-s-line mode-chevron" :class="{ open: showModeMenu }"></i>
               </button>
 
@@ -237,7 +237,7 @@
               <Transition name="mode-menu">
                 <div v-if="showModeMenu" class="mode-menu">
                   <button v-for="(mode, key) in runModes" :key="key" class="mode-menu-item"
-                    :class="{ active: runMode === key }" @click="runMode = key as string; showModeMenu = false">
+                    :class="{ active: activeRunMode === key }" @click="selectRunMode(key); showModeMenu = false">
                     <i :class="mode.icon" class="mode-item-icon"></i>
                     <span class="mode-item-label">{{ mode.label }}</span>
                     <span v-if="mode.shortcut" class="mode-item-shortcut">{{ mode.shortcut }}</span>
@@ -385,11 +385,29 @@
         <!-- 底部操作栏 -->
         <div class="p-3 border-t border-(--border-color) bg-(--bg-secondary)/30 space-y-2">
           <!-- 操作按钮组 -->
-          <div class="flex gap-2">
-            <button @click="handleRunFlow" :disabled="flowRunControlBusy"
-              class="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-(--accent-color) text-white text-[11px] font-bold rounded hover:brightness-110 active:scale-[0.98] transition-all disabled:opacity-50 shadow-lg shadow-(--accent-color)/20">
-              <i :class="flowRunControlBusy ? 'ri-loader-4-line animate-spin' : 'ri-play-fill'"></i>
-              {{ flowRunControlBusy ? 'RUNNING' : 'RUN' }}
+          <div class="step-run-control">
+            <div class="mode-selector" @click.stop>
+              <button class="mode-trigger" @click="showModeMenu = !showModeMenu" :disabled="flowRunControlBusy">
+                <i :class="runModes[activeRunMode].icon" class="mode-trigger-icon"></i>
+                <span>{{ runModes[activeRunMode].label }}</span>
+                <i class="ri-arrow-down-s-line mode-chevron" :class="{ open: showModeMenu }"></i>
+              </button>
+
+              <Transition name="mode-menu">
+                <div v-if="showModeMenu" class="mode-menu">
+                  <button v-for="(mode, key) in runModes" :key="key" class="mode-menu-item"
+                    :class="{ active: activeRunMode === key }" @click="selectRunMode(key); showModeMenu = false">
+                    <i :class="mode.icon" class="mode-item-icon"></i>
+                    <span class="mode-item-label">{{ mode.label }}</span>
+                    <span v-if="mode.shortcut" class="mode-item-shortcut">{{ mode.shortcut }}</span>
+                  </button>
+                </div>
+              </Transition>
+            </div>
+
+            <button @click="handleRunFlow" :disabled="flowRunControlBusy" class="run-go-btn"
+              :class="{ running: flowRunControlBusy }">
+              <i :class="flowRunControlBusy ? 'ri-loader-4-line animate-spin' : runModes[activeRunMode].icon"></i>
             </button>
           </div>
         </div>
@@ -403,6 +421,7 @@ import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { useFlowStages } from '@/composables/useFlowStages'
 import { useSubflow } from '@/composables/useSubflow'
 import { useFlowRunner } from '@/composables/useFlowRunner'
+import { useFlowRunMode } from '@/composables/useFlowRunMode'
 import { useCurrentStage } from '@/composables/useCurrentStage'
 import { useWorkspace } from '@/composables/useWorkspace'
 
@@ -445,6 +464,13 @@ const {
 // 当前阶段
 const { currentStage, showProgressPanel, showOverviewPanel, showSubflowPanel } = useCurrentStage()
 
+const {
+  activeRunMode,
+  isRerun,
+  runModes,
+  selectRunMode,
+} = useFlowRunMode(currentStage)
+
 // ============ Flow 概览计算 ============
 // 只统计 run 组的步骤
 const runStages = computed(() => flowStages.value.filter(s => s.group === 'run'))
@@ -478,13 +504,7 @@ const flowRunControlBusy = computed(() => isRunning.value || hasOngoingRunStage.
 
 
 // ============ 运行模式 ============
-const runMode = ref('run')
 const showModeMenu = ref(false)
-
-const runModes: Record<string, { label: string; icon: string; shortcut?: string }> = {
-  run: { label: 'Run RTL2GDS', icon: 'ri-play-fill' },
-  rerun: { label: 'ReRun', icon: 'ri-restart-line' },
-}
 
 // 点击外部关闭菜单
 const closeMenu = () => { showModeMenu.value = false }
@@ -505,11 +525,11 @@ const handleRunFlow = async () => {
 
   if (currentStage.value === 'home') {
     setFirstRunStepOngoing()
-    await runAllFlow()
+    await runAllFlow({ rerun: isRerun.value })
     await refreshFlowStages()
   } else {
     setRunStepOngoingByPath(currentStage.value)
-    await runFlow()
+    await runFlow({ rerun: isRerun.value })
     await Promise.all([
       refreshCurrentSubflow(),
       refreshFlowStages()
@@ -543,6 +563,12 @@ const handleRunFlow = async () => {
   align-items: center;
   gap: 6px;
   padding: 6px 8px;
+}
+
+.step-run-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 /* 状态指示灯 */

--- a/ecos/gui/apps/renderer/src/components/StepConfigPanel.vue
+++ b/ecos/gui/apps/renderer/src/components/StepConfigPanel.vue
@@ -73,13 +73,13 @@
                   Reload
                 </button>
                 <button type="button" class="btn-text"
-                  :disabled="!hasStepConfigChanges || loading || !!stepConfigReadError"
+                  :disabled="!hasStepConfigChanges || loading || !!stepConfigReadError || isMutationLocked"
                   @click="resetStepConfig">
                   <i class="ri-arrow-go-back-line"></i>
                   Reset
                 </button>
                 <button type="button" class="btn-primary"
-                  :disabled="!hasStepConfigChanges || isSavingStepConfig || !!stepConfigReadError"
+                  :disabled="!hasStepConfigChanges || isSavingStepConfig || !!stepConfigReadError || isMutationLocked"
                   @click="onSaveStepConfig">
                   <i :class="isSavingStepConfig ? 'ri-loader-4-line spin' : 'ri-save-line'"></i>
                   {{ isSavingStepConfig ? 'Saving…' : 'Save' }}
@@ -140,6 +140,7 @@ const {
   hasStepConfigChanges,
   isSavingStepConfig,
   stepConfigSaveError,
+  isMutationLocked,
   saveStepConfig,
   resetStepConfig,
   reloadStepConfigFiles,

--- a/ecos/gui/apps/renderer/src/composables/homeRunArtifacts.ts
+++ b/ecos/gui/apps/renderer/src/composables/homeRunArtifacts.ts
@@ -1,0 +1,58 @@
+type HomeRunArtifactResetListener = (projectPath: string) => void
+
+const resetListeners = new Set<HomeRunArtifactResetListener>()
+const pendingResetProjectPaths = new Set<string>()
+const awaitingBackendStartProjectPaths = new Set<string>()
+
+function normalizeProjectPath(path: string): string {
+  const normalized = path.trim().replace(/\\/g, '/')
+  return normalized.length > 1 && normalized.endsWith('/')
+    ? normalized.slice(0, -1)
+    : normalized
+}
+
+export function requestHomeRunArtifactReset(projectPath: string): void {
+  const normalizedProjectPath = normalizeProjectPath(projectPath)
+  if (!normalizedProjectPath) return
+  awaitingBackendStartProjectPaths.delete(normalizedProjectPath)
+  pendingResetProjectPaths.add(normalizedProjectPath)
+  for (const listener of resetListeners) {
+    listener(normalizedProjectPath)
+  }
+}
+
+export function markHomeRunArtifactResetAwaitingBackendStart(projectPath: string): void {
+  const normalizedProjectPath = normalizeProjectPath(projectPath)
+  if (!normalizedProjectPath) return
+  awaitingBackendStartProjectPaths.add(normalizedProjectPath)
+}
+
+export function clearHomeRunArtifactResetAwaitingBackendStart(projectPath: string): void {
+  const normalizedProjectPath = normalizeProjectPath(projectPath)
+  if (!normalizedProjectPath) return
+  awaitingBackendStartProjectPaths.delete(normalizedProjectPath)
+}
+
+export function isHomeRunArtifactResetAwaitingBackendStart(projectPath: string): boolean {
+  const normalizedProjectPath = normalizeProjectPath(projectPath)
+  return awaitingBackendStartProjectPaths.has(normalizedProjectPath)
+}
+
+export function isHomeRunArtifactResetPending(projectPath: string): boolean {
+  const normalizedProjectPath = normalizeProjectPath(projectPath)
+  return pendingResetProjectPaths.has(normalizedProjectPath)
+}
+
+export function onHomeRunArtifactReset(listener: HomeRunArtifactResetListener): () => void {
+  resetListeners.add(listener)
+  return () => {
+    resetListeners.delete(listener)
+  }
+}
+
+export function consumePendingHomeRunArtifactReset(projectPath: string): boolean {
+  const normalizedProjectPath = normalizeProjectPath(projectPath)
+  if (!pendingResetProjectPaths.has(normalizedProjectPath)) return false
+  pendingResetProjectPaths.delete(normalizedProjectPath)
+  return true
+}

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunMode.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunMode.test.ts
@@ -1,0 +1,28 @@
+import { ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { useFlowRunMode } from './useFlowRunMode'
+
+describe('useFlowRunMode', () => {
+  it('keeps full-flow and single-step run modes independent', () => {
+    const currentStage = ref('home')
+    const { activeRunMode, isRerun, runModes, selectRunMode } = useFlowRunMode(currentStage)
+
+    expect(activeRunMode.value).toBe('run')
+    expect(runModes.value.run.label).toBe('Run RTL2GDS')
+    expect(runModes.value.rerun.label).toBe('ReRun RTL2GDS')
+
+    selectRunMode('rerun')
+    expect(activeRunMode.value).toBe('rerun')
+    expect(isRerun.value).toBe(true)
+
+    currentStage.value = 'Floorplan'
+    expect(activeRunMode.value).toBe('run')
+    expect(runModes.value.run.label).toBe('Run Step')
+    expect(runModes.value.rerun.label).toBe('ReRun Step')
+    expect(isRerun.value).toBe(false)
+
+    selectRunMode('rerun')
+    currentStage.value = 'home'
+    expect(activeRunMode.value).toBe('rerun')
+  })
+})

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunMode.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunMode.ts
@@ -1,0 +1,55 @@
+import { computed, ref, type Ref } from 'vue'
+
+export type FlowRunModeKey = 'run' | 'rerun'
+
+export interface FlowRunModeOption {
+  label: string
+  icon: string
+  shortcut?: string
+}
+
+function isHomeStage(stage: string | undefined | null): boolean {
+  return stage === 'home'
+}
+
+export function useFlowRunMode(currentStage: Ref<string | undefined | null>) {
+  const fullFlowRunMode = ref<FlowRunModeKey>('run')
+  const stepRunMode = ref<FlowRunModeKey>('run')
+
+  const isFullFlowContext = computed(() => isHomeStage(currentStage.value))
+
+  const activeRunMode = computed({
+    get: () => isFullFlowContext.value ? fullFlowRunMode.value : stepRunMode.value,
+    set: (mode: FlowRunModeKey) => {
+      if (isFullFlowContext.value) {
+        fullFlowRunMode.value = mode
+      } else {
+        stepRunMode.value = mode
+      }
+    },
+  })
+
+  const runModes = computed<Record<FlowRunModeKey, FlowRunModeOption>>(() => {
+    const target = isFullFlowContext.value ? 'RTL2GDS' : 'Step'
+
+    return {
+      run: { label: `Run ${target}`, icon: 'ri-play-fill' },
+      rerun: { label: `ReRun ${target}`, icon: 'ri-restart-line' },
+    }
+  })
+
+  const isRerun = computed(() => activeRunMode.value === 'rerun')
+
+  function selectRunMode(mode: string): void {
+    if (mode === 'run' || mode === 'rerun') {
+      activeRunMode.value = mode
+    }
+  }
+
+  return {
+    activeRunMode,
+    isRerun,
+    runModes,
+    selectRunMode,
+  }
+}

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunner.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunner.test.ts
@@ -11,6 +11,9 @@ const {
   runStepApi,
   rtl2gdsApi,
   currentProject,
+  requestHomeRunArtifactReset,
+  markHomeRunArtifactResetAwaitingBackendStart,
+  clearHomeRunArtifactResetAwaitingBackendStart,
 } = vi.hoisted(() => ({
   ensureDesktopRuntime: vi.fn(() => false),
   ensureApiReady: vi.fn(() => Promise.resolve(true)),
@@ -37,6 +40,9 @@ const {
   runStepApi: vi.fn(),
   rtl2gdsApi: vi.fn(),
   currentProject: { value: null as { path: string } | null },
+  requestHomeRunArtifactReset: vi.fn(),
+  markHomeRunArtifactResetAwaitingBackendStart: vi.fn(),
+  clearHomeRunArtifactResetAwaitingBackendStart: vi.fn(),
 }))
 
 vi.mock('vue-router', () => ({
@@ -70,6 +76,12 @@ vi.mock('@/api/flow', () => ({
   rtl2gdsApi,
 }))
 
+vi.mock('./homeRunArtifacts', () => ({
+  requestHomeRunArtifactReset,
+  markHomeRunArtifactResetAwaitingBackendStart,
+  clearHomeRunArtifactResetAwaitingBackendStart,
+}))
+
 import {
   clearFlowExecutionActiveForWorkspace,
   flowExecutionActive,
@@ -101,6 +113,9 @@ describe('useFlowRunner desktop-only guard', () => {
     }
     runStepApi.mockReset()
     rtl2gdsApi.mockReset()
+    requestHomeRunArtifactReset.mockReset()
+    markHomeRunArtifactResetAwaitingBackendStart.mockReset()
+    clearHomeRunArtifactResetAwaitingBackendStart.mockReset()
     flowExecutionActive.value = false
     currentProject.value = null
   })
@@ -161,6 +176,29 @@ describe('useFlowRunner desktop-only guard', () => {
         rerun: false,
       },
     })
+    expect(requestHomeRunArtifactReset).not.toHaveBeenCalled()
+  })
+
+  it('passes rerun=true to the full flow API when requested', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    rtl2gdsApi.mockResolvedValue({
+      response: 'success',
+      data: { rerun: true },
+      message: ['done'],
+    })
+
+    const { runAllFlow } = useFlowRunner()
+
+    await expect(runAllFlow({ rerun: true })).resolves.toEqual({ rerun: true })
+    expect(requestHomeRunArtifactReset).not.toHaveBeenCalled()
+    expect(rtl2gdsApi).toHaveBeenCalledWith({
+      cmd: 'rtl2gds',
+      data: {
+        directory: '/work/demo',
+        rerun: true,
+      },
+    })
   })
 
   it('does not mark the full flow running when the runtime bridge is unavailable', async () => {
@@ -194,6 +232,30 @@ describe('useFlowRunner desktop-only guard', () => {
       data: {
         directory: '/work/demo',
         rerun: false,
+        step: StepEnum.FLOORPLAN,
+      },
+    })
+  })
+
+  it('passes rerun=true to the single step API when requested', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    runStepApi.mockResolvedValue({
+      data: { state: StateEnum.Success, step: StepEnum.FLOORPLAN },
+      message: ['done'],
+      response: 'success',
+    })
+
+    const { runFlow } = useFlowRunner()
+
+    await runFlow({ rerun: true })
+
+    expect(requestHomeRunArtifactReset).not.toHaveBeenCalled()
+    expect(runStepApi).toHaveBeenCalledWith({
+      cmd: 'run_step',
+      data: {
+        directory: '/work/demo',
+        rerun: true,
         step: StepEnum.FLOORPLAN,
       },
     })

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunner.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunner.ts
@@ -5,6 +5,10 @@ import { useWorkspace } from './useWorkspace'
 import { CMDEnum, StateEnum, StepEnum } from '@/api/type'
 import { runStepApi, rtl2gdsApi, type RunStepResponse } from '@/api/flow'
 import type { WorkspaceInvalidationScope } from './useWorkspaceLifecycle'
+import {
+  clearHomeRunArtifactResetAwaitingBackendStart,
+  markHomeRunArtifactResetAwaitingBackendStart,
+} from './homeRunArtifacts'
 
 // ============ 模块级运行标志（run_step / rtl2gds 共用）============
 
@@ -12,6 +16,10 @@ import type { WorkspaceInvalidationScope } from './useWorkspaceLifecycle'
 export const flowExecutionActive = ref(false)
 const activeFlowWorkspaces = shallowReactive(new Set<string>())
 const RUN_STEP_FALLBACK_SCOPES: WorkspaceInvalidationScope[] = ['home', 'parameters']
+
+export interface FlowRunOptions {
+  rerun?: boolean
+}
 
 function normalizeWorkspacePath(path: string): string {
   const normalized = path.trim().replace(/\\/g, '/')
@@ -111,7 +119,7 @@ export function useFlowRunner() {
   /**
    * 运行当前步骤
    */
-  async function runFlow(): Promise<RunStepResponse | null> {
+  async function runFlow(options: FlowRunOptions = {}): Promise<RunStepResponse | null> {
     // 从动态路由参数获取当前步骤
     const step = getCurrentStep()
 
@@ -160,7 +168,7 @@ export function useFlowRunner() {
         data: {
           directory,
           step: step as StepEnum,
-          rerun: false
+          rerun: Boolean(options.rerun)
         }
       })
       console.log('run step result', result)
@@ -211,7 +219,7 @@ export function useFlowRunner() {
    * 执行过程中，Electron runtime 转发 CLI lifecycle events，
    * 前端通过 useWorkspace 中已建立的 runtime event 连接实时接收。
    */
-  async function runAllFlow(): Promise<any | null> {
+  async function runAllFlow(options: FlowRunOptions = {}): Promise<any | null> {
     // 检查是否在 desktop runtime 环境中
     if (!ensureDesktopRuntime()) {
       console.warn('Not running in desktop runtime environment, cannot execute ECC CLI flow command')
@@ -239,6 +247,9 @@ export function useFlowRunner() {
     }
 
     clearTransientInteractionLocks()
+    if (options.rerun) {
+      markHomeRunArtifactResetAwaitingBackendStart(directory)
+    }
     markFlowExecutionActiveForWorkspace(directory)
     state.value = StateEnum.Ongoing
     error.value = null
@@ -250,7 +261,7 @@ export function useFlowRunner() {
         cmd: CMDEnum.rtl2gds,
         data: {
           directory,
-          rerun: false
+          rerun: Boolean(options.rerun)
         }
       })
       console.log('rtl2gds result:', result)
@@ -287,6 +298,7 @@ export function useFlowRunner() {
       })
     } finally {
       clearTransientInteractionLocks()
+      clearHomeRunArtifactResetAwaitingBackendStart(directory)
       clearFlowExecutionActiveForWorkspace(directory)
     }
     return null

--- a/ecos/gui/apps/renderer/src/composables/useFlowStages.live-watch.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowStages.live-watch.test.ts
@@ -243,4 +243,101 @@ describe('useFlowStages live project file watchers', () => {
 
     expect(flowWatch!.unwatch).toHaveBeenCalledTimes(1)
   })
+
+  it('resets run stage states when a full-flow rerun reset is requested for the current workspace', async () => {
+    const { useFlowStages } = await importFreshFlowStagesModule()
+    await startLifecycleSession('/workspace/a')
+    testState.readProjectTextFile.mockResolvedValue(flowJsonFor({
+      Synthesis: 'Success',
+      Floorplan: 'Ongoing',
+    }))
+
+    const flow = useFlowStages()
+
+    await vi.waitFor(() => {
+      expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+        'Success',
+        'Ongoing',
+      ])
+    })
+
+    ;(await import('./homeRunArtifacts')).requestHomeRunArtifactReset('/workspace/a')
+    await nextTick()
+    ;(await import('./homeRunArtifacts')).consumePendingHomeRunArtifactReset('/workspace/a')
+
+    expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+      'Unstart',
+      'Unstart',
+    ])
+  })
+
+  it('does not reload a stale completed flow snapshot after a rerun reset until flow.json starts changing', async () => {
+    const { useFlowStages } = await importFreshFlowStagesModule()
+    await startLifecycleSession('/workspace/a')
+    let states = {
+      Synthesis: 'Success',
+      Floorplan: 'Success',
+    }
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path === '/workspace/a/home/flow.json') return flowJsonFor(states)
+      return '{}'
+    })
+
+    const flow = useFlowStages()
+
+    await vi.waitFor(() => {
+      expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+        'Success',
+        'Success',
+      ])
+    })
+
+    ;(await import('./homeRunArtifacts')).requestHomeRunArtifactReset('/workspace/a')
+    await nextTick()
+    ;(await import('./homeRunArtifacts')).consumePendingHomeRunArtifactReset('/workspace/a')
+
+    expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+      'Unstart',
+      'Unstart',
+    ])
+
+    await flow.loadFlowStages()
+
+    expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+      'Unstart',
+      'Unstart',
+    ])
+
+    testState.resourceVersions!.value = {
+      ...testState.resourceVersions!.value,
+      flow: testState.resourceVersions!.value.flow + 1,
+    }
+    await nextTick()
+
+    expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+      'Unstart',
+      'Unstart',
+    ])
+
+    states = {
+      Synthesis: 'Ongoing',
+      Floorplan: 'Unstart',
+    }
+    const flowWatch = testState.projectFileWatchers.find((entry) =>
+      entry.path === '/workspace/a/home/flow.json'
+    )
+    expect(flowWatch).toBeDefined()
+    flowWatch!.listener({
+      subscriptionId: 'flow-watch-1',
+      path: '/workspace/a/home/flow.json',
+      eventType: 'change',
+    })
+
+    await vi.waitFor(() => {
+      expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+        'Ongoing',
+        'Unstart',
+      ])
+    })
+  })
 })

--- a/ecos/gui/apps/renderer/src/composables/useFlowStages.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowStages.ts
@@ -7,6 +7,11 @@ import { readProjectTextFile, watchProjectFile } from '@/utils/projectFiles'
 import { resolveProjectPathAccess } from '@/utils/projectFs'
 import { readWorkspaceFlowResourceApi, readWorkspaceHomeResourceApi } from '@/api/workspaceResources'
 import { useWorkspaceLifecycle } from './useWorkspaceLifecycle'
+import {
+  consumePendingHomeRunArtifactReset,
+  isHomeRunArtifactResetPending,
+  onHomeRunArtifactReset,
+} from './homeRunArtifacts'
 
 // ============ 类型定义 ============
 
@@ -97,6 +102,16 @@ function fallbackRunStepKeys(): string[] {
     .map((m) => m.path)
 }
 
+function flowDataHasStartedRun(flowData: FlowData): boolean {
+  return flowData.steps.some((step) => {
+    const state = (step.state ?? '').trim().toLowerCase()
+    return state === 'ongoing'
+      || state === 'running'
+      || state === 'unstart'
+      || state === 'pending'
+  })
+}
+
 // ============ Composable ============
 
 /**
@@ -114,6 +129,8 @@ export function useFlowStages() {
   const error = ref<string | null>(null)
   let unwatchFlowJsonFile: (() => void) | null = null
   let unregisterFlowJsonLifecycleCleanup: (() => void) | null = null
+  let unregisterHomeRunArtifactReset: (() => void) | null = null
+  let pendingRerunFlowStartProjectPath = ''
   let watchSession = 0
 
   // 合并后的完整流程步骤
@@ -162,6 +179,7 @@ export function useFlowStages() {
       )
       if (!isCurrent() || fileContent === undefined) return
       const flowData: FlowData = JSON.parse(fileContent)
+      if (!shouldApplyFlowData(flowData)) return
 
       console.log('Loaded flow data from path:', flowData)
 
@@ -206,6 +224,7 @@ export function useFlowStages() {
         dynamicFlowStages.value = []
         return
       }
+      if (!shouldApplyFlowData(flowData)) return
 
       console.log('Loaded flow data:', flowData)
 
@@ -229,6 +248,36 @@ export function useFlowStages() {
     unregisterFlowJsonLifecycleCleanup = null
     unwatchFlowJsonFile?.()
     unwatchFlowJsonFile = null
+  }
+
+  function normalizeProjectPath(path: string): string {
+    const normalized = path.trim().replace(/\\/g, '/')
+    return normalized.length > 1 && normalized.endsWith('/')
+      ? normalized.slice(0, -1)
+      : normalized
+  }
+
+  function resetRunStagesForRerun(): void {
+    if (dynamicFlowStages.value.length === 0) return
+    dynamicFlowStages.value = dynamicFlowStages.value.map((stage) => ({
+      ...stage,
+      state: 'Unstart',
+      runtime: '',
+      'peak memory (mb)': 0,
+    }))
+  }
+
+  function shouldApplyFlowData(flowData: FlowData): boolean {
+    const projectPath = currentProject.value?.path
+    if (!projectPath) return true
+    const normalizedProjectPath = normalizeProjectPath(projectPath)
+    const resetPending = pendingRerunFlowStartProjectPath === normalizedProjectPath
+      || isHomeRunArtifactResetPending(projectPath)
+    if (!resetPending) return true
+    if (!flowDataHasStartedRun(flowData)) return false
+    pendingRerunFlowStartProjectPath = ''
+    consumePendingHomeRunArtifactReset(projectPath)
+    return true
   }
 
   async function startFlowJsonWatchForCurrentProject(): Promise<void> {
@@ -348,10 +397,25 @@ export function useFlowStages() {
     },
   )
 
+  unregisterHomeRunArtifactReset = onHomeRunArtifactReset((projectPath) => {
+    const currentProjectPath = currentProject.value?.path
+    if (
+      !currentProjectPath
+      || normalizeProjectPath(projectPath) !== normalizeProjectPath(currentProjectPath)
+    ) {
+      return
+    }
+
+    pendingRerunFlowStartProjectPath = normalizeProjectPath(currentProjectPath)
+    resetRunStagesForRerun()
+  })
+
   if (getCurrentInstance()) {
     onUnmounted(() => {
       watchSession++
       cleanupFlowJsonWatch()
+      unregisterHomeRunArtifactReset?.()
+      unregisterHomeRunArtifactReset = null
     })
   }
 

--- a/ecos/gui/apps/renderer/src/composables/useHomeData.live-watch.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useHomeData.live-watch.test.ts
@@ -87,6 +87,9 @@ vi.mock('./useFlowRunner', () => ({
   },
   flowExecutionActive: testState.flowExecutionActive,
   isFlowExecutionActiveForWorkspace: () => testState.flowExecutionActive?.value ?? false,
+  markFlowExecutionActiveForWorkspace: () => {
+    if (testState.flowExecutionActive) testState.flowExecutionActive.value = true
+  },
 }))
 
 vi.mock('@/api/workspaceResources', () => ({
@@ -129,6 +132,18 @@ function flowJsonFor(stepName: string) {
         name: stepName,
         tool: 'yosys',
         state: 'Ongoing',
+      },
+    ],
+  })
+}
+
+function flowJsonWithState(stepName: string, state: string) {
+  return JSON.stringify({
+    steps: [
+      {
+        name: stepName,
+        tool: 'yosys',
+        state,
       },
     ],
   })
@@ -301,6 +316,10 @@ describe('useHomeData live project file watchers', () => {
   })
 
   afterEach(() => {
+    for (const callback of testState.unmountCallbacks.splice(0)) {
+      callback()
+    }
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -911,6 +930,59 @@ describe('useHomeData live project file watchers', () => {
     secondScope.stop()
   })
 
+  it('clears stale Home artifacts on remount when a full-flow rerun reset was requested while unmounted', async () => {
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-old.png`,
+          metrics: {
+            'old chart': `${projectPath}/home/old-chart.png`,
+          },
+          monitor: {
+            step: ['Filler'],
+            frequency: [814.33],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Filler', 'Success')
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    const { requestHomeRunArtifactReset } = await import('./homeRunArtifacts')
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const firstScope = effectScope()
+    const firstHome = firstScope.run(() => useHomeData())!
+    await vi.waitFor(() => {
+      expect(firstHome.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+    expect(firstHome.analysisCharts.value).toEqual([
+      { label: 'old chart', imageBlobUrl: 'blob:/workspace/a/home/old-chart.png' },
+    ])
+
+    firstScope.stop()
+    for (const callback of testState.unmountCallbacks.splice(0)) {
+      callback()
+    }
+
+    requestHomeRunArtifactReset('/workspace/a')
+
+    const secondScope = effectScope()
+    const remountedHome = secondScope.run(() => useHomeData())!
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(remountedHome.layoutBlobUrl.value).toBe('')
+    expect(remountedHome.analysisCharts.value).toEqual([])
+    expect(remountedHome.monitorData.value).toBeNull()
+
+    secondScope.stop()
+  })
+
   it('keeps the newest same-session home refresh when an older resource-version reload resolves last', async () => {
     let version = 1
     const delayedReads: Array<{
@@ -995,6 +1067,976 @@ describe('useHomeData live project file watchers', () => {
     expect(home.monitorData.value).toEqual({
       step: ['Synthesis'],
       frequency: [3],
+    })
+  })
+
+  it('clears stale Home run artifacts when a full-flow rerun has started', async () => {
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-old.png`,
+          metrics: {
+            'instances dist.': `${projectPath}/home/instances-old.png`,
+          },
+          monitor: {
+            step: ['Synthesis'],
+            frequency: [50],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonFor('Synthesis')
+      if (path === '/workspace/a/home/checklist.json') {
+        return JSON.stringify({
+          checklist: [
+            {
+              step: 'Floorplan',
+              type: 'Area',
+              item: 'check DIE area',
+              state: 'Accepted',
+            },
+          ],
+        })
+      }
+      if (path === '/workspace/a/Synthesis_yosys/log/Synthesis.log') return 'old synthesis log'
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'instances dist.', imageBlobUrl: 'blob:/workspace/a/home/instances-old.png' },
+    ])
+    expect(home.monitorData.value).toEqual({
+      step: ['Synthesis'],
+      frequency: [50],
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+    expect(home.analysisCharts.value).toEqual([])
+    expect(home.monitorData.value).toBeNull()
+    expect(home.checklistItems.value).toEqual([])
+    expect(home.flowLogSegments.value).toEqual([])
+    expect(home.flowLogContentByKey.value).toEqual({})
+  })
+
+  it('ignores stale Home reads that were already in flight when full-flow rerun starts', async () => {
+    const delayedHomeReads: Array<(content: string) => void> = []
+    let homeMode: 'empty' | 'delayed-old' = 'empty'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        if (homeMode === 'delayed-old') {
+          return await new Promise<string>((resolve) => {
+            delayedHomeReads.push(resolve)
+          })
+        }
+        return JSON.stringify(homeDataFor(projectPath))
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', 'Ongoing')
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+
+    homeMode = 'delayed-old'
+    testState.resourceVersions!.value = {
+      ...testState.resourceVersions!.value,
+      home: testState.resourceVersions!.value.home + 1,
+    }
+    await vi.waitFor(() => {
+      expect(delayedHomeReads.length).toBeGreaterThan(0)
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+
+    delayedHomeReads[0]!(JSON.stringify({
+      ...homeDataFor('/workspace/a'),
+      layout: '/workspace/a/home/layout-old.png',
+      metrics: {
+        'old chart': '/workspace/a/home/old-chart.png',
+      },
+      monitor: {
+        step: ['Filler'],
+        frequency: [814.33],
+      },
+    }))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(home.layoutBlobUrl.value).toBe('')
+    expect(home.analysisCharts.value).toEqual([])
+    expect(home.monitorData.value).toBeNull()
+  })
+
+  it('restarts live log watching when rerun starts after seeing old completed flow state', async () => {
+    let flowState = 'Success'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        return JSON.stringify(homeDataFor(projectPath))
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', flowState)
+      if (path === '/workspace/a/Synthesis_yosys/log/Synthesis.log') return 'old synthesis log'
+      return '{}'
+    })
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+    testState.flowExecutionActive!.value = true
+
+    await vi.waitFor(() => {
+      expect(testState.projectFileWatchers.some((entry) =>
+        entry.path === '/workspace/a/home/flow.json'
+      )).toBe(true)
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.flowLogSegments.value).toEqual([])
+    })
+    expect(home.flowLogContentByKey.value).toEqual({})
+    expect(home.currentWorkspaceFlowExecutionActive.value).toBe(true)
+
+    flowState = 'Ongoing'
+    const flowWatch = [...testState.projectFileWatchers].reverse().find((entry) =>
+      entry.path === '/workspace/a/home/flow.json'
+    )
+    expect(flowWatch).toBeDefined()
+    flowWatch!.listener({
+      subscriptionId: 'flow-watch-rerun',
+      path: '/workspace/a/home/flow.json',
+      eventType: 'change',
+    })
+
+    await vi.waitFor(() => {
+      expect(testState.subscribeProjectLogTail).toHaveBeenCalledWith(
+        '/workspace/a/Synthesis_yosys/log/Synthesis.log',
+        expect.any(Function),
+        expect.any(Object),
+      )
+    })
+
+    const liveTail = [...testState.logTailListeners].reverse().find((entry) =>
+      entry.path === '/workspace/a/Synthesis_yosys/log/Synthesis.log'
+    )
+    expect(liveTail).toBeDefined()
+    liveTail!.listener({
+      subscriptionId: 'project-log-tail-rerun',
+      path: '/workspace/a/Synthesis_yosys/log/Synthesis.log',
+      eventType: 'snapshot',
+      content: 'new rerun synthesis log',
+      fromOffsetBytes: 0,
+      nextOffsetBytes: 23,
+      sizeBytes: 23,
+      reset: false,
+      truncated: false,
+    })
+
+    await vi.waitFor(() => {
+      expect(home.flowLogContentByKey.value[flowLogKey('Synthesis')]).toBe(
+        'new rerun synthesis log',
+      )
+    })
+  })
+
+  it('continues loading Home file updates after backend rerun reset is observed', async () => {
+    let homeVersion: 'old' | 'empty' | 'new' = 'old'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        if (homeVersion === 'empty') {
+          return JSON.stringify(homeDataFor(projectPath))
+        }
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-${homeVersion}.png`,
+          metrics: {
+            [`${homeVersion} chart`]: `${projectPath}/home/${homeVersion}-chart.png`,
+          },
+          monitor: {
+            step: [homeVersion === 'old' ? 'Synthesis' : 'Floorplan'],
+            frequency: [homeVersion === 'old' ? 50 : 55],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonFor('Synthesis')
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+
+    testState.resourceVersions!.value = {
+      ...testState.resourceVersions!.value,
+      home: testState.resourceVersions!.value.home + 1,
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(home.layoutBlobUrl.value).toBe('')
+
+    homeVersion = 'empty'
+    testState.resourceVersions!.value = {
+      ...testState.resourceVersions!.value,
+      home: testState.resourceVersions!.value.home + 1,
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(home.layoutBlobUrl.value).toBe('')
+
+    homeVersion = 'new'
+    testState.resourceVersions!.value = {
+      ...testState.resourceVersions!.value,
+      home: testState.resourceVersions!.value.home + 1,
+    }
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-new.png')
+    })
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'new chart', imageBlobUrl: 'blob:/workspace/a/home/new-chart.png' },
+    ])
+    expect(home.monitorData.value).toEqual({
+      step: ['Floorplan'],
+      frequency: [55],
+    })
+  })
+
+  it('loads new Home artifacts while a full-flow rerun is still running', async () => {
+    let homeVersion: 'old' | 'new' = 'old'
+    let flowState = 'Success'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        if (homeVersion === 'old') {
+          return JSON.stringify({
+            ...homeDataFor(projectPath),
+            layout: `${projectPath}/home/layout-old.png`,
+            checklist: `${projectPath}/home/checklist-old.json`,
+            metrics: {
+              'instances dist.': `${projectPath}/home/instances-old.png`,
+            },
+            monitor: {
+              step: ['Synthesis'],
+              frequency: [50],
+            },
+          })
+        }
+
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-new.png`,
+          checklist: `${projectPath}/home/checklist-new.json`,
+          metrics: {
+            'pin dist.': `${projectPath}/home/pin-new.png`,
+          },
+          monitor: {
+            step: ['Floorplan'],
+            frequency: [55],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/checklist-old.json') {
+        return JSON.stringify({
+          path,
+          checklist: [{ step: 'Floorplan', type: 'Area', item: 'old check', state: 'Accepted' }],
+        })
+      }
+      if (path === '/workspace/a/home/checklist-new.json') {
+        return JSON.stringify({
+          path,
+          checklist: [{ step: 'Floorplan', type: 'Area', item: 'new check', state: 'Accepted' }],
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', flowState)
+      if (path === '/workspace/a/Synthesis_yosys/log/Synthesis.log') return 'new synthesis log'
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+
+    homeVersion = 'new'
+    flowState = 'Ongoing'
+    const flowWatches = await vi.waitFor(() => {
+      const active = testState.projectFileWatchers.filter((entry) =>
+        entry.path === '/workspace/a/home/flow.json'
+      )
+      expect(active.length).toBeGreaterThan(0)
+      return active
+    })
+    for (const flowWatch of flowWatches) {
+      flowWatch.listener({
+        subscriptionId: 'flow-watch-rerun-new-artifacts',
+        path: '/workspace/a/home/flow.json',
+        eventType: 'change',
+      })
+    }
+
+    const homeWatches = await vi.waitFor(() => {
+      const active = testState.projectFileWatchers.filter((entry) =>
+        entry.path === '/workspace/a/home/home.json'
+      )
+      expect(active.length).toBeGreaterThan(0)
+      return active
+    })
+    for (const homeWatch of homeWatches) {
+      homeWatch.listener({
+        subscriptionId: 'home-watch-rerun-new-artifacts',
+        path: '/workspace/a/home/home.json',
+        eventType: 'change',
+      })
+    }
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-new.png')
+    })
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'pin dist.', imageBlobUrl: 'blob:/workspace/a/home/pin-new.png' },
+    ])
+    expect(home.checklistItems.value).toEqual([
+      { step: 'Floorplan', type: 'Area', item: 'new check', state: 'Accepted' },
+    ])
+    expect(home.monitorData.value).toEqual({
+      step: ['Floorplan'],
+      frequency: [55],
+    })
+  })
+
+  it('polls home.json for new Home artifacts while a full-flow rerun is still running', async () => {
+    vi.useFakeTimers()
+    let homeVersion: 'old' | 'empty' | 'new' = 'old'
+    let flowState = 'Success'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        if (homeVersion === 'empty') {
+          return JSON.stringify(homeDataFor(projectPath))
+        }
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-${homeVersion}.png`,
+          metrics: {
+            [`${homeVersion} chart`]: `${projectPath}/home/${homeVersion}-chart.png`,
+          },
+          monitor: {
+            step: [homeVersion === 'old' ? 'Synthesis' : 'Floorplan'],
+            frequency: [homeVersion === 'old' ? 50 : 55],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', flowState)
+      if (path === '/workspace/a/Synthesis_yosys/log/Synthesis.log') return 'new synthesis log'
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+
+    homeVersion = 'empty'
+    flowState = 'Ongoing'
+    const flowWatches = await vi.waitFor(() => {
+      const active = testState.projectFileWatchers.filter((entry) =>
+        entry.path === '/workspace/a/home/flow.json'
+      )
+      expect(active.length).toBeGreaterThan(0)
+      return active
+    })
+    for (const flowWatch of flowWatches) {
+      flowWatch.listener({
+        subscriptionId: 'flow-watch-rerun-poll-home',
+        path: '/workspace/a/home/flow.json',
+        eventType: 'change',
+      })
+    }
+
+    await vi.waitFor(() => {
+      expect(home.flowLogSegments.value.some((segment) => segment.live)).toBe(true)
+    })
+    expect(home.layoutBlobUrl.value).toBe('')
+
+    homeVersion = 'new'
+    await vi.advanceTimersByTimeAsync(1600)
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-new.png')
+    })
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'new chart', imageBlobUrl: 'blob:/workspace/a/home/new-chart.png' },
+    ])
+    expect(home.monitorData.value).toEqual({
+      step: ['Floorplan'],
+      frequency: [55],
+    })
+  })
+
+  it('does not restore stale Home artifacts from home.json reads that race ahead of backend rerun reset', async () => {
+    vi.useFakeTimers()
+    let homeVersion: 'old' | 'empty' | 'new' = 'old'
+    let flowState = 'Success'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        if (homeVersion === 'empty') {
+          return JSON.stringify(homeDataFor(projectPath))
+        }
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-${homeVersion}.png`,
+          metrics: {
+            [`${homeVersion} chart`]: `${projectPath}/home/${homeVersion}-chart.png`,
+          },
+          monitor: {
+            step: [homeVersion === 'old' ? 'Filler' : 'Floorplan'],
+            frequency: [homeVersion === 'old' ? 814.3 : 55],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', flowState)
+      if (path === '/workspace/a/Synthesis_yosys/log/Synthesis.log') return 'rerun synthesis log'
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'old chart', imageBlobUrl: 'blob:/workspace/a/home/old-chart.png' },
+    ])
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+    expect(home.analysisCharts.value).toEqual([])
+
+    flowState = 'Ongoing'
+    await vi.advanceTimersByTimeAsync(1600)
+
+    expect(home.layoutBlobUrl.value).toBe('')
+    expect(home.analysisCharts.value).toEqual([])
+    expect(home.monitorData.value).toBeNull()
+
+    homeVersion = 'empty'
+    await vi.advanceTimersByTimeAsync(1600)
+    expect(home.layoutBlobUrl.value).toBe('')
+
+    homeVersion = 'new'
+    await vi.advanceTimersByTimeAsync(1600)
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-new.png')
+    })
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'new chart', imageBlobUrl: 'blob:/workspace/a/home/new-chart.png' },
+    ])
+    expect(home.monitorData.value).toEqual({
+      step: ['Floorplan'],
+      frequency: [55],
+    })
+  })
+
+  it('does not clear Home artifacts from an empty live home.json read before backend rerun start', async () => {
+    vi.useFakeTimers()
+    let homeVersion: 'old' | 'empty' = 'old'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        if (homeVersion === 'empty') {
+          return JSON.stringify(homeDataFor(projectPath))
+        }
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-old.png`,
+          metrics: {
+            'old chart': `${projectPath}/home/old-chart.png`,
+          },
+          monitor: {
+            step: ['Filler'],
+            frequency: [814.3],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', 'Ongoing')
+      if (path === '/workspace/a/Synthesis_yosys/log/Synthesis.log') return 'rerun synthesis log'
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'old chart', imageBlobUrl: 'blob:/workspace/a/home/old-chart.png' },
+    ])
+
+    ;(await import('./homeRunArtifacts')).markHomeRunArtifactResetAwaitingBackendStart('/workspace/a')
+    testState.flowExecutionActive!.value = true
+    await vi.waitFor(() => {
+      expect(testState.projectFileWatchers.some((entry) =>
+        entry.path === '/workspace/a/home/home.json'
+      )).toBe(true)
+    })
+
+    homeVersion = 'empty'
+    await vi.advanceTimersByTimeAsync(1600)
+
+    expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'old chart', imageBlobUrl: 'blob:/workspace/a/home/old-chart.png' },
+    ])
+    expect(home.monitorData.value).toEqual({
+      step: ['Filler'],
+      frequency: [814.3],
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+    expect(home.analysisCharts.value).toEqual([])
+    expect(home.monitorData.value).toBeNull()
+  })
+
+  it('keeps suppressing stale Home artifacts when the backend rerun start is observed twice', async () => {
+    vi.useFakeTimers()
+    let flowState = 'Success'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-old.png`,
+          metrics: {
+            'old chart': `${projectPath}/home/old-chart.png`,
+          },
+          monitor: {
+            step: ['Filler'],
+            frequency: [814.3],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', flowState)
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    const { requestHomeRunArtifactReset } = await import('./homeRunArtifacts')
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+
+    requestHomeRunArtifactReset('/workspace/a')
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+    flowState = 'Ongoing'
+    await vi.advanceTimersByTimeAsync(1600)
+
+    expect(home.layoutBlobUrl.value).toBe('')
+    expect(home.analysisCharts.value).toEqual([])
+    expect(home.monitorData.value).toBeNull()
+  })
+
+  it('does not treat stale completed flow.json as terminal during rerun startup', async () => {
+    vi.useFakeTimers()
+    let flowState = 'Success'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-old.png`,
+          metrics: {
+            'old chart': `${projectPath}/home/old-chart.png`,
+          },
+          monitor: {
+            step: ['Filler'],
+            frequency: [814.3],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', flowState)
+      if (path === '/workspace/a/Synthesis_yosys/log/Synthesis.log') return 'rerun synthesis log'
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-old.png')
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+    expect(testState.flowExecutionActive!.value).toBe(true)
+    const allBeforePoll = testState.resourceVersions!.value.all
+
+    await vi.advanceTimersByTimeAsync(1600)
+
+    expect(testState.flowExecutionActive!.value).toBe(true)
+    expect(testState.resourceVersions!.value.all).toBe(allBeforePoll)
+    expect(home.flowLogSegments.value).toEqual([])
+
+    flowState = 'Ongoing'
+    await vi.advanceTimersByTimeAsync(1600)
+
+    await vi.waitFor(() => {
+      expect(home.flowLogSegments.value.map((segment) => segment.state)).toEqual(['Ongoing'])
+    })
+    expect(testState.flowExecutionActive!.value).toBe(true)
+  })
+
+  it('does not reload unchanged Home artifacts on each live home.json poll', async () => {
+    vi.useFakeTimers()
+    let flowState = 'Success'
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-stable.png`,
+          metrics: {
+            'stable chart': `${projectPath}/home/stable-chart.png`,
+          },
+          monitor: {
+            step: ['Synthesis'],
+            frequency: [50],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonWithState('Synthesis', flowState)
+      if (path === '/workspace/a/Synthesis_yosys/log/Synthesis.log') return 'stable synthesis log'
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-stable.png')
+    })
+    expect(testState.readProjectBlobUrl).toHaveBeenCalledTimes(2)
+
+    flowState = 'Ongoing'
+    testState.flowExecutionActive!.value = true
+    await vi.waitFor(() => {
+      expect(testState.projectFileWatchers.some((entry) =>
+        entry.path === '/workspace/a/home/home.json'
+      )).toBe(true)
+    })
+
+    testState.readProjectBlobUrl.mockClear()
+    await vi.advanceTimersByTimeAsync(1600)
+    await vi.advanceTimersByTimeAsync(1600)
+
+    expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-stable.png')
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'stable chart', imageBlobUrl: 'blob:/workspace/a/home/stable-chart.png' },
+    ])
+    expect(testState.readProjectBlobUrl).not.toHaveBeenCalled()
+  })
+
+  it('allows Home run artifacts to load again after the full-flow rerun finishes', async () => {
+    testState.readProjectTextFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/home/home.json')) {
+        const projectPath = path.replace(/\/home\/home\.json$/, '')
+        return JSON.stringify({
+          ...homeDataFor(projectPath),
+          layout: `${projectPath}/home/layout-final.png`,
+          metrics: {
+            'instances dist.': `${projectPath}/home/instances-final.png`,
+          },
+          monitor: {
+            step: ['Filler'],
+            frequency: [55],
+          },
+        })
+      }
+      if (path === '/workspace/a/home/flow.json') return flowJsonFor('Filler')
+      return '{}'
+    })
+    testState.readProjectBlobUrl.mockImplementation(async (path: string) => `blob:${path}`)
+
+    const { useHomeData } = await importFreshHomeDataModule()
+    await startLifecycleSession('/workspace/a')
+    testState.currentProject!.value = { path: '/workspace/a' }
+
+    const home = useHomeData()
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-final.png')
+    })
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          rerun: true,
+          type: 'message',
+        },
+        message: ['Started rtl2gds'],
+        response: 'success',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('')
+    })
+
+    testState.runtimeEvents!.value = [
+      ...testState.runtimeEvents!.value,
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          type: 'task_complete',
+        },
+        message: ['done'],
+        response: 'success',
+      },
+    ]
+    testState.resourceVersions!.value = {
+      ...testState.resourceVersions!.value,
+      home: testState.resourceVersions!.value.home + 1,
+    }
+
+    await vi.waitFor(() => {
+      expect(home.layoutBlobUrl.value).toBe('blob:/workspace/a/home/layout-final.png')
+    })
+    expect(home.analysisCharts.value).toEqual([
+      { label: 'instances dist.', imageBlobUrl: 'blob:/workspace/a/home/instances-final.png' },
+    ])
+    expect(home.monitorData.value).toEqual({
+      step: ['Filler'],
+      frequency: [55],
     })
   })
 

--- a/ecos/gui/apps/renderer/src/composables/useHomeData.ts
+++ b/ecos/gui/apps/renderer/src/composables/useHomeData.ts
@@ -4,6 +4,7 @@ import { useDesktopRuntime } from './useDesktopRuntime'
 import {
   clearFlowExecutionActiveForWorkspace,
   isFlowExecutionActiveForWorkspace,
+  markFlowExecutionActiveForWorkspace,
 } from './useFlowRunner'
 import { getWorkspaceResourceIndexApi, readWorkspaceHomeResourceApi } from '@/api/workspaceResources'
 import type { DesktopProjectLogTailEvent } from '@ecos-studio/shared'
@@ -20,6 +21,11 @@ import { requestProjectPathAccess, resolveProjectPathAccess } from '@/utils/proj
 import { convertRemoteToLocalPath } from '@/utils/projectPaths'
 import { mergePlannedFlowLogSegments } from './flowLogSegmentPlan'
 import { useWorkspaceLifecycle } from './useWorkspaceLifecycle'
+import {
+  consumePendingHomeRunArtifactReset,
+  isHomeRunArtifactResetAwaitingBackendStart,
+  onHomeRunArtifactReset,
+} from './homeRunArtifacts'
 
 export { convertRemoteToLocalPath } from '@/utils/projectPaths'
 
@@ -380,11 +386,65 @@ let _loadedChecklistPath = ''
 let _loadedLayoutPath = ''
 let _loadedMetricsSignature = ''
 let _loadedHomeResourceVersionSignature = ''
+let _rerunStartupWatchHandledForWorkspace = ''
+let _pendingRerunResetConfirmationWorkspace = ''
+let _pendingRerunStaleHomeSignature = ''
+let _pendingRerunFlowStartWorkspace = ''
 
 function homeResourceVersionSignature(
   versions: Record<typeof HOME_DATA_RESOURCE_VERSION_KEYS[number], number>,
 ): string {
   return HOME_DATA_RESOURCE_VERSION_KEYS.map((key) => `${key}:${versions[key] ?? 0}`).join('|')
+}
+
+function homeMetricSourceEntries(metrics: unknown): string[] {
+  return metrics && typeof metrics === 'object'
+    ? Object.entries(metrics)
+        .filter(([, value]) => typeof value === 'string' && value.length > 0)
+        .map(([label, value]) => `${label}=${value}`)
+        .sort()
+    : []
+}
+
+function homeMonitorSignature(monitor: MonitorData | null | undefined): string {
+  if (!monitor || typeof monitor !== 'object') return ''
+  return JSON.stringify(
+    Object.entries(monitor)
+      .filter(([, value]) => Array.isArray(value))
+      .map(([key, value]) => [key, value])
+      .sort(([a], [b]) => String(a).localeCompare(String(b))),
+  )
+}
+
+function homeAssetSourceSignature(data: HomeData | null): string {
+  if (!data) return '__none__'
+  const metrics = homeMetricSourceEntries(data.metrics)
+  return JSON.stringify({
+    checklist: data.checklist ?? '',
+    layout: data.layout ?? '',
+    metrics,
+  })
+}
+
+function homeRerunContentSignature(data: HomeData | null): string {
+  if (!data) return '__none__'
+  return JSON.stringify({
+    checklist: data.checklist ?? '',
+    layout: data.layout ?? '',
+    metrics: homeMetricSourceEntries(data.metrics),
+    monitor: homeMonitorSignature(data.monitor),
+  })
+}
+
+function currentDisplayedHomeRerunContentSignature(): string {
+  const sharedSignature = homeRerunContentSignature(sharedHomeData.value)
+  if (sharedSignature !== '__none__') return sharedSignature
+  return JSON.stringify({
+    checklist: _loadedChecklistPath,
+    layout: _loadedLayoutPath,
+    metrics: _loadedMetricsSignature,
+    monitor: homeMonitorSignature(monitorDataState.value),
+  })
 }
 
 function invalidateLayoutCache(): void {
@@ -494,11 +554,16 @@ export async function fetchSharedHomeData(
 }
 
 /** 从 runtime event 路径更新共享缓存 */
-export function updateSharedHomeData(data: HomeData) {
+export function updateSharedHomeData(
+  data: HomeData,
+  options: { markAssetsStale?: boolean } = {},
+) {
   sharedHomeData.value = data
   // Runtime event 代表 home.json 有新内容；把资源签名清空让 loader 下一次真重读。
   // 但 blob URL 暂时保留，新 blob 到位后再 revoke，避免 UI 闪白。
-  markHomeAssetSignaturesStale()
+  if (options.markAssetsStale ?? true) {
+    markHomeAssetSignaturesStale()
+  }
 }
 
 /** 清除共享缓存 */
@@ -515,11 +580,145 @@ function invalidateHomeDataForResourceChange() {
   invalidateLogFileCache()
 }
 
+function normalizeWorkspaceEventPath(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const normalized = value.trim().replace(/\\/g, '/')
+  return normalized.length > 1 && normalized.endsWith('/')
+    ? normalized.slice(0, -1)
+    : normalized
+}
+
+function clearHomeRunArtifactsForRerun(projectPath: string): void {
+  const workspaceKey = normalizeWorkspaceEventPath(projectPath)
+  if (!workspaceKey) return
+
+  _rerunStartupWatchHandledForWorkspace = workspaceKey
+  _pendingRerunFlowStartWorkspace = workspaceKey
+  if (_pendingRerunResetConfirmationWorkspace !== workspaceKey) {
+    _pendingRerunStaleHomeSignature = currentDisplayedHomeRerunContentSignature()
+  }
+  _pendingRerunResetConfirmationWorkspace = workspaceKey
+  invalidateSharedHomeData()
+  invalidateHomeAssetCache()
+  resetFlowLogState()
+  invalidateLogFileCache()
+}
+
+function hasHomeRunArtifacts(data: HomeData | null): boolean {
+  if (!data) return false
+  const hasLayout = typeof data.layout === 'string' && data.layout.length > 0
+  const hasMetrics = homeMetricSourceEntries(data.metrics).length > 0
+  const hasMonitor = Boolean(
+    data.monitor
+    && typeof data.monitor === 'object'
+    && Object.values(data.monitor).some((value) => Array.isArray(value) && value.length > 0),
+  )
+  return hasLayout || hasMetrics || hasMonitor
+}
+
+function shouldDeferHomeDataUntilRerunReset(projectPath: string, data: HomeData): boolean {
+  const key = normalizeWorkspaceEventPath(projectPath)
+  if (!key || _pendingRerunResetConfirmationWorkspace !== key) return false
+
+  const nextSignature = homeRerunContentSignature(data)
+  if (!hasHomeRunArtifacts(data)) {
+    _pendingRerunResetConfirmationWorkspace = ''
+    _pendingRerunStaleHomeSignature = ''
+    return false
+  }
+
+  if (
+    _pendingRerunStaleHomeSignature
+    && nextSignature === _pendingRerunStaleHomeSignature
+  ) {
+    if (homeRerunContentSignature(sharedHomeData.value) === nextSignature) {
+      sharedHomeData.value = null
+      _fetchPromise = null
+      _fetchGeneration += 1
+    }
+    return true
+  }
+
+  _pendingRerunResetConfirmationWorkspace = ''
+  _pendingRerunStaleHomeSignature = ''
+  return false
+}
+
+function shouldDeferHomeDataUntilBackendRerunStart(projectPath: string, data: HomeData): boolean {
+  return isHomeRunArtifactResetAwaitingBackendStart(projectPath) && !hasHomeRunArtifacts(data)
+}
+
+function isWaitingForRerunFlowStart(projectPath: string): boolean {
+  const key = normalizeWorkspaceEventPath(projectPath)
+  return Boolean(key) && _pendingRerunFlowStartWorkspace === key
+}
+
+function updateRerunFlowStartState(
+  projectPath: string,
+  plan: {
+    hasOngoingStep: boolean
+    hasPendingStep: boolean
+  },
+): void {
+  if (!isWaitingForRerunFlowStart(projectPath)) return
+  if (plan.hasOngoingStep || plan.hasPendingStep) {
+    _pendingRerunFlowStartWorkspace = ''
+  }
+}
+
+function consumeRerunStartupWatchHandledFor(projectPath: unknown): boolean {
+  const key = normalizeWorkspaceEventPath(projectPath)
+  if (!key || _rerunStartupWatchHandledForWorkspace !== key) return false
+  _rerunStartupWatchHandledForWorkspace = ''
+  return true
+}
+
+function isCurrentWorkspaceRerunStartEvent(event: unknown, projectPath: string): boolean {
+  if (!event || typeof event !== 'object') return false
+  const payload = event as Record<string, unknown>
+  const data = payload.data
+  if (!data || typeof data !== 'object') return false
+
+  const eventData = data as Record<string, unknown>
+  if (eventData.cmd !== 'rtl2gds') return false
+  if (eventData.type !== 'message') return false
+  if (eventData.rerun !== true) return false
+
+  const eventWorkspace = normalizeWorkspaceEventPath(eventData.workspaceId)
+    || normalizeWorkspaceEventPath(eventData.directory)
+  return eventWorkspace === normalizeWorkspaceEventPath(projectPath)
+}
+
+function isCurrentWorkspaceRerunTerminalEvent(event: unknown, projectPath: string): boolean {
+  if (!event || typeof event !== 'object') return false
+  const payload = event as Record<string, unknown>
+  const data = payload.data
+  if (!data || typeof data !== 'object') return false
+
+  const eventData = data as Record<string, unknown>
+  if (eventData.cmd !== 'rtl2gds') return false
+  if (
+    eventData.type !== 'task_complete'
+    && eventData.type !== 'error'
+    && eventData.type !== 'cancelled'
+  ) {
+    return false
+  }
+
+  const eventWorkspace = normalizeWorkspaceEventPath(eventData.workspaceId)
+    || normalizeWorkspaceEventPath(eventData.directory)
+  return eventWorkspace === normalizeWorkspaceEventPath(projectPath)
+}
+
 export function resetSharedHomeDataProjectState() {
   sharedHomeData.value = null
   _fetchPromise = null
   _cachedForProject = ''
   _fetchGeneration += 1
+  _rerunStartupWatchHandledForWorkspace = ''
+  _pendingRerunResetConfirmationWorkspace = ''
+  _pendingRerunStaleHomeSignature = ''
+  _pendingRerunFlowStartWorkspace = ''
   // 项目切换时，所有跨组件的模块级缓存一并失效
   logFileCache.clear()
   resolvedPathCache.clear()
@@ -537,6 +736,7 @@ export function useHomeData() {
   const { isDesktopRuntimeAvailable } = useDesktopRuntime()
   const {
     currentProject,
+    runtimeEvents,
     resourceVersions,
   } = useWorkspace()
   const workspaceLifecycle = useWorkspaceLifecycle()
@@ -562,6 +762,7 @@ export function useHomeData() {
   /** flow log 渐进刷新会话：递增后旧异步回调全部失效 */
   let liveSession = 0
   let pollFlowJsonTimer: ReturnType<typeof setInterval> | null = null
+  let pollHomeJsonTimer: ReturnType<typeof setInterval> | null = null
   let pollLogFallbackTimer: ReturnType<typeof setInterval> | null = null
   let unwatchFlowJsonFile: (() => void) | null = null
   let unwatchHomeJsonFile: (() => void) | null = null
@@ -575,6 +776,7 @@ export function useHomeData() {
   let homeDataLoadSession = 0
   let lastOngoingKey: string | null = null
   let unregisterLiveLifecycleCleanup: (() => void) | null = null
+  let unregisterHomeRunArtifactReset: (() => void) | null = null
 
   /**
    * 将远程路径转换为本地项目路径
@@ -686,8 +888,10 @@ export function useHomeData() {
     for (const result of results) {
       if (result.status === 'fulfilled') {
         const { label, blobUrl } = result.value
-        charts.push({ label, imageBlobUrl: blobUrl })
-        if (blobUrl) newBlobUrls.push(blobUrl)
+        if (blobUrl) {
+          charts.push({ label, imageBlobUrl: blobUrl })
+          newBlobUrls.push(blobUrl)
+        }
       }
     }
     if (!isCurrent()) {
@@ -857,6 +1061,10 @@ export function useHomeData() {
     if (pollFlowJsonTimer != null) {
       clearInterval(pollFlowJsonTimer)
       pollFlowJsonTimer = null
+    }
+    if (pollHomeJsonTimer != null) {
+      clearInterval(pollHomeJsonTimer)
+      pollHomeJsonTimer = null
     }
     liveProjectPath = null
     lastOngoingKey = null
@@ -1111,9 +1319,15 @@ export function useHomeData() {
     try {
       const plan = await planFlowLogSegments(flowLocal, true)
       if (!plan || sid !== liveSession || currentProject.value?.path !== projectPath) return
+      const waitingForRerunFlowStart = isWaitingForRerunFlowStart(projectPath)
+      if (waitingForRerunFlowStart && !plan.hasOngoingStep && !plan.hasPendingStep) {
+        return
+      }
+      updateRerunFlowStartState(projectPath, plan)
 
       if (
         isFlowExecutionActiveForWorkspace(projectPath)
+        && !waitingForRerunFlowStart
         && !plan.hasOngoingStep
         && !plan.hasPendingStep
       ) {
@@ -1395,6 +1609,12 @@ export function useHomeData() {
         clearHomeData()
         return
       }
+      if (shouldDeferHomeDataUntilBackendRerunStart(projectPath, homeData)) {
+        return
+      }
+      if (shouldDeferHomeDataUntilRerunReset(projectPath, homeData)) {
+        return
+      }
 
       console.log('Loaded home data:', homeData)
 
@@ -1512,10 +1732,10 @@ export function useHomeData() {
     }
   }
 
-  async function refreshHomeDataFromCurrentHomeFile(sid: number): Promise<void> {
-    if (sid !== liveSession) return
+  async function refreshHomeAssetsFromCurrentHomeFile(sid: number): Promise<boolean> {
+    if (sid !== liveSession) return false
     const projectPath = liveProjectPath
-    if (!projectPath || currentProject.value?.path !== projectPath) return
+    if (!projectPath || currentProject.value?.path !== projectPath) return false
 
     const sessionId = workspaceLifecycle.currentSessionId.value
     const loadSession = ++homeDataLoadSession
@@ -1528,24 +1748,46 @@ export function useHomeData() {
       && currentProject.value?.path === projectPath
 
     const resolvedHomePath = await resolvedPathMemo(`${projectPath}/home/home.json`)
-    if (!resolvedHomePath || !isCurrent()) return
+    if (!resolvedHomePath || !isCurrent()) return false
 
     try {
       const fileContent = await readProjectTextFile(resolvedHomePath)
       const homeData: HomeData = JSON.parse(fileContent)
-      if (!isCurrent()) return
+      if (!isCurrent()) return false
+      if (shouldDeferHomeDataUntilBackendRerunStart(projectPath, homeData)) {
+        return false
+      }
+      if (shouldDeferHomeDataUntilRerunReset(projectPath, homeData)) {
+        return false
+      }
 
-      updateSharedHomeData(homeData)
+      updateSharedHomeData(homeData, {
+        markAssetsStale: homeAssetSourceSignature(sharedHomeData.value) !== homeAssetSourceSignature(homeData),
+      })
       await loadHomeAssetsFromData(homeData, { includeFlowLogs: false, isCurrent })
-      if (!isCurrent()) return
+      return isCurrent()
+    } catch (err) {
+      console.error('refreshHomeAssetsFromCurrentHomeFile:', err)
+      return false
+    }
+  }
+
+  async function refreshHomeDataFromCurrentHomeFile(sid: number): Promise<void> {
+    const loaded = await refreshHomeAssetsFromCurrentHomeFile(sid)
+    if (!loaded) return
+
+    try {
       await refreshFlowLogLivePanel(sid)
     } catch (err) {
       console.error('refreshHomeDataFromCurrentHomeFile:', err)
     }
   }
 
-  async function startFlowLogLiveWatchForCurrentProject(): Promise<void> {
-    if (!isDesktopRuntimeAvailable || !currentWorkspaceFlowExecutionActive.value) return
+  async function startFlowLogLiveWatchForCurrentProject(
+    options: { force?: boolean; initialRefresh?: boolean } = {},
+  ): Promise<void> {
+    if (!isDesktopRuntimeAvailable) return
+    if (!options.force && !currentWorkspaceFlowExecutionActive.value) return
     const projectPath = currentProject.value?.path
     if (!projectPath) return
 
@@ -1562,17 +1804,7 @@ export function useHomeData() {
       label: 'home live file watchers',
     })
 
-    const homeData = await fetchSharedHomeData(projectPath, isDesktopRuntimeAvailable)
-    if (sid !== liveSession || currentProject.value?.path !== projectPath) return
-
-    const flowRemote = homeData?.flow ?? ''
-    if (!flowRemote) {
-      console.warn('flow-log live: no flow path in home data')
-      return
-    }
-
-    const flowLocal = convertRemoteToLocalPath(flowRemote, projectPath)
-    const resolvedFlowPath = await resolvedPathMemo(flowLocal)
+    const resolvedFlowPath = await resolvedPathMemo(`${projectPath}/home/flow.json`)
     if (sid !== liveSession || currentProject.value?.path !== projectPath) return
     if (!resolvedFlowPath) return
 
@@ -1614,8 +1846,13 @@ export function useHomeData() {
     pollFlowJsonTimer = setInterval(() => {
       void refreshFlowLogLivePanel(sid)
     }, 1600)
+    pollHomeJsonTimer = setInterval(() => {
+      void refreshHomeAssetsFromCurrentHomeFile(sid)
+    }, 1600)
 
-    await refreshFlowLogLivePanel(sid)
+    if (options.initialRefresh ?? true) {
+      await refreshFlowLogLivePanel(sid)
+    }
   }
 
   // run_step / rtl2gds 期间：监听 flow.json 与当前步日志文件，渐进更新 Flow step log
@@ -1634,7 +1871,13 @@ export function useHomeData() {
         return
       }
 
-      await startFlowLogLiveWatchForCurrentProject()
+      if (consumeRerunStartupWatchHandledFor(currentProject.value?.path)) {
+        return
+      }
+
+      await startFlowLogLiveWatchForCurrentProject({
+        initialRefresh: true,
+      })
     },
     { immediate: true },
   )
@@ -1648,6 +1891,12 @@ export function useHomeData() {
         if (projectChanged) {
           liveSession++
           cleanupFlowLogLiveWatch()
+        }
+        if (consumePendingHomeRunArtifactReset(newPath)) {
+          clearHomeRunArtifactsForRerun(newPath)
+          markFlowExecutionActiveForWorkspace(newPath)
+          await startFlowLogLiveWatchForCurrentProject({ force: true, initialRefresh: false })
+          return
         }
         await loadHomeData()
         if (
@@ -1678,6 +1927,56 @@ export function useHomeData() {
     },
   )
 
+  watch(
+    () => runtimeEvents.value[runtimeEvents.value.length - 1],
+    (event) => {
+      const projectPath = currentProject.value?.path
+      if (!projectPath) return
+      if (isCurrentWorkspaceRerunStartEvent(event, projectPath)) {
+        const hasLiveWatchForProject = liveProjectPath === projectPath
+          && Boolean(
+            unwatchFlowJsonFile
+            || unwatchHomeJsonFile
+            || pollFlowJsonTimer
+            || pollHomeJsonTimer,
+          )
+        clearHomeRunArtifactsForRerun(projectPath)
+        markFlowExecutionActiveForWorkspace(projectPath)
+        if (!hasLiveWatchForProject) {
+          void startFlowLogLiveWatchForCurrentProject({ force: true, initialRefresh: false })
+        }
+        return
+      }
+      if (isCurrentWorkspaceRerunTerminalEvent(event, projectPath)) {
+        _pendingRerunResetConfirmationWorkspace = ''
+        _pendingRerunStaleHomeSignature = ''
+      }
+    },
+  )
+
+  unregisterHomeRunArtifactReset = onHomeRunArtifactReset((projectPath) => {
+    const currentProjectPath = currentProject.value?.path
+    if (
+      !currentProjectPath
+      || normalizeWorkspaceEventPath(projectPath) !== normalizeWorkspaceEventPath(currentProjectPath)
+    ) {
+      return
+    }
+
+    const hasLiveWatchForProject = liveProjectPath === currentProjectPath
+      && Boolean(
+        unwatchFlowJsonFile
+        || unwatchHomeJsonFile
+        || pollFlowJsonTimer
+        || pollHomeJsonTimer,
+      )
+    consumePendingHomeRunArtifactReset(currentProjectPath)
+    clearHomeRunArtifactsForRerun(currentProjectPath)
+    if (!hasLiveWatchForProject) {
+      void startFlowLogLiveWatchForCurrentProject({ force: true, initialRefresh: false })
+    }
+  })
+
   // 组件卸载：只停掉本实例挂载的 live watcher / 定时器；
   // **不** 清模块级缓存或 revoke blob —— 下次 mount 直接复用 home.json、
   // checklist、layout blob、metrics blob、flowLogSegments。
@@ -1685,6 +1984,8 @@ export function useHomeData() {
   // 在 onUnmounted 里 revoke 会导致下一次 mount 的 <img :src> 拿到已失效的 URL。
   // 数据新鲜度由 runtime events（markHomeAssetSignaturesStale）+ 项目切换里的 reset 负责。
   onUnmounted(() => {
+    unregisterHomeRunArtifactReset?.()
+    unregisterHomeRunArtifactReset = null
     liveSession++
     cleanupFlowLogLiveWatch()
   })

--- a/ecos/gui/apps/renderer/src/composables/useParameters.runtime.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useParameters.runtime.test.ts
@@ -82,6 +82,7 @@ import {
   markFlowExecutionActiveForWorkspace,
 } from './useFlowRunner'
 import { useWorkspaceLifecycle } from './useWorkspaceLifecycle'
+import { requestHomeRunArtifactReset } from './homeRunArtifacts'
 
 function createDeferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void
@@ -223,6 +224,261 @@ describe('useParameters desktop bridge integration', () => {
       '/workspace/demo/home/parameters.json',
       expect.stringContaining('"Design": "updated_demo"'),
     )
+    expect(refreshConfigApi).toHaveBeenCalledWith({
+      cmd: 'refresh_config',
+      data: {
+        directory: '/workspace/demo',
+      },
+    })
+  })
+
+  it('keeps displayed parameters unchanged when rerun reset is requested before parameters.json changes', async () => {
+    fetchSharedHomeData.mockResolvedValue({
+      parameters: '/workspace/demo/home/parameters.json',
+    })
+    readProjectTextFile
+      .mockResolvedValueOnce(JSON.stringify({
+      PDK: 'ics55',
+      Design: 'demo',
+      'Top module': 'chip_top',
+      Die: { Size: [100, 100], Area: 10000 },
+      Core: {
+        Size: [80, 80],
+        Area: 6400,
+        'Bounding box': '(0,0) (80,80)',
+        Utilitization: 0.5,
+        Margin: [4, 4],
+        'Aspect ratio': 1,
+      },
+      'Max fanout': 20,
+      'Target density': 0.3,
+      'Target overflow': 0.1,
+      'Global right padding': 0,
+      'Cell padding x': 600,
+      'Routability opt flag': 1,
+      Clock: 'clk',
+      'Frequency max [MHz]': 100,
+      'Bottom layer': 'MET2',
+      'Top layer': 'MET5',
+      'PDK Root': '/pdks/ics55',
+    }))
+      .mockResolvedValueOnce(JSON.stringify({
+        PDK: 'ics55',
+        Design: 'demo',
+        'Top module': 'chip_top',
+        Die: { Size: [110, 110], Area: 12100 },
+        Core: {
+          Size: [88, 88],
+          Area: 7744,
+          'Bounding box': '(0,0) (88,88)',
+          Utilitization: 0.5,
+          Margin: [4, 4],
+          'Aspect ratio': 1,
+        },
+        'Max fanout': 20,
+        'Target density': 0.3,
+        'Target overflow': 0.1,
+        'Global right padding': 0,
+        'Cell padding x': 600,
+        'Routability opt flag': 1,
+        Clock: 'clk',
+        'Frequency max [MHz]': 100,
+        'Bottom layer': 'MET2',
+        'Top layer': 'MET5',
+        'PDK Root': '/pdks/ics55',
+      }))
+
+    const parameters = useParameters()
+
+    await vi.waitFor(() => {
+      expect(parameters.config.design).toBe('demo')
+    })
+
+    requestHomeRunArtifactReset('/workspace/demo')
+
+    expect(parameters.config.design).toBe('demo')
+    expect(parameters.config.topModule).toBe('chip_top')
+    expect(parameters.config.clock).toBe('clk')
+    expect(parameters.config.frequencyMax).toBe(100)
+    expect(parameters.config.bottomLayer).toBe('MET2')
+    expect(parameters.config.topLayer).toBe('MET5')
+    expect(parameters.config.die.Size).toEqual([100, 100])
+    expect(parameters.config.die.area).toBe(10000)
+    expect(parameters.config.core.Size).toEqual([80, 80])
+    expect(parameters.config.core.area).toBe(6400)
+    expect(parameters.config.core.boundingBox).toBe('(0,0) (80,80)')
+    expect(parameters.config.core.utilization).toBe(0.5)
+    expect(parameters.config.core.margin).toEqual([4, 4])
+    await vi.waitFor(() => {
+      expect(parameters.hasChanges.value).toBe(false)
+    })
+
+    await parameters.loadParameters()
+
+    await vi.waitFor(() => {
+      expect(parameters.config.die.Size).toEqual([110, 110])
+    })
+    expect(parameters.config.core.Size).toEqual([88, 88])
+    expect(parameters.config.core.boundingBox).toBe('(0,0) (88,88)')
+    expect(parameters.hasChanges.value).toBe(false)
+  })
+
+  it('keeps the last valid parameters during transient rerun home reloads without a parameters path', async () => {
+    fetchSharedHomeData
+      .mockResolvedValueOnce({
+        parameters: '/workspace/demo/home/parameters.json',
+      })
+      .mockResolvedValueOnce({
+        parameters: '',
+      })
+      .mockResolvedValueOnce({
+        parameters: '/workspace/demo/home/parameters.json',
+      })
+    readProjectTextFile
+      .mockResolvedValueOnce(JSON.stringify({
+        PDK: 'ics55',
+        Design: 'demo',
+        'Top module': 'chip_top',
+        Die: { Size: [100, 100], Area: 10000 },
+        Core: {
+          Size: [80, 80],
+          Area: 6400,
+          'Bounding box': '(0,0) (80,80)',
+          Utilitization: 0.5,
+          Margin: [4, 4],
+          'Aspect ratio': 1,
+        },
+        'Max fanout': 20,
+        'Target density': 0.3,
+        'Target overflow': 0.1,
+        'Global right padding': 0,
+        'Cell padding x': 600,
+        'Routability opt flag': 1,
+        Clock: 'clk',
+        'Frequency max [MHz]': 100,
+        'Bottom layer': 'MET2',
+        'Top layer': 'MET5',
+        'PDK Root': '/pdks/ics55',
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        PDK: 'ics55',
+        Design: 'demo',
+        'Top module': 'chip_top',
+        Die: { Size: [], Area: 0 },
+        Core: {
+          Size: [],
+          Area: 0,
+          'Bounding box': '',
+          Utilitization: 0.5,
+          Margin: [4, 4],
+          'Aspect ratio': 1,
+        },
+        'Max fanout': 20,
+        'Target density': 0.3,
+        'Target overflow': 0.1,
+        'Global right padding': 0,
+        'Cell padding x': 600,
+        'Routability opt flag': 1,
+        Clock: 'clk',
+        'Frequency max [MHz]': 100,
+        'Bottom layer': 'MET2',
+        'Top layer': 'MET5',
+        'PDK Root': '/pdks/ics55',
+      }))
+
+    const parameters = useParameters()
+
+    await vi.waitFor(() => {
+      expect(parameters.config.design).toBe('demo')
+    })
+
+    markFlowExecutionActiveForWorkspace('/workspace/demo')
+    await parameters.loadParameters()
+
+    expect(parameters.config.design).toBe('demo')
+    expect(parameters.config.topModule).toBe('chip_top')
+    expect(parameters.config.clock).toBe('clk')
+    expect(parameters.config.die.Size).toEqual([100, 100])
+    expect(parameters.config.core.Size).toEqual([80, 80])
+    expect(parameters.hasChanges.value).toBe(false)
+
+    await parameters.loadParameters()
+
+    expect(parameters.config.design).toBe('demo')
+    expect(parameters.config.topModule).toBe('chip_top')
+    expect(parameters.config.clock).toBe('clk')
+    expect(parameters.config.die.Size).toEqual([])
+    expect(parameters.config.core.Size).toEqual([])
+    expect(parameters.hasChanges.value).toBe(false)
+
+    clearFlowExecutionActiveForWorkspace('/workspace/demo')
+  })
+
+  it('reloads parameters directly from the cached file path while a flow is running', async () => {
+    fetchSharedHomeData.mockResolvedValue({
+      parameters: '/workspace/demo/home/parameters.json',
+    })
+    readProjectTextFile
+      .mockResolvedValueOnce(parametersJson())
+      .mockResolvedValueOnce(parametersJson({
+        Die: { Size: [], Area: 0 },
+        Core: {
+          Size: [],
+          Area: 0,
+          'Bounding box': '',
+          Utilitization: 0.5,
+          Margin: [4, 4],
+          'Aspect ratio': 1,
+        },
+      }))
+
+    const parameters = useParameters()
+
+    await vi.waitFor(() => {
+      expect(parameters.config.design).toBe('demo')
+    })
+    expect(parameters.config.die.Size).toEqual([100, 100])
+    expect(fetchSharedHomeData).toHaveBeenCalledTimes(1)
+
+    markFlowExecutionActiveForWorkspace('/workspace/demo')
+    await parameters.refreshParameters()
+
+    await vi.waitFor(() => {
+      expect(parameters.config.die.Size).toEqual([])
+    })
+
+    expect(parameters.config.design).toBe('demo')
+    expect(parameters.config.topModule).toBe('chip_top')
+    expect(parameters.config.clock).toBe('clk')
+    expect(fetchSharedHomeData).toHaveBeenCalledTimes(1)
+    expect(readProjectTextFile).toHaveBeenLastCalledWith('/workspace/demo/home/parameters.json')
+
+    clearFlowExecutionActiveForWorkspace('/workspace/demo')
+  })
+
+  it('does not replace config objects when a direct running-flow refresh reads unchanged parameters', async () => {
+    fetchSharedHomeData.mockResolvedValue({
+      parameters: '/workspace/demo/home/parameters.json',
+    })
+    readProjectTextFile.mockResolvedValue(parametersJson())
+
+    const parameters = useParameters()
+
+    await vi.waitFor(() => {
+      expect(parameters.config.design).toBe('demo')
+    })
+
+    const dieRef = parameters.config.die
+    const coreRef = parameters.config.core
+
+    markFlowExecutionActiveForWorkspace('/workspace/demo')
+    await parameters.refreshParameters()
+
+    expect(parameters.config.die).toBe(dieRef)
+    expect(parameters.config.core).toBe(coreRef)
+    expect(fetchSharedHomeData).toHaveBeenCalledTimes(1)
+
+    clearFlowExecutionActiveForWorkspace('/workspace/demo')
   })
 
   it('polls the known parameters file while a flow is running without touching shared home data', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useParameters.runtime.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useParameters.runtime.test.ts
@@ -1,10 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
 
 const {
   currentProject,
   fetchSharedHomeData,
   invalidateWorkspaceResources,
   readProjectTextFile,
+  refreshConfigApi,
   runtimeEvents,
   resourceVersions,
   writeProjectTextFile,
@@ -21,6 +23,7 @@ const {
     resourceVersions.value = lifecycle.resourceVersions.value
   }),
   readProjectTextFile: vi.fn(),
+  refreshConfigApi: vi.fn(),
   runtimeEvents: { value: [] },
   resourceVersions: {
     __v_isRef: true,
@@ -69,7 +72,15 @@ vi.mock('@/utils/projectFs', () => ({
   resolveProjectPathAccess,
 }))
 
+vi.mock('@/api/flow', () => ({
+  refreshConfigApi,
+}))
+
 import { useParameters } from './useParameters'
+import {
+  clearFlowExecutionActiveForWorkspace,
+  markFlowExecutionActiveForWorkspace,
+} from './useFlowRunner'
 import { useWorkspaceLifecycle } from './useWorkspaceLifecycle'
 
 function createDeferred<T = void>() {
@@ -80,6 +91,35 @@ function createDeferred<T = void>() {
     reject = rej
   })
   return { promise, resolve, reject }
+}
+
+function parametersJson(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    PDK: 'ics55',
+    Design: 'demo',
+    'Top module': 'chip_top',
+    Die: { Size: [100, 100], Area: 10000 },
+    Core: {
+      Size: [80, 80],
+      Area: 6400,
+      'Bounding box': '(0,0) (80,80)',
+      Utilitization: 0.5,
+      Margin: [4, 4],
+      'Aspect ratio': 1,
+    },
+    'Max fanout': 20,
+    'Target density': 0.3,
+    'Target overflow': 0.1,
+    'Global right padding': 0,
+    'Cell padding x': 600,
+    'Routability opt flag': 1,
+    Clock: 'clk',
+    'Frequency max [MHz]': 100,
+    'Bottom layer': 'MET2',
+    'Top layer': 'MET5',
+    'PDK Root': '/pdks/ics55',
+    ...overrides,
+  })
 }
 
 describe('useParameters desktop bridge integration', () => {
@@ -118,8 +158,21 @@ describe('useParameters desktop bridge integration', () => {
     fetchSharedHomeData.mockReset()
     invalidateWorkspaceResources.mockClear()
     readProjectTextFile.mockReset()
+    refreshConfigApi.mockReset()
+    refreshConfigApi.mockResolvedValue({
+      cmd: 'refresh_config',
+      data: { directory: '/workspace/demo', refreshed: true },
+      message: ['refreshed'],
+      response: 'success',
+    })
     writeProjectTextFile.mockReset()
     resolveProjectPathAccess.mockClear()
+    clearFlowExecutionActiveForWorkspace('/workspace/demo')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    clearFlowExecutionActiveForWorkspace('/workspace/demo')
   })
 
   it('loads and saves parameters through the bridge-backed file helpers', async () => {
@@ -172,7 +225,98 @@ describe('useParameters desktop bridge integration', () => {
     )
   })
 
-  it('increments home and parameters resource versions only after a successful save', async () => {
+  it('polls the known parameters file while a flow is running without touching shared home data', async () => {
+    vi.useFakeTimers()
+    fetchSharedHomeData.mockResolvedValue({
+      parameters: '/workspace/demo/home/parameters.json',
+    })
+    readProjectTextFile
+      .mockResolvedValueOnce(parametersJson())
+      .mockResolvedValueOnce(parametersJson({
+        Die: { Size: [], Area: 0 },
+        Core: {
+          Size: [],
+          Area: 0,
+          'Bounding box': '',
+          Utilitization: 0.5,
+          Margin: [4, 4],
+          'Aspect ratio': 1,
+        },
+      }))
+
+    const scope = effectScope()
+    const parameters = scope.run(() => useParameters())!
+
+    try {
+      await vi.waitFor(() => {
+        expect(parameters.config.die.Size).toEqual([100, 100])
+      })
+      expect(fetchSharedHomeData).toHaveBeenCalledTimes(1)
+
+      markFlowExecutionActiveForWorkspace('/workspace/demo')
+      await vi.advanceTimersByTimeAsync(1600)
+
+      await vi.waitFor(() => {
+        expect(parameters.config.die.Size).toEqual([])
+      })
+      expect(fetchSharedHomeData).toHaveBeenCalledTimes(1)
+
+      clearFlowExecutionActiveForWorkspace('/workspace/demo')
+      await vi.advanceTimersByTimeAsync(1600)
+
+      expect(readProjectTextFile).toHaveBeenCalledTimes(2)
+      expect(fetchSharedHomeData).toHaveBeenCalledTimes(1)
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('rejects parameter saves while the workspace flow is running', async () => {
+    fetchSharedHomeData.mockResolvedValue({
+      parameters: '/workspace/demo/home/parameters.json',
+    })
+    readProjectTextFile.mockResolvedValue(JSON.stringify({
+      PDK: 'ics55',
+      Design: 'demo',
+      'Top module': 'chip_top',
+      Die: { Size: [100, 100], Area: 10000 },
+      Core: {
+        Size: [80, 80],
+        Area: 6400,
+        'Bounding box': '(0,0) (80,80)',
+        Utilitization: 0.5,
+        Margin: [4, 4],
+        'Aspect ratio': 1,
+      },
+      'Max fanout': 20,
+      'Target density': 0.3,
+      'Target overflow': 0.1,
+      'Global right padding': 0,
+      'Cell padding x': 600,
+      'Routability opt flag': 1,
+      Clock: 'clk',
+      'Frequency max [MHz]': 100,
+      'Bottom layer': 'MET2',
+      'Top layer': 'MET5',
+      'PDK Root': '/pdks/ics55',
+    }))
+
+    const parameters = useParameters()
+
+    await vi.waitFor(() => {
+      expect(readProjectTextFile).toHaveBeenCalledWith('/workspace/demo/home/parameters.json')
+    })
+
+    parameters.config.design = 'blocked_update'
+    markFlowExecutionActiveForWorkspace('/workspace/demo')
+
+    await expect(parameters.saveParameters()).resolves.toBe(false)
+
+    expect(writeProjectTextFile).not.toHaveBeenCalled()
+    expect(parameters.error.value).toContain('Flow is running')
+  })
+
+  it('increments dependent resource versions only after a successful save', async () => {
     fetchSharedHomeData.mockResolvedValue({
       parameters: '/workspace/demo/home/parameters.json',
     })
@@ -216,7 +360,61 @@ describe('useParameters desktop bridge integration', () => {
 
     expect(resourceVersions.value.parameters).toBe(initialVersions.parameters + 1)
     expect(resourceVersions.value.home).toBe(initialVersions.home + 1)
+    expect(resourceVersions.value['step-config']).toBe(initialVersions['step-config'] + 1)
+    expect(resourceVersions.value.flow).toBe(initialVersions.flow + 1)
     expect(resourceVersions.value.all).toBe(initialVersions.all)
+  })
+
+  it('refreshes workspace config after saving a max fanout parameter change', async () => {
+    fetchSharedHomeData.mockResolvedValue({
+      parameters: '/workspace/demo/home/parameters.json',
+    })
+    readProjectTextFile.mockResolvedValue(JSON.stringify({
+      PDK: 'ics55',
+      Design: 'demo',
+      'Top module': 'chip_top',
+      Die: { Size: [100, 100], Area: 10000 },
+      Core: {
+        Size: [80, 80],
+        Area: 6400,
+        'Bounding box': '(0,0) (80,80)',
+        Utilitization: 0.5,
+        Margin: [4, 4],
+        'Aspect ratio': 1,
+      },
+      'Max fanout': 20,
+      'Target density': 0.3,
+      'Target overflow': 0.1,
+      'Global right padding': 0,
+      'Cell padding x': 600,
+      'Routability opt flag': 1,
+      Clock: 'clk',
+      'Frequency max [MHz]': 100,
+      'Bottom layer': 'MET2',
+      'Top layer': 'MET5',
+      'PDK Root': '/pdks/ics55',
+    }))
+
+    const parameters = useParameters()
+
+    await vi.waitFor(() => {
+      expect(readProjectTextFile).toHaveBeenCalledWith('/workspace/demo/home/parameters.json')
+    })
+
+    parameters.config.maxFanout = 64
+
+    await expect(parameters.saveParameters()).resolves.toBe(true)
+
+    expect(writeProjectTextFile).toHaveBeenCalledWith(
+      '/workspace/demo/home/parameters.json',
+      expect.stringContaining('"Max fanout": 64'),
+    )
+    expect(refreshConfigApi).toHaveBeenCalledWith({
+      cmd: 'refresh_config',
+      data: {
+        directory: '/workspace/demo',
+      },
+    })
   })
 
   it('does not increment home or parameters resource versions when save fails', async () => {
@@ -263,6 +461,57 @@ describe('useParameters desktop bridge integration', () => {
     await expect(parameters.saveParameters()).resolves.toBe(false)
 
     expect(resourceVersions.value).toEqual(initialVersions)
+  })
+
+  it('keeps written parameters as the baseline when refresh config fails after save', async () => {
+    fetchSharedHomeData.mockResolvedValue({
+      parameters: '/workspace/demo/home/parameters.json',
+    })
+    readProjectTextFile.mockResolvedValue(JSON.stringify({
+      PDK: 'ics55',
+      Design: 'demo',
+      'Top module': 'chip_top',
+      Die: { Size: [100, 100], Area: 10000 },
+      Core: {
+        Size: [80, 80],
+        Area: 6400,
+        'Bounding box': '(0,0) (80,80)',
+        Utilitization: 0.5,
+        Margin: [4, 4],
+        'Aspect ratio': 1,
+      },
+      'Max fanout': 20,
+      'Target density': 0.3,
+      'Target overflow': 0.1,
+      'Global right padding': 0,
+      'Cell padding x': 600,
+      'Routability opt flag': 1,
+      Clock: 'clk',
+      'Frequency max [MHz]': 100,
+      'Bottom layer': 'MET2',
+      'Top layer': 'MET5',
+      'PDK Root': '/pdks/ics55',
+    }))
+    refreshConfigApi.mockResolvedValue({
+      cmd: 'refresh_config',
+      data: { directory: '/workspace/demo', refreshed: false },
+      message: ['refresh failed'],
+      response: 'error',
+    })
+
+    const parameters = useParameters()
+
+    await vi.waitFor(() => {
+      expect(readProjectTextFile).toHaveBeenCalledWith('/workspace/demo/home/parameters.json')
+    })
+
+    parameters.config.design = 'updated_demo'
+
+    await expect(parameters.saveParameters()).resolves.toBe(false)
+
+    expect(writeProjectTextFile).toHaveBeenCalled()
+    expect(parameters.hasChanges.value).toBe(false)
+    expect(parameters.error.value).toBe('refresh failed')
   })
 
   it('does not invalidate the new workspace when an old save resolves after a session switch', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useParameters.ts
+++ b/ecos/gui/apps/renderer/src/composables/useParameters.ts
@@ -1,10 +1,13 @@
-import { ref, reactive, watch, computed } from 'vue'
+import { ref, reactive, watch, computed, getCurrentScope, onScopeDispose } from 'vue'
 import { useWorkspace } from './useWorkspace'
 import { useDesktopRuntime } from './useDesktopRuntime'
 import { fetchSharedHomeData, convertRemoteToLocalPath } from './useHomeData'
 import { resolveProjectPathAccess } from '@/utils/projectFs'
 import { readProjectTextFile, writeProjectTextFile } from '@/utils/projectFiles'
 import { useWorkspaceLifecycle } from './useWorkspaceLifecycle'
+import { isFlowExecutionActiveForWorkspace } from './useFlowRunner'
+import { refreshConfigApi } from '@/api/flow'
+import { CMDEnum, ResponseEnum } from '@/api/type'
 
 // ============ 类型定义 ============
 // 与 ecc/chipcompiler/data/parameter.py 中 ICS55_PARAMETERS_TEMPLATE 及 workspace 写入的 PDK Root 对齐
@@ -70,6 +73,9 @@ export interface ConfigData {
 
 /** 用于 Bottom/Top 金属层下拉的常见顺序（与 PDK 文档一致即可） */
 const ROUTING_LAYER_ORDER = ['LI1', 'MET1', 'MET2', 'MET3', 'MET4', 'MET5', 'MET6', 'MET7', 'MET8']
+const FLOW_RUNNING_SAVE_BLOCKED_MESSAGE =
+  'Flow is running. Configuration is read-only until the current run finishes.'
+const RUNNING_FLOW_PARAMETERS_POLL_MS = 1600
 
 function getDefaultConfig(): ConfigData {
   return {
@@ -97,6 +103,10 @@ function getDefaultConfig(): ConfigData {
     bottomLayer: 'MET2',
     topLayer: 'MET5'
   }
+}
+
+function firstResponseMessage(response: { message?: string[] } | undefined, fallback: string): string {
+  return response?.message?.[0] || fallback
 }
 
 function normalizeDie(d: unknown): ParametersData['Die'] {
@@ -240,6 +250,7 @@ export function useParameters() {
   const isSaving = ref(false)
   const error = ref<string | null>(null)
   const hasChanges = ref(false)
+  const isMutationLocked = computed(() => isFlowExecutionActiveForWorkspace(currentProject.value?.path))
 
   let originalConfig: string = ''
   let resolvedParametersPath: string = ''
@@ -248,6 +259,12 @@ export function useParameters() {
   let activeSaveRequestId = 0
   let parametersResourceToken = 0
   let saveWriteQueue: Promise<void> = Promise.resolve()
+  let runningFlowParametersPollTimer: ReturnType<typeof setInterval> | null = null
+  let runningFlowParametersPollInFlight = false
+
+  function fallbackParametersPath(projectPath: string): string {
+    return `${projectPath}/home/parameters.json`
+  }
 
   function advanceParametersResourceToken(): number {
     parametersResourceToken += 1
@@ -273,6 +290,11 @@ export function useParameters() {
     return projectPath ? convertRemoteToLocalPath(remotePath, projectPath) : remotePath
   }
 
+  function keepLastParametersDuringFlowReload(): boolean {
+    if (!currentProject.value?.path) return false
+    return Boolean(originalConfig) && isFlowExecutionActiveForWorkspace(currentProject.value.path)
+  }
+
   function isSaveContextCurrent(options: {
     sessionId: string
     requestId: number
@@ -287,6 +309,98 @@ export function useParameters() {
       && resolvedParametersPath === options.parametersPath
       && currentProject.value?.path === options.projectPath
     )
+  }
+
+  function blockSaveWhileFlowRunning(projectPath = currentProject.value?.path): boolean {
+    if (!isFlowExecutionActiveForWorkspace(projectPath)) return false
+    error.value = FLOW_RUNNING_SAVE_BLOCKED_MESSAGE
+    return true
+  }
+
+  function applyParametersFileContent(fileContent: string): void {
+    const parametersData = parseParametersData(fileContent)
+
+    console.log('Loaded parameters data:', parametersData)
+
+    const transformedConfig = transformParametersToConfig(parametersData)
+    const nextConfigSnapshot = JSON.stringify(transformedConfig)
+    if (nextConfigSnapshot === originalConfig) {
+      hasChanges.value = false
+      return
+    }
+
+    Object.assign(config, transformedConfig)
+    console.log('Loaded config:', config)
+    originalConfig = JSON.stringify(config)
+    hasChanges.value = false
+
+    console.log('Parameters loaded:', config)
+  }
+
+  async function reloadParametersFromKnownPathIfRunning(): Promise<boolean> {
+    const projectPath = currentProject.value?.path
+    if (!projectPath || !isFlowExecutionActiveForWorkspace(projectPath)) return false
+
+    const sessionId = workspaceLifecycle.currentSessionId.value
+    const knownPath = resolvedParametersPath || fallbackParametersPath(projectPath)
+    isLoading.value = true
+    error.value = null
+    const loadResourceToken = advanceParametersResourceToken()
+
+    try {
+      const resolvedPath = await workspaceLifecycle.runForSession(
+        sessionId,
+        () => resolveProjectPathAccess(knownPath),
+      )
+      if (resolvedPath === undefined && !workspaceLifecycle.isCurrentSession(sessionId)) return true
+      if (!resolvedPath) {
+        if (keepLastParametersDuringFlowReload()) return true
+        resetParametersState()
+        return true
+      }
+
+      const fileContent = await workspaceLifecycle.runForSession(
+        sessionId,
+        () => readProjectTextFile(resolvedPath),
+      )
+      if (fileContent === undefined && !workspaceLifecycle.isCurrentSession(sessionId)) return true
+      if (fileContent === undefined) return true
+      if (loadResourceToken !== parametersResourceToken) return true
+
+      resolvedParametersPath = resolvedPath
+      applyParametersFileContent(fileContent)
+      return true
+    } catch (err) {
+      if (!workspaceLifecycle.isCurrentSession(sessionId)) return true
+      console.error('Failed to reload running flow parameters:', err)
+      if (!keepLastParametersDuringFlowReload()) {
+        error.value = err instanceof Error ? err.message : String(err)
+        resetParametersState()
+      }
+      return true
+    } finally {
+      if (workspaceLifecycle.isCurrentSession(sessionId)) {
+        isLoading.value = false
+      }
+    }
+  }
+
+  function stopRunningFlowParametersPoll(): void {
+    if (runningFlowParametersPollTimer == null) return
+    clearInterval(runningFlowParametersPollTimer)
+    runningFlowParametersPollTimer = null
+    runningFlowParametersPollInFlight = false
+  }
+
+  function startRunningFlowParametersPoll(): void {
+    if (runningFlowParametersPollTimer != null) return
+    runningFlowParametersPollTimer = setInterval(() => {
+      if (runningFlowParametersPollInFlight || hasChanges.value) return
+      runningFlowParametersPollInFlight = true
+      void reloadParametersFromKnownPathIfRunning().finally(() => {
+        runningFlowParametersPollInFlight = false
+      })
+    }, RUNNING_FLOW_PARAMETERS_POLL_MS)
   }
 
   async function loadParameters(): Promise<void> {
@@ -315,12 +429,14 @@ export function useParameters() {
       if (homeData === undefined && !workspaceLifecycle.isCurrentSession(sessionId)) return
       if (!homeData) {
         console.warn('Failed to get home data')
+        if (keepLastParametersDuringFlowReload()) return
         resetParametersState()
         return
       }
 
       if (!homeData.parameters) {
         console.warn('No parameters field found in home.json')
+        if (keepLastParametersDuringFlowReload()) return
         resetParametersState()
         return
       }
@@ -333,6 +449,7 @@ export function useParameters() {
       if (resolvedPath === undefined && !workspaceLifecycle.isCurrentSession(sessionId)) return
       console.log('Loading parameters from:', resolvedPath ?? parametersPath)
       if (!resolvedPath) {
+        if (keepLastParametersDuringFlowReload()) return
         resetParametersState()
         return
       }
@@ -343,20 +460,11 @@ export function useParameters() {
       )
       if (fileContent === undefined && !workspaceLifecycle.isCurrentSession(sessionId)) return
       if (fileContent === undefined) return
-      const parametersData = parseParametersData(fileContent)
-
-      console.log('Loaded parameters data:', parametersData)
 
       if (loadResourceToken !== parametersResourceToken) return
       resolvedParametersPath = resolvedPath
 
-      const transformedConfig = transformParametersToConfig(parametersData)
-      Object.assign(config, transformedConfig)
-      console.log('Loaded config:', config)
-      originalConfig = JSON.stringify(config)
-      hasChanges.value = false
-
-      console.log('Parameters loaded:', config)
+      applyParametersFileContent(fileContent)
     } catch (err) {
       if (!workspaceLifecycle.isCurrentSession(sessionId)) return
       console.error('Failed to load parameters:', err)
@@ -377,6 +485,10 @@ export function useParameters() {
 
     if (!resolvedParametersPath) {
       console.warn('Parameters file path is not resolved. Call loadParameters first.')
+      return false
+    }
+
+    if (blockSaveWhileFlowRunning()) {
       return false
     }
 
@@ -404,6 +516,9 @@ export function useParameters() {
           parametersPath: saveParametersPath,
           projectPath: saveProjectPath,
         })) {
+          return
+        }
+        if (blockSaveWhileFlowRunning(saveProjectPath)) {
           return
         }
         console.log('Saving parameters to:', saveParametersPath)
@@ -436,7 +551,32 @@ export function useParameters() {
       } else {
         hasChanges.value = true
       }
-      invalidateWorkspaceResources(['parameters', 'home'], { sessionId: saveSessionId })
+
+      const refreshResult = await workspaceLifecycle.runForSession(
+        saveSessionId,
+        () => refreshConfigApi({
+          cmd: CMDEnum.refresh_config,
+          data: {
+            directory: saveProjectPath,
+          },
+        }),
+      )
+      if (!isSaveContextCurrent({
+        sessionId: saveSessionId,
+        requestId: saveRequestId,
+        resourceToken: saveResourceToken,
+        parametersPath: saveParametersPath,
+        projectPath: saveProjectPath,
+      })) {
+        return refreshResult?.response === ResponseEnum.success
+      }
+
+      invalidateWorkspaceResources(['parameters', 'home', 'step-config', 'flow'], { sessionId: saveSessionId })
+
+      if (refreshResult?.response !== ResponseEnum.success) {
+        error.value = firstResponseMessage(refreshResult, 'Refresh workspace config failed')
+        return false
+      }
 
       console.log('Parameters saved successfully')
       return true
@@ -478,6 +618,7 @@ export function useParameters() {
   }
 
   async function refreshParameters(): Promise<void> {
+    if (await reloadParametersFromKnownPathIfRunning()) return
     await loadParameters()
   }
 
@@ -486,6 +627,7 @@ export function useParameters() {
       console.warn('Skip automatic parameters reload because there are unsaved changes')
       return
     }
+    if (await reloadParametersFromKnownPathIfRunning()) return
     await loadParameters()
   }
 
@@ -501,6 +643,7 @@ export function useParameters() {
     () => currentProject.value?.path,
     async (newPath) => {
       isSaving.value = false
+      stopRunningFlowParametersPoll()
       if (newPath) {
         await loadParameters()
       } else {
@@ -520,6 +663,25 @@ export function useParameters() {
       await reloadParametersIfClean()
     },
   )
+
+  if (getCurrentScope()) {
+    const stopFlowExecutionWatch = watch(
+      () => isFlowExecutionActiveForWorkspace(currentProject.value?.path),
+      (active) => {
+        if (active) {
+          startRunningFlowParametersPoll()
+        } else {
+          stopRunningFlowParametersPoll()
+        }
+      },
+      { immediate: true },
+    )
+
+    onScopeDispose(() => {
+      stopFlowExecutionWatch()
+      stopRunningFlowParametersPoll()
+    })
+  }
 
   const layerOptions = computed(() => {
     return ROUTING_LAYER_ORDER.map(layer => ({ label: layer, value: layer }))
@@ -549,6 +711,7 @@ export function useParameters() {
     isSaving,
     error,
     hasChanges,
+    isMutationLocked,
     layerOptions,
     layersList,
     isLayerInRange,

--- a/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.test.ts
@@ -6,6 +6,7 @@ const testState = vi.hoisted(() => ({
   route: {
     path: '/workspace/floorplan',
   },
+  syncConfigApi: vi.fn(),
   writeProjectTextFile: vi.fn(),
 }))
 
@@ -45,7 +46,15 @@ vi.mock('@/utils/projectFs', () => ({
   resolveProjectPathAccess: testState.resolveProjectPathAccess,
 }))
 
+vi.mock('@/api/flow', () => ({
+  syncConfigApi: testState.syncConfigApi,
+}))
+
 import { useStepConfigInfo } from './useStepConfigInfo'
+import {
+  clearFlowExecutionActiveForWorkspace,
+  markFlowExecutionActiveForWorkspace,
+} from './useFlowRunner'
 import { useWorkspaceLifecycle } from './useWorkspaceLifecycle'
 
 describe('useStepConfigInfo', () => {
@@ -65,7 +74,20 @@ describe('useStepConfigInfo', () => {
     testState.readProjectTextFile.mockReset()
     testState.resolveProjectPathAccess.mockClear()
     testState.resolveWorkspaceStepInfoApi.mockReset()
+    testState.syncConfigApi.mockReset()
+    testState.syncConfigApi.mockResolvedValue({
+      cmd: 'sync_config',
+      data: {
+        config_path: '/workspace/demo/config/fp_default_config.json',
+        directory: '/workspace/demo',
+        parameters_changed: false,
+        refreshed: false,
+      },
+      message: ['synced'],
+      response: 'success',
+    })
     testState.writeProjectTextFile.mockReset()
+    clearFlowExecutionActiveForWorkspace('/workspace/demo')
   })
 
   afterEach(() => {
@@ -326,11 +348,129 @@ describe('useStepConfigInfo', () => {
       '/workspace/demo/config/fp_default_config.json',
       '{\n    "density": 0.6\n}',
     )
+    expect(testState.syncConfigApi).toHaveBeenCalledWith({
+      cmd: 'sync_config',
+      data: {
+        config_path: '/workspace/demo/config/fp_default_config.json',
+        directory: '/workspace/demo',
+      },
+    })
     expect(lifecycle.resourceVersions.value['step-config']).toBe(stepConfigVersionBeforeSave + 1)
     await vi.waitFor(() => {
       expect(result.stepConfigRaw.value).toBe('{\n    "density": 0.6\n}')
       expect(result.hasStepConfigChanges.value).toBe(false)
     })
+  })
+
+  it('rejects step config saves while the workspace flow is running', async () => {
+    testState.resolveWorkspaceStepInfoApi.mockResolvedValue({
+      response: 'available',
+      info: {
+        config: '/workspace/demo/config/fp_default_config.json',
+      },
+      missing: [],
+      message: [],
+      id: 'config',
+      step: 'Floorplan',
+    })
+    testState.readProjectTextFile.mockResolvedValue('{"density":0.5}')
+
+    const result = scope.run(() => useStepConfigInfo())!
+
+    await vi.waitFor(() => {
+      expect(result.stepConfigDraft.value).toEqual({ density: 0.5 })
+    })
+
+    result.stepConfigDraft.value = { density: 0.7 }
+    markFlowExecutionActiveForWorkspace('/workspace/demo')
+
+    await expect(result.saveStepConfig()).resolves.toBe(false)
+
+    expect(testState.writeProjectTextFile).not.toHaveBeenCalled()
+    expect(result.stepConfigSaveError.value).toContain('Flow is running')
+  })
+
+  it('invalidates parameters and home when step config sync changes parameters', async () => {
+    testState.resolveWorkspaceStepInfoApi.mockResolvedValue({
+      response: 'available',
+      info: {
+        config: '/workspace/demo/config/rt_default_config.json',
+      },
+      missing: [],
+      message: [],
+      id: 'config',
+      step: 'route',
+    })
+    testState.readProjectTextFile
+      .mockResolvedValueOnce('{"RT":{"-bottom_routing_layer":"MET2"}}')
+      .mockResolvedValue('{\n    "RT": {\n        "-bottom_routing_layer": "MET4"\n    }\n}')
+    testState.syncConfigApi.mockResolvedValue({
+      cmd: 'sync_config',
+      data: {
+        config_path: '/workspace/demo/config/rt_default_config.json',
+        directory: '/workspace/demo',
+        parameters_changed: true,
+        refreshed: true,
+      },
+      message: ['synced'],
+      response: 'success',
+    })
+
+    testState.route.path = '/workspace/route'
+    const result = scope.run(() => useStepConfigInfo())!
+
+    await vi.waitFor(() => {
+      expect(result.stepConfigDraft.value).toEqual({ RT: { '-bottom_routing_layer': 'MET2' } })
+    })
+
+    const lifecycle = useWorkspaceLifecycle()
+    const initialVersions = { ...lifecycle.resourceVersions.value }
+    result.stepConfigDraft.value = { RT: { '-bottom_routing_layer': 'MET4' } }
+
+    await expect(result.saveStepConfig()).resolves.toBe(true)
+
+    expect(lifecycle.resourceVersions.value['step-config']).toBe(initialVersions['step-config'] + 1)
+    expect(lifecycle.resourceVersions.value.parameters).toBe(initialVersions.parameters + 1)
+    expect(lifecycle.resourceVersions.value.home).toBe(initialVersions.home + 1)
+  })
+
+  it('keeps written step config as the baseline when sync config fails after save', async () => {
+    testState.resolveWorkspaceStepInfoApi.mockResolvedValue({
+      response: 'available',
+      info: {
+        config: '/workspace/demo/config/fp_default_config.json',
+      },
+      missing: [],
+      message: [],
+      id: 'config',
+      step: 'Floorplan',
+    })
+    testState.readProjectTextFile.mockResolvedValue('{"density":0.5}')
+    testState.syncConfigApi.mockResolvedValue({
+      cmd: 'sync_config',
+      data: {
+        config_path: '/workspace/demo/config/fp_default_config.json',
+        directory: '/workspace/demo',
+        parameters_changed: false,
+        refreshed: false,
+      },
+      message: ['sync failed'],
+      response: 'error',
+    })
+
+    const result = scope.run(() => useStepConfigInfo())!
+
+    await vi.waitFor(() => {
+      expect(result.stepConfigDraft.value).toEqual({ density: 0.5 })
+    })
+
+    result.stepConfigDraft.value = { density: 0.9 }
+
+    await expect(result.saveStepConfig()).resolves.toBe(false)
+
+    expect(testState.writeProjectTextFile).toHaveBeenCalled()
+    expect(result.hasStepConfigChanges.value).toBe(false)
+    expect(result.stepConfigSaveError.value).toBe('sync failed')
   })
 
   it('ignores stale step config save completions after the workspace session changes', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.ts
+++ b/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.ts
@@ -1,6 +1,7 @@
 import { ref, computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
-import { InfoEnum, StepEnum } from '@/api/type'
+import { CMDEnum, InfoEnum, ResponseEnum, StepEnum } from '@/api/type'
+import { syncConfigApi } from '@/api/flow'
 import { resolveWorkspaceStepInfoApi } from '@/api/workspaceResources'
 import { convertRemoteToLocalPath } from '@/composables/useHomeData'
 import { readProjectTextFile, writeProjectTextFile } from '@/utils/projectFiles'
@@ -8,8 +9,11 @@ import { resolveProjectPathAccess } from '@/utils/projectFs'
 import { useDesktopRuntime } from '@/composables/useDesktopRuntime'
 import { useWorkspace } from '@/composables/useWorkspace'
 import { useWorkspaceLifecycle } from '@/composables/useWorkspaceLifecycle'
+import { isFlowExecutionActiveForWorkspace } from './useFlowRunner'
 
 const stepEnumValues = Object.values(StepEnum)
+const FLOW_RUNNING_SAVE_BLOCKED_MESSAGE =
+  'Flow is running. Configuration is read-only until the current run finishes.'
 
 function getStepEnumFromPath(path: string): StepEnum | undefined {
   return stepEnumValues.find((step) => step.toLowerCase() === path.toLowerCase())
@@ -52,6 +56,10 @@ function pickStepConfigPathFromInfo(data: Record<string, unknown>): string | und
   return typeof v === 'string' && v.trim() ? v.trim() : undefined
 }
 
+function firstResponseMessage(response: { message?: string[] } | undefined, fallback: string): string {
+  return response?.message?.[0] || fallback
+}
+
 export function useStepConfigInfo() {
   const route = useRoute()
   const { isDesktopRuntimeAvailable } = useDesktopRuntime()
@@ -81,6 +89,7 @@ export function useStepConfigInfo() {
   const isSavingStepConfig = ref(false)
   const activeStepConfigSave = ref<symbol | null>(null)
   const stepConfigSaveError = ref<string | null>(null)
+  const isMutationLocked = computed(() => isFlowExecutionActiveForWorkspace(currentProject.value?.path))
   let activeRefetchToken: symbol | null = null
   let lastLoadedStep: StepEnum | null = null
 
@@ -352,6 +361,12 @@ export function useStepConfigInfo() {
     return stableJsonSig(stepConfigDraft.value) !== stepConfigBaselineSig.value
   })
 
+  function blockStepConfigSaveWhileFlowRunning(): boolean {
+    if (!isMutationLocked.value) return false
+    stepConfigSaveError.value = FLOW_RUNNING_SAVE_BLOCKED_MESSAGE
+    return true
+  }
+
   async function saveStepConfig(): Promise<boolean> {
     stepConfigSaveError.value = null
     const path = stepConfigPathResolved.value
@@ -374,6 +389,9 @@ export function useStepConfigInfo() {
       stepConfigSaveError.value = 'Saving requires the ECOS Studio desktop runtime'
       return false
     }
+    if (blockStepConfigSaveWhileFlowRunning()) {
+      return false
+    }
     const rawBeforeSave = stepConfigRaw.value
     const textDraftBeforeSave = stepConfigTextDraft.value
     const draftBeforeSave = stepConfigDraft.value === null ? null : deepClone(stepConfigDraft.value)
@@ -389,6 +407,50 @@ export function useStepConfigInfo() {
         stepConfigSaveError.value = `No file-system access to ${path}`
         return false
       }
+      if (blockStepConfigSaveWhileFlowRunning()) {
+        return false
+      }
+
+      const syncWorkspaceConfig = async (): Promise<boolean> => {
+        const projectPath = currentProject.value?.path
+        if (!projectPath) {
+          stepConfigSaveError.value = 'No workspace is open'
+          return false
+        }
+        const syncResult = await workspaceLifecycle.runForSession(
+          sessionId,
+          () => syncConfigApi({
+            cmd: CMDEnum.sync_config,
+            data: {
+              config_path: resolvedPath,
+              directory: projectPath,
+            },
+          }),
+        )
+        if (!canApply()) return false
+
+        workspaceLifecycle.invalidate('step-config', {
+          reason: 'step-config-save',
+          sessionId,
+          step,
+        })
+
+        if (syncResult?.data?.parameters_changed === true) {
+          workspaceLifecycle.invalidate(['parameters', 'home'], {
+            reason: 'step-config-sync',
+            sessionId,
+            step,
+          })
+        }
+
+        if (syncResult?.response !== ResponseEnum.success) {
+          stepConfigSaveError.value = firstResponseMessage(syncResult, 'Sync workspace config failed')
+          return false
+        }
+
+        return true
+      }
+
       let text: string
       if (!rawLooksValidJson(rawBeforeSave ?? '')) {
         text = textDraftBeforeSave
@@ -402,12 +464,7 @@ export function useStepConfigInfo() {
         if (!canApply() || writeResult !== true) return false
         stepConfigRaw.value = text
         stepConfigTextBaseline.value = text
-        workspaceLifecycle.invalidate('step-config', {
-          reason: 'step-config-save',
-          sessionId,
-          step,
-        })
-        return true
+        return await syncWorkspaceConfig()
       }
       if (draftBeforeSave === null) {
         stepConfigSaveError.value = 'Nothing to save'
@@ -424,12 +481,7 @@ export function useStepConfigInfo() {
       if (!canApply() || writeResult !== true) return false
       stepConfigRaw.value = text
       stepConfigBaselineSig.value = stableJsonSig(draftBeforeSave)
-      workspaceLifecycle.invalidate('step-config', {
-        reason: 'step-config-save',
-        sessionId,
-        step,
-      })
-      return true
+      return await syncWorkspaceConfig()
     } catch (e) {
       if (!canApply()) return false
       stepConfigSaveError.value = e instanceof Error ? e.message : String(e)
@@ -469,6 +521,7 @@ export function useStepConfigInfo() {
     hasStepConfigChanges,
     isSavingStepConfig,
     stepConfigSaveError,
+    isMutationLocked,
     saveStepConfig,
     resetStepConfig,
     reloadStepConfigFiles,

--- a/ecos/gui/apps/renderer/src/composables/useWorkspace.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useWorkspace.test.ts
@@ -15,6 +15,8 @@ const {
   toastAddMock,
   waitForRuntimeReadyMock,
   waitForDesktopApiMock,
+  requestHomeRunArtifactResetMock,
+  clearHomeRunArtifactResetAwaitingBackendStartMock,
 } = vi.hoisted(() => ({
   createRuntimeEventClientMock: vi.fn(),
   createWorkspaceApiMock: vi.fn(),
@@ -28,6 +30,8 @@ const {
   toastAddMock: vi.fn(),
   waitForRuntimeReadyMock: vi.fn(),
   waitForDesktopApiMock: vi.fn(),
+  requestHomeRunArtifactResetMock: vi.fn(),
+  clearHomeRunArtifactResetAwaitingBackendStartMock: vi.fn(),
 }))
 
 vi.mock('vue-router', () => ({
@@ -71,6 +75,11 @@ vi.mock('@/stores/messageStore', () => ({
   useMessageStore: () => ({
     clearMessages: clearMessagesMock,
   }),
+}))
+
+vi.mock('./homeRunArtifacts', () => ({
+  requestHomeRunArtifactReset: requestHomeRunArtifactResetMock,
+  clearHomeRunArtifactResetAwaitingBackendStart: clearHomeRunArtifactResetAwaitingBackendStartMock,
 }))
 
 import { useWorkspace } from './useWorkspace'
@@ -170,6 +179,7 @@ describe('useWorkspace openProject', () => {
     toastAddMock.mockReset()
     waitForRuntimeReadyMock.mockReset()
     waitForDesktopApiMock.mockReset()
+    requestHomeRunArtifactResetMock.mockReset()
     settingsData.clear()
 
     desktopApi = createDesktopApiMock()
@@ -1636,6 +1646,25 @@ describe('useWorkspace openProject', () => {
     expect(workspace.resourceVersions.value.flow).toBe(before.flow + 1)
     expect(workspace.resourceVersions.value.maps).toBe(before.maps + 1)
     expect(workspace.resourceVersions.value.logs).toBe(before.logs + 1)
+  })
+
+  it('requests Home artifact reset when backend reports rerun start', async () => {
+    const workspace = await openWorkspaceAndConnectRuntimeEvents()
+
+    onRuntimeEvent?.({
+      cmd: 'notify',
+      data: {
+        type: 'message',
+        cmd: 'rtl2gds',
+        directory: '/work/demo',
+        rerun: true,
+      },
+      message: ['Started rtl2gds'],
+      response: 'success',
+    })
+
+    expect(workspace.runtimeEvents.value).toHaveLength(1)
+    expect(requestHomeRunArtifactResetMock).toHaveBeenCalledWith('/work/demo')
   })
 
   it('keeps the workspace loading overlay visible while a new workspace is being created', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useWorkspace.ts
+++ b/ecos/gui/apps/renderer/src/composables/useWorkspace.ts
@@ -19,6 +19,10 @@ import {
   readWorkspaceHomeResourceApi,
   readWorkspaceParametersResourceApi,
 } from '@/api/workspaceResources'
+import {
+  clearHomeRunArtifactResetAwaitingBackendStart,
+  requestHomeRunArtifactReset,
+} from './homeRunArtifacts'
 
 interface SerializedProject {
   id: string
@@ -813,6 +817,15 @@ export function useWorkspace() {
       // 过滤心跳消息，不记录到 messages
       if (response.data?.type !== 'heartbeat') {
         runtimeEvents.value.push(response)
+        if (isRtl2gdsRerunStartEvent(response)) {
+          const resetProjectPath = asString(response.data.workspaceId)
+            ?? asString(response.data.directory)
+            ?? currentProject.value?.path
+          if (resetProjectPath) {
+            clearHomeRunArtifactResetAwaitingBackendStart(resetProjectPath)
+            requestHomeRunArtifactReset(resetProjectPath)
+          }
+        }
         invalidateResourcesForRuntimeEvent(response, sessionId)
       }
     })
@@ -907,6 +920,13 @@ export function useWorkspace() {
     }
 
     return [...scopes]
+  }
+
+  function isRtl2gdsRerunStartEvent(response: RuntimeEventResponse): boolean {
+    const event = response.data
+    return event?.cmd === 'rtl2gds'
+      && event.type === 'message'
+      && event.rerun === true
   }
 
   function invalidateResourcesForRuntimeEvent(response: RuntimeEventResponse, sessionId: string): void {

--- a/ecos/gui/apps/renderer/src/views/ConfigureView.vue
+++ b/ecos/gui/apps/renderer/src/views/ConfigureView.vue
@@ -12,6 +12,7 @@ const {
   isSaving,
   error,
   hasChanges,
+  isMutationLocked,
   saveParameters,
   resetParameters,
   refreshParameters,
@@ -61,11 +62,11 @@ const resetConfig = () => {
           <i class="ri-refresh-line"></i>
           Reload
         </button>
-        <button class="btn-text" @click="resetConfig" :disabled="!hasChanges || isLoading">
+        <button class="btn-text" @click="resetConfig" :disabled="!hasChanges || isLoading || isMutationLocked">
           <i class="ri-arrow-go-back-line"></i>
           Reset
         </button>
-        <button class="btn-primary" @click="saveConfig" :disabled="!hasChanges || isSaving">
+        <button class="btn-primary" @click="saveConfig" :disabled="!hasChanges || isSaving || isMutationLocked">
           <i :class="isSaving ? 'ri-loader-4-line spin' : 'ri-save-line'"></i>
           {{ isSaving ? 'Saving...' : 'Save' }}
         </button>

--- a/ecos/gui/packages/shared/src/contracts/desktopCli.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopCli.ts
@@ -7,6 +7,8 @@ export type DesktopCliCommandName =
   | 'rtl2gds'
   | 'get_info'
   | 'home_page'
+  | 'refresh_config'
+  | 'sync_config'
 
 export type DesktopCliCommandSource = 'button' | 'menu' | 'terminal' | 'test'
 
@@ -44,6 +46,7 @@ export interface DesktopCliCommandEvent {
   jobId: string
   cmd: DesktopCliCommandName
   type: DesktopCliCommandEventType
+  data?: Record<string, unknown>
   workspaceId?: string
   directory?: string
   stream?: 'stdout' | 'stderr' | 'system'


### PR DESCRIPTION
## Summary
- Add desktop CLI bridge support for `refresh_config` and `sync_config`, including renderer APIs and shared command contracts.
- Guard parameter and step-config saves while a workspace flow is active, then refresh/sync workspace config and invalidate dependent GUI resources after successful saves.
- Add rerun mode handling from the left sidebar, propagate rerun startup metadata, and reset/reload stale home, flow, parameters, and stage artifacts during flow restart.
- Use the source-tree ECC virtualenv for desktop Electron development runtime resolution.
- Update both the `ecc` submodule pointer and Bazel `@ecc` packaged CLI override to ECC PR #113 commit `125e39c`, so GUI AppImage CI builds package the matching CLI changes before the ECC PR lands.

## Commits
- `fix(gui): use source-tree ecc venv in development`
  - Resolves desktop Electron dev runtime lookup to the source-tree ECC virtualenv.
- `feat(gui): add workspace config sync bridge`
  - Adds desktop CLI command contracts, adapter support, and renderer APIs for `refresh_config` and `sync_config`.
- `feat(gui): guard active config saves`
  - Blocks parameter/step-config writes while a workspace flow is running, refreshes/syncs config after saves, and invalidates dependent resources.
- `feat(gui): reset rerun artifacts during flow restart`
  - Adds ReRun mode UI wiring, propagates rerun startup metadata, and reloads/reset home, flow, parameter, stage, and workspace artifacts.
- `chore(gui): update ecc submodule for workspace sync`
  - Points the GUI PR checkout at the ECC companion branch commit that adds workspace config refresh/sync and rerun artifact preparation.
- `build(gui): pin packaged ecc cli to workspace sync commit`
  - Points Bazel `@ecc//:build_ecc_cli_bundle` at the same ECC companion commit and refreshes the Bazel module lock digests, so AppImage packaging uses the matching CLI bundle.

## Tests
- `pnpm exec vitest run electron/services/eccCliRuntime.test.ts electron/services/desktopRuntimeManager.test.ts electron/services/eccCliAdapter.test.ts electron/services/workspaceService.test.ts --silent` from `ecos/gui/apps/desktop-electron`
- `pnpm exec vitest run src/api/flow.desktop-ipc.test.ts src/api/runtimeEvents.desktop-cli.test.ts src/composables/useFlowRunner.test.ts src/composables/useFlowRunMode.test.ts src/composables/useFlowStages.live-watch.test.ts src/composables/useHomeData.live-watch.test.ts src/composables/useParameters.runtime.test.ts src/composables/useStepConfigInfo.test.ts src/composables/useWorkspace.test.ts --silent` from `ecos/gui/apps/renderer`
- `.venv/bin/python -m chipcompiler.cli.main workspace refresh-config --help`, `.venv/bin/python -m chipcompiler.cli.main workspace sync-config --help`, and `.venv/bin/python -m chipcompiler.cli.main workspace run-flow --help` from `ecc`
- `python3 - <<'PY' ...` check that `MODULE.bazel` pins `@ecc` to `125e39c6559b4440d79505a3685b6b04a28519f9`
- `bazel cquery --output=label @ecc//:build_ecc_cli_bundle`
- `git diff --check HEAD~1..HEAD`

## Related PRs
- ECC companion PR: https://github.com/openecos-projects/ecc/pull/113

## Notes
- This PR intentionally points both the checked-out `ecc` submodule and the Bazel packaged CLI input at ECC companion PR branch commit `125e39c6559b4440d79505a3685b6b04a28519f9`. After ECC #113 merges, reconcile both pointers to the merged ECC commit if GitHub creates a different merge commit.
