### PR TITLE
fix(gui): keep topbar dropdown above content controls

### DIFF
--- a/ecos/gui/apps/renderer/src/components/TopBar.test.ts
+++ b/ecos/gui/apps/renderer/src/components/TopBar.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import topBarSource from './TopBar.vue?raw'
 
+function getCssDeclaration(selector: string, property: string): string | null {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const blockMatch = topBarSource.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`))
+  if (!blockMatch) return null
+
+  const declarationMatch = blockMatch[1].match(new RegExp(`${property}\\s*:\\s*([^;]+);`))
+  return declarationMatch?.[1].trim() ?? null
+}
+
 describe('TopBar drag region layout', () => {
   it('offers a home button that routes back to ECOSView', () => {
     expect(topBarSource).toContain('class="home-btn"')
@@ -14,5 +23,11 @@ describe('TopBar drag region layout', () => {
 
   it('keeps the centered title overlay pointer-transparent', () => {
     expect(topBarSource).toMatch(/\.topbar-center\s*\{[\s\S]*pointer-events:\s*none;/)
+  })
+
+  it('keeps dropdown menus above workspace content controls', () => {
+    const topbarLeftZIndex = Number(getCssDeclaration('.topbar-left', 'z-index'))
+
+    expect(topbarLeftZIndex).toBeGreaterThan(20)
   })
 })

--- a/ecos/gui/apps/renderer/src/components/TopBar.vue
+++ b/ecos/gui/apps/renderer/src/components/TopBar.vue
@@ -275,7 +275,7 @@ const handleClose = async () => {
   height: 100%;
   padding-left: 16px;
   gap: 8px;
-  z-index: 10;
+  z-index: 30;
   position: relative;
   -webkit-app-region: no-drag;
 }


### PR DESCRIPTION
## Summary

- Fixes the TopBar menu stacking order so File/Help dropdowns render above workspace content controls.
- Adds a regression check for the TopBar dropdown layer ordering.

Fixes #90

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## What Changed

- Raised `.topbar-left` from `z-index: 10` to `z-index: 30` so its dropdown stacking context sits above content controls such as the Backend Design back button.
- Added a TopBar test that checks the menu layer remains above content-level controls.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm --filter @ecos-studio/renderer exec vitest run src/components/TopBar.test.ts`
- [x] `cd ecos/gui && pnpm --filter @ecos-studio/renderer run test -- TopBar`
- [x] `cd ecos/gui && pnpm --filter @ecos-studio/renderer run typecheck`
- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

- Full workspace test/build and manual GUI smoke not run; this change is scoped to TopBar CSS layer ordering and covered by the focused renderer test/typecheck commands above.

## Screenshots or Recordings

Required for visible GUI changes.

- Not attached; the change is a stacking-order fix validated by the regression test.

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- No dependency, lockfile, packaging, or runtime resource changes.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed. N/A: no text/docs changes needed.
- [x] I included lockfile changes for dependency updates. N/A: no dependency changes.
- [x] I documented intentional submodule updates. N/A: no submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.