### PR TITLE
feat(gui): add tech library page

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.test.ts
@@ -94,6 +94,147 @@ describe('WorkspaceResourceService', () => {
     })
   })
 
+  it('exposes workspace-level view package tech resources from the design view directory', async () => {
+    const root = await tempWorkspace()
+    await writeWorkspace(root, [{ name: 'place', tool: 'ecc' }])
+    await mkdir(join(root, 'gcd_view', 'tech'), { recursive: true })
+    await writeJson(join(root, 'gcd_view', 'manifest.json'), {
+      schema: 'ieda.view.v1',
+      format: 'layout_view_package',
+      files: {
+        meta: 'meta.json',
+        layers: 'tech/layers.json',
+        sites: 'tech/sites.json',
+        vias: 'tech/vias.json',
+        cell_masters: 'tech/cell_masters.json',
+      },
+    })
+    await writeJson(join(root, 'gcd_view', 'meta.json'), {})
+    await writeJson(join(root, 'gcd_view', 'tech', 'layers.json'), {})
+    await writeJson(join(root, 'gcd_view', 'tech', 'sites.json'), {})
+    await writeJson(join(root, 'gcd_view', 'tech', 'vias.json'), {})
+    await writeJson(join(root, 'gcd_view', 'tech', 'cell_masters.json'), {})
+
+    const service = new WorkspaceResourceService({ projectScopeProvider: provider(root) })
+    const index = await service.getIndex()
+
+    expect(index.tech).toMatchObject({
+      packageRoot: join(root, 'gcd_view'),
+      source: 'view-package',
+      manifest: {
+        path: join(root, 'gcd_view', 'manifest.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+      layers: {
+        path: join(root, 'gcd_view', 'tech', 'layers.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+      sites: {
+        path: join(root, 'gcd_view', 'tech', 'sites.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+      vias: {
+        path: join(root, 'gcd_view', 'tech', 'vias.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+      cellMasters: {
+        path: join(root, 'gcd_view', 'tech', 'cell_masters.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+    })
+  })
+
+  it('discovers tech resources from a step output view package', async () => {
+    const root = await tempWorkspace()
+    await writeWorkspace(root, [{ name: 'place', tool: 'dreamplace' }])
+    const packageRoot = join(root, 'place_dreamplace', 'output', 'gcd_place_view')
+    await mkdir(join(packageRoot, 'tech'), { recursive: true })
+    await writeJson(join(packageRoot, 'manifest.json'), {
+      schema: 'ieda.view.v1',
+      format: 'layout_view_package',
+      files: {
+        meta: 'meta.json',
+        layers: 'tech/layers.json',
+        sites: 'tech/sites.json',
+        vias: 'tech/vias.json',
+        cell_masters: 'tech/cell_masters.json',
+      },
+    })
+    await writeJson(join(packageRoot, 'meta.json'), {})
+    await writeJson(join(packageRoot, 'tech', 'layers.json'), {})
+    await writeJson(join(packageRoot, 'tech', 'sites.json'), {})
+    await writeJson(join(packageRoot, 'tech', 'vias.json'), {})
+    await writeJson(join(packageRoot, 'tech', 'cell_masters.json'), {})
+
+    const service = new WorkspaceResourceService({ projectScopeProvider: provider(root) })
+    const index = await service.getIndex()
+
+    expect(index.tech).toMatchObject({
+      packageRoot,
+      source: 'view-package',
+      manifest: {
+        path: join(packageRoot, 'manifest.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+      layers: {
+        path: join(packageRoot, 'tech', 'layers.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+      sites: {
+        path: join(packageRoot, 'tech', 'sites.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+      vias: {
+        path: join(packageRoot, 'tech', 'vias.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+      cellMasters: {
+        path: join(packageRoot, 'tech', 'cell_masters.json'),
+        exists: true,
+        kind: 'tech-json',
+      },
+    })
+  })
+
+  it('keeps the resource index available when a discovered tech package has missing tech files', async () => {
+    const root = await tempWorkspace()
+    await writeWorkspace(root, [{ name: 'place', tool: 'ecc' }])
+    await mkdir(join(root, 'gcd_view', 'tech'), { recursive: true })
+    await writeJson(join(root, 'gcd_view', 'manifest.json'), {
+      schema: 'ieda.view.v1',
+      format: 'layout_view_package',
+      files: {
+        layers: 'tech/layers.json',
+        sites: 'tech/sites.json',
+        vias: 'tech/vias.json',
+        cell_masters: 'tech/cell_masters.json',
+      },
+    })
+    await writeJson(join(root, 'gcd_view', 'tech', 'layers.json'), {})
+
+    const service = new WorkspaceResourceService({ projectScopeProvider: provider(root) })
+    const index = await service.getIndex()
+
+    expect(index.status).toBe('available')
+    expect(index.tech?.layers.exists).toBe(true)
+    expect(index.tech?.sites).toMatchObject({
+      path: join(root, 'gcd_view', 'tech', 'sites.json'),
+      exists: false,
+      kind: 'tech-json',
+    })
+    expect(index.tech?.vias.exists).toBe(false)
+    expect(index.tech?.cellMasters.exists).toBe(false)
+  })
+
   it('returns resolveStepInfo(layout) with missing files instead of throwing', async () => {
     const root = await tempWorkspace()
     await mkdir(join(root, 'home'), { recursive: true })

--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.ts
@@ -7,6 +7,7 @@ import type {
   WorkspaceStepInfoRequest,
   WorkspaceStepInfoResult,
   WorkspaceStepResource,
+  WorkspaceTechResources,
 } from '@ecos-studio/shared'
 import type { ProjectScopeProvider } from './workspaceService'
 
@@ -149,6 +150,7 @@ export class WorkspaceResourceService {
     const flowSteps = await Promise.all(
       steps.map((step) => this.buildStepResource(root, design, topModule, step, statErrors)),
     )
+    const tech = await this.discoverTechResources(root, design, flowSteps, statErrors)
     const status = resolveIndexStatus({
       messages,
       statErrors,
@@ -173,6 +175,7 @@ export class WorkspaceResourceService {
         flow: {
           steps: flowSteps,
         },
+        ...(tech ? { tech } : {}),
         status,
         messages: [...messages, ...statErrors],
       },
@@ -213,6 +216,63 @@ export class WorkspaceResourceService {
       directory,
       info: step.info,
       resources,
+    }
+  }
+
+  private async discoverTechResources(
+    root: string,
+    design: string,
+    flowSteps: WorkspaceStepResource[],
+    errors: string[],
+  ): Promise<WorkspaceTechResources | undefined> {
+    if (!design) return undefined
+
+    const candidateRoots = uniqueStrings([
+      join(root, `${design}_view`),
+      ...flowSteps.map((step) => join(step.directory, 'output', `${design}_${step.name}_view`)),
+    ])
+
+    for (const packageRoot of candidateRoots) {
+      const tech = await this.describeTechPackage(packageRoot, errors)
+      if (tech) return tech
+    }
+
+    return undefined
+  }
+
+  private async describeTechPackage(
+    packageRoot: string,
+    errors: string[],
+  ): Promise<WorkspaceTechResources | undefined> {
+    const manifestPath = join(packageRoot, 'manifest.json')
+    const manifest = await this.describeFile(manifestPath, 'tech-json', errors)
+    if (!manifest.exists) return undefined
+
+    const manifestJson = await this.readJsonForIndex(manifestPath, errors)
+    const files = isRecord(manifestJson?.files) ? manifestJson.files : {}
+    const filePath = (key: string, fallback: string): string => {
+      const value = files[key]
+      return typeof value === 'string' && value.length > 0 ? value : fallback
+    }
+
+    const metaPath = filePath('meta', 'meta.json')
+    const meta = await this.describeFile(join(packageRoot, metaPath), 'tech-json', errors)
+    const [layers, sites, vias, cellMasters] = await Promise.all([
+      this.describeFile(join(packageRoot, filePath('layers', 'tech/layers.json')), 'tech-json', errors),
+      this.describeFile(join(packageRoot, filePath('sites', 'tech/sites.json')), 'tech-json', errors),
+      this.describeFile(join(packageRoot, filePath('vias', 'tech/vias.json')), 'tech-json', errors),
+      this.describeFile(join(packageRoot, filePath('cell_masters', 'tech/cell_masters.json')), 'tech-json', errors),
+    ])
+
+    return {
+      packageRoot,
+      source: 'view-package',
+      manifest,
+      ...(meta.exists ? { meta } : {}),
+      layers,
+      sites,
+      vias,
+      cellMasters,
     }
   }
 
@@ -377,6 +437,10 @@ export class WorkspaceResourceService {
 
 function createFile(path: string, kind: WorkspaceResourceFileKind): WorkspaceResourceFile {
   return { path, exists: false, kind }
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values))
 }
 
 function createEmptyBuckets(): StepFileBuckets {

--- a/ecos/gui/apps/renderer/src/api/type.tech.test.ts
+++ b/ecos/gui/apps/renderer/src/api/type.tech.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { STEP_METADATA } from './type'
+
+describe('STEP_METADATA Tech Library entry', () => {
+  it('adds Tech as a workspace setup route shown in the sidebar', () => {
+    expect(STEP_METADATA.tech).toMatchObject({
+      label: 'Tech',
+      icon: 'ri-database-2-line',
+      path: 'tech',
+      showInSidebar: true,
+      group: 'setup',
+    })
+  })
+})

--- a/ecos/gui/apps/renderer/src/api/type.ts
+++ b/ecos/gui/apps/renderer/src/api/type.ts
@@ -67,6 +67,7 @@ export interface StepMetadata {
 export const STEP_METADATA: Record<string, StepMetadata> = {
   // 设置页面
   'home': { label: 'Home', icon: 'ri-home-4-line', path: 'home', showInSidebar: true, group: 'setup' },
+  'tech': { label: 'Tech', icon: 'ri-database-2-line', path: 'tech', showInSidebar: true, group: 'setup' },
   'configure': { label: 'Config', icon: 'ri-settings-3-line', path: 'configure', showInSidebar: true, group: 'setup' },
 
   // 运行步骤 (key 为 flow.json 中的 step.name 小写)

--- a/ecos/gui/apps/renderer/src/applications/editor/tech-library/loader.test.ts
+++ b/ecos/gui/apps/renderer/src/applications/editor/tech-library/loader.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceResourceIndex } from '@ecos-studio/shared'
+import { loadTechLibrary } from './loader'
+
+function indexWithTech(): WorkspaceResourceIndex {
+  return {
+    root: '/workspace/demo',
+    design: 'gcd',
+    topModule: 'gcd',
+    pdk: 'ics55',
+    home: {
+      homeJson: { path: '/workspace/demo/home/home.json', exists: true, kind: 'home' },
+      flowJson: { path: '/workspace/demo/home/flow.json', exists: true, kind: 'flow' },
+      parametersJson: { path: '/workspace/demo/home/parameters.json', exists: true, kind: 'parameters' },
+      checklistJson: { path: '/workspace/demo/home/checklist.json', exists: false, kind: 'checklist' },
+    },
+    homeData: null,
+    parameters: null,
+    flow: { steps: [] },
+    tech: {
+      packageRoot: '/workspace/demo/gcd_view',
+      source: 'view-package',
+      manifest: { path: '/workspace/demo/gcd_view/manifest.json', exists: true, kind: 'tech-json' },
+      layers: { path: '/workspace/demo/gcd_view/tech/layers.json', exists: true, kind: 'tech-json' },
+      sites: { path: '/workspace/demo/gcd_view/tech/sites.json', exists: true, kind: 'tech-json' },
+      vias: { path: '/workspace/demo/gcd_view/tech/vias.json', exists: true, kind: 'tech-json' },
+      cellMasters: { path: '/workspace/demo/gcd_view/tech/cell_masters.json', exists: true, kind: 'tech-json' },
+    },
+    status: 'available',
+    messages: [],
+  }
+}
+
+describe('loadTechLibrary', () => {
+  it('loads workspace tech files and builds lookup maps without reading design data', async () => {
+    const reads: string[] = []
+    const files: Record<string, unknown> = {
+      '/workspace/demo/gcd_view/tech/layers.json': {
+        schema: 'ieda.view.v1',
+        kind: 'layers',
+        count: 2,
+        data: [
+          { id: 7, name: 'MET1', type: 'ROUTING', order: 7, direction: 'HORIZONTAL' },
+          { id: 8, name: 'VIA1', type: 'CUT', order: 8, direction: '' },
+        ],
+      },
+      '/workspace/demo/gcd_view/tech/sites.json': {
+        schema: 'ieda.view.v1',
+        kind: 'sites',
+        count: 1,
+        data: [
+          { id: 1, name: 'core7', class: 'CORE', size: [200, 1400], orient: 'N_R0', symmetry: [] },
+        ],
+      },
+      '/workspace/demo/gcd_view/tech/vias.json': {
+        schema: 'ieda.view.v1',
+        kind: 'via_masters',
+        count: 1,
+        data: [
+          {
+            id: 0,
+            name: 'MET2_MET1_VIA1_0',
+            type: 'FIXED',
+            is_default: true,
+            cut_rows: 1,
+            cut_cols: 1,
+            shapes: [{ layer_id: 7, rects: [[-50, -85, 50, 85]] }],
+          },
+        ],
+      },
+      '/workspace/demo/gcd_view/tech/cell_masters.json': {
+        schema: 'ieda.view.v1',
+        kind: 'cell_masters',
+        count: 1,
+        data: [
+          {
+            id: 0,
+            name: 'INVX1',
+            type: 'CORE',
+            origin: [0, 0],
+            size: [800, 1400],
+            site: 'core7',
+            symmetry: ['X', 'Y'],
+            pins: [],
+            obs: [],
+          },
+        ],
+      },
+    }
+
+    const data = await loadTechLibrary(indexWithTech(), {
+      readText: async (path) => {
+        reads.push(path)
+        return JSON.stringify(files[path])
+      },
+    })
+
+    expect(data.summary).toMatchObject({
+      pdk: 'ics55',
+      design: 'gcd',
+      layerCount: 2,
+      siteCount: 1,
+      viaCount: 1,
+      cellMasterCount: 1,
+    })
+    expect(data.layerById.get(7)?.name).toBe('MET1')
+    expect(data.cellMasterById.get(0)?.name).toBe('INVX1')
+    expect(reads).toEqual([
+      '/workspace/demo/gcd_view/tech/layers.json',
+      '/workspace/demo/gcd_view/tech/sites.json',
+      '/workspace/demo/gcd_view/tech/vias.json',
+      '/workspace/demo/gcd_view/tech/cell_masters.json',
+    ])
+  })
+
+  it('rejects unsupported tech schema with a clear error', async () => {
+    await expect(loadTechLibrary(indexWithTech(), {
+      readText: async () => JSON.stringify({ schema: 'unknown', kind: 'layers', data: [] }),
+    })).rejects.toThrow('Unsupported layers tech file')
+  })
+})

--- a/ecos/gui/apps/renderer/src/applications/editor/tech-library/loader.ts
+++ b/ecos/gui/apps/renderer/src/applications/editor/tech-library/loader.ts
@@ -1,0 +1,81 @@
+import type { WorkspaceResourceIndex } from '@ecos-studio/shared'
+import { readProjectTextFile } from '@/utils/projectFiles'
+import type {
+  TechCellMaster,
+  TechJsonFile,
+  TechLayer,
+  TechLibraryData,
+  TechSite,
+  TechViaMaster,
+} from './types'
+
+export interface TechLibraryReader {
+  readText(path: string): Promise<string>
+}
+
+export interface LoadTechLibraryOptions {
+  projectPath?: string
+  readText?: (path: string) => Promise<string>
+}
+
+function parseJson<T>(text: string, label: string): T {
+  try {
+    return JSON.parse(text) as T
+  } catch (error) {
+    throw new Error(`Failed to parse ${label}: ${String(error)}`)
+  }
+}
+
+function validateTechFile<T>(raw: TechJsonFile, expectedKind: string): T[] {
+  if (raw.schema !== 'ieda.view.v1' || raw.kind !== expectedKind || !Array.isArray(raw.data)) {
+    throw new Error(`Unsupported ${expectedKind.replace(/_/g, ' ')} tech file.`)
+  }
+  return raw.data as T[]
+}
+
+async function readTechArray<T>(
+  readText: (path: string) => Promise<string>,
+  path: string,
+  kind: string,
+): Promise<T[]> {
+  const raw = parseJson<TechJsonFile>(await readText(path), path)
+  return validateTechFile<T>(raw, kind)
+}
+
+export async function loadTechLibrary(
+  index: WorkspaceResourceIndex,
+  options: LoadTechLibraryOptions = {},
+): Promise<TechLibraryData> {
+  const tech = index.tech
+  if (!tech) {
+    throw new Error('Workspace has no Tech Library resources.')
+  }
+
+  const readText = options.readText
+    ?? ((path: string) => readProjectTextFile(path, { projectPath: options.projectPath }))
+
+  const [layers, sites, vias, cellMasters] = await Promise.all([
+    readTechArray<TechLayer>(readText, tech.layers.path, 'layers'),
+    readTechArray<TechSite>(readText, tech.sites.path, 'sites'),
+    readTechArray<TechViaMaster>(readText, tech.vias.path, 'via_masters'),
+    readTechArray<TechCellMaster>(readText, tech.cellMasters.path, 'cell_masters'),
+  ])
+
+  return {
+    summary: {
+      pdk: index.pdk,
+      design: index.design,
+      packageRoot: tech.packageRoot,
+      layerCount: layers.length,
+      siteCount: sites.length,
+      viaCount: vias.length,
+      cellMasterCount: cellMasters.length,
+    },
+    layers,
+    sites,
+    vias,
+    cellMasters,
+    layerById: new Map(layers.map((layer) => [layer.id, layer])),
+    cellMasterById: new Map(cellMasters.map((cell) => [cell.id, cell])),
+  }
+}

--- a/ecos/gui/apps/renderer/src/applications/editor/tech-library/previewGeometry.test.ts
+++ b/ecos/gui/apps/renderer/src/applications/editor/tech-library/previewGeometry.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCellPreviewGeometry,
+  buildViaPreviewGeometry,
+} from './previewGeometry'
+import type { TechCellMaster, TechViaMaster } from './types'
+
+describe('tech preview geometry', () => {
+  it('converts cell pin rectangles from EDA coordinates to Pixi world coordinates', () => {
+    const cell: TechCellMaster = {
+      id: 1,
+      name: 'INVX1',
+      type: 'CORE',
+      origin: [0, 0],
+      size: [800, 1400],
+      site: 'core7',
+      symmetry: [],
+      pins: [
+        {
+          name: 'A',
+          direction: 'INPUT',
+          use: 'SIGNAL',
+          ports: [{ layer_id: 7, rects: [[0, 0, 200, 100]] }],
+        },
+      ],
+      obs: [],
+    }
+
+    const geometry = buildCellPreviewGeometry(cell)
+
+    expect(geometry.bounds).toEqual({ x: 0, y: 0, w: 800, h: 1400 })
+    expect(geometry.rects[0]).toMatchObject({
+      layerId: 7,
+      kind: 'pin',
+      name: 'A',
+      world: { x: 0, y: 1300, w: 200, h: 100 },
+    })
+  })
+
+  it('normalizes via rectangles with negative coordinates while preserving relative geometry', () => {
+    const via: TechViaMaster = {
+      id: 0,
+      name: 'MET2_MET1_VIA1_0',
+      type: 'FIXED',
+      is_default: true,
+      cut_rows: 1,
+      cut_cols: 1,
+      shapes: [
+        { layer_id: 7, rects: [[-50, -85, 50, 85]] },
+        { layer_id: 8, rects: [[-45, -45, 45, 45]] },
+      ],
+    }
+
+    const geometry = buildViaPreviewGeometry(via)
+
+    expect(geometry.bounds).toEqual({ x: 0, y: 0, w: 100, h: 170 })
+    expect(geometry.rects).toEqual([
+      {
+        layerId: 7,
+        kind: 'via',
+        name: 'MET2_MET1_VIA1_0',
+        world: { x: 0, y: 0, w: 100, h: 170 },
+      },
+      {
+        layerId: 8,
+        kind: 'via',
+        name: 'MET2_MET1_VIA1_0',
+        world: { x: 5, y: 40, w: 90, h: 90 },
+      },
+    ])
+  })
+})

--- a/ecos/gui/apps/renderer/src/applications/editor/tech-library/previewGeometry.ts
+++ b/ecos/gui/apps/renderer/src/applications/editor/tech-library/previewGeometry.ts
@@ -1,0 +1,101 @@
+import { edaBBoxToWorldRect } from '@/applications/editor/core/editorCoordinates'
+import type {
+  TechBBox,
+  TechCellMaster,
+  TechPreviewGeometry,
+  TechPreviewRect,
+  TechViaMaster,
+} from './types'
+
+function emptyGeometry(): TechPreviewGeometry {
+  return { bounds: { x: 0, y: 0, w: 0, h: 0 }, rects: [] }
+}
+
+function unionBbox(rects: TechBBox[]): TechBBox | null {
+  if (rects.length === 0) return null
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const rect of rects) {
+    minX = Math.min(minX, rect[0], rect[2])
+    minY = Math.min(minY, rect[1], rect[3])
+    maxX = Math.max(maxX, rect[0], rect[2])
+    maxY = Math.max(maxY, rect[1], rect[3])
+  }
+  return [minX, minY, maxX, maxY]
+}
+
+function normalizeRect(rect: TechBBox, bbox: TechBBox): TechBBox {
+  return [
+    rect[0] - bbox[0],
+    rect[1] - bbox[1],
+    rect[2] - bbox[0],
+    rect[3] - bbox[1],
+  ]
+}
+
+export function buildCellPreviewGeometry(cell: TechCellMaster): TechPreviewGeometry {
+  const worldHeight = cell.size[1]
+  const rects: TechPreviewRect[] = []
+
+  for (const pin of cell.pins) {
+    for (const port of pin.ports) {
+      for (const rect of port.rects) {
+        rects.push({
+          layerId: port.layer_id,
+          kind: 'pin',
+          name: pin.name,
+          world: edaBBoxToWorldRect(rect[0], rect[1], rect[2], rect[3], worldHeight),
+        })
+      }
+    }
+  }
+
+  for (const obs of cell.obs) {
+    for (const rect of obs.rects) {
+      rects.push({
+        layerId: obs.layer_id,
+        kind: 'obs',
+        name: 'OBS',
+        world: edaBBoxToWorldRect(rect[0], rect[1], rect[2], rect[3], worldHeight),
+      })
+    }
+  }
+
+  return {
+    bounds: { x: 0, y: 0, w: cell.size[0], h: cell.size[1] },
+    rects,
+  }
+}
+
+export function buildViaPreviewGeometry(via: TechViaMaster): TechPreviewGeometry {
+  const sourceRects = via.shapes.flatMap((shape) => shape.rects)
+  const bbox = unionBbox(sourceRects)
+  if (!bbox) return emptyGeometry()
+
+  const worldHeight = bbox[3] - bbox[1]
+  const rects: TechPreviewRect[] = []
+  for (const shape of via.shapes) {
+    for (const rect of shape.rects) {
+      const normalized = normalizeRect(rect, bbox)
+      rects.push({
+        layerId: shape.layer_id,
+        kind: 'via',
+        name: via.name,
+        world: edaBBoxToWorldRect(
+          normalized[0],
+          normalized[1],
+          normalized[2],
+          normalized[3],
+          worldHeight,
+        ),
+      })
+    }
+  }
+
+  return {
+    bounds: { x: 0, y: 0, w: bbox[2] - bbox[0], h: worldHeight },
+    rects,
+  }
+}

--- a/ecos/gui/apps/renderer/src/applications/editor/tech-library/previewRendering.test.ts
+++ b/ecos/gui/apps/renderer/src/applications/editor/tech-library/previewRendering.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTechPreviewRenderGroups,
+  colorForTechLayer,
+} from './previewRendering'
+import type { TechLayer, TechPreviewGeometry } from './types'
+
+const layers: TechLayer[] = [
+  { id: 7, name: 'MET1', type: 'ROUTING', order: 7, direction: 'HORIZONTAL' },
+  { id: 8, name: 'VIA1', type: 'CUT', order: 8, direction: 'none' },
+]
+
+describe('tech preview rendering', () => {
+  it('groups same layer geometry into one fill pass', () => {
+    const geometry: TechPreviewGeometry = {
+      bounds: { x: 0, y: 0, w: 120, h: 120 },
+      rects: [
+        { layerId: 7, kind: 'pin', name: 'A', world: { x: 0, y: 0, w: 80, h: 80 } },
+        { layerId: 7, kind: 'pin', name: 'B', world: { x: 40, y: 40, w: 80, h: 80 } },
+        { layerId: 7, kind: 'obs', name: 'OBS', world: { x: 20, y: 20, w: 20, h: 20 } },
+      ],
+    }
+
+    const groups = buildTechPreviewRenderGroups(geometry, layers)
+
+    expect(groups).toHaveLength(2)
+    expect(groups[0]).toMatchObject({
+      key: '7:pin',
+      layerId: 7,
+      kind: 'pin',
+      rects: [geometry.rects[0], geometry.rects[1]],
+    })
+    expect(groups[1]).toMatchObject({
+      key: '7:obs',
+      layerId: 7,
+      kind: 'obs',
+      rects: [geometry.rects[2]],
+    })
+  })
+
+  it('decomposes same-style overlaps into non-overlapping draw rects', () => {
+    const geometry: TechPreviewGeometry = {
+      bounds: { x: 0, y: 0, w: 120, h: 120 },
+      rects: [
+        { layerId: 7, kind: 'pin', name: 'A', world: { x: 0, y: 0, w: 80, h: 80 } },
+        { layerId: 7, kind: 'pin', name: 'B', world: { x: 40, y: 40, w: 80, h: 80 } },
+      ],
+    }
+
+    const [group] = buildTechPreviewRenderGroups(geometry, layers)
+
+    expect(group.drawRects).toEqual([
+      { x: 0, y: 0, w: 80, h: 40 },
+      { x: 0, y: 40, w: 120, h: 40 },
+      { x: 40, y: 80, w: 80, h: 40 },
+    ])
+  })
+
+  it('uses the same default layer colors as the view-json renderer for known layers', () => {
+    expect(colorForTechLayer(layers[0], 0)).toBe(0x4444ff)
+    expect(colorForTechLayer(layers[1], 1)).toBe(0xaaaaaa)
+  })
+})

--- a/ecos/gui/apps/renderer/src/applications/editor/tech-library/previewRendering.ts
+++ b/ecos/gui/apps/renderer/src/applications/editor/tech-library/previewRendering.ts
@@ -1,0 +1,174 @@
+import type { TechLayer, TechPreviewGeometry, TechPreviewRect } from './types'
+
+type PreviewWorldRect = TechPreviewRect['world']
+
+interface TechPreviewStyle {
+  color: number
+  fillAlpha: number
+  strokeAlpha: number
+}
+
+export interface TechPreviewRenderGroup extends TechPreviewStyle {
+  key: string
+  layerId: number
+  kind: TechPreviewRect['kind']
+  rects: TechPreviewRect[]
+  drawRects: PreviewWorldRect[]
+}
+
+const VIEW_JSON_LAYER_COLORS: Record<string, number> = {
+  OVERLAP: 0x888888,
+  ACT: 0xcc8844,
+  NP: 0x88cc44,
+  PP: 0x44cc88,
+  NW1: 0x44cccc,
+  POLY: 0xff8844,
+  CT: 0x999999,
+  MET1: 0x4444ff,
+  VIA1: 0xaaaaaa,
+  MET2: 0xff4444,
+  VIA2: 0xbbbbbb,
+  MET3: 0x44ff44,
+  VIA3: 0xcccccc,
+  MET4: 0xffff44,
+  VIA4: 0xdddddd,
+  MET5: 0xff44ff,
+  T4V2: 0x777777,
+  T4M2: 0x998877,
+  RV: 0x666666,
+  RDL: 0x559988,
+}
+
+const FALLBACK_COLORS = [
+  0x4444ff,
+  0xff4444,
+  0x44cc88,
+  0xff8844,
+  0x44cccc,
+  0xffff44,
+  0xff44ff,
+]
+
+export function colorForTechLayer(layer: TechLayer | undefined, fallbackIndex: number): number {
+  const layerName = layer?.name.toUpperCase()
+  if (layerName && VIEW_JSON_LAYER_COLORS[layerName] !== undefined) {
+    return VIEW_JSON_LAYER_COLORS[layerName]
+  }
+  return FALLBACK_COLORS[fallbackIndex % FALLBACK_COLORS.length]
+}
+
+function styleForRect(rect: TechPreviewRect, layer: TechLayer | undefined, fallbackIndex: number): TechPreviewStyle {
+  if (rect.kind === 'obs') {
+    return { color: 0x64748b, fillAlpha: 0.26, strokeAlpha: 0.82 }
+  }
+  return {
+    color: colorForTechLayer(layer, fallbackIndex),
+    fillAlpha: 0.35,
+    strokeAlpha: 0.8,
+  }
+}
+
+function uniqueSorted(values: number[]): number[] {
+  return [...new Set(values)]
+    .filter((value) => Number.isFinite(value))
+    .sort((a, b) => a - b)
+}
+
+function rectContains(rect: PreviewWorldRect, x: number, y: number, w: number, h: number): boolean {
+  return rect.x <= x &&
+    rect.y <= y &&
+    rect.x + rect.w >= x + w &&
+    rect.y + rect.h >= y + h
+}
+
+function mergeHorizontal(cells: PreviewWorldRect[]): PreviewWorldRect[] {
+  const byBand = new Map<string, PreviewWorldRect[]>()
+  for (const cell of cells) {
+    const key = `${cell.y}:${cell.h}`
+    const band = byBand.get(key)
+    if (band) band.push(cell)
+    else byBand.set(key, [cell])
+  }
+
+  const merged: PreviewWorldRect[] = []
+  const sortedBands = [...byBand.values()]
+    .sort((a, b) => a[0].y - b[0].y || a[0].h - b[0].h)
+  for (const band of sortedBands) {
+    const sorted = [...band].sort((a, b) => a.x - b.x)
+    let current: PreviewWorldRect | null = null
+    for (const cell of sorted) {
+      if (current && Math.abs(current.x + current.w - cell.x) < 0.001) {
+        current.w += cell.w
+      } else {
+        if (current) merged.push(current)
+        current = { ...cell }
+      }
+    }
+    if (current) merged.push(current)
+  }
+  return merged
+}
+
+function decomposeToNonOverlappingRects(rects: PreviewWorldRect[]): PreviewWorldRect[] {
+  const validRects = rects.filter((rect) => rect.w > 0 && rect.h > 0)
+  if (validRects.length <= 1) return validRects.map((rect) => ({ ...rect }))
+
+  const xs = uniqueSorted(validRects.flatMap((rect) => [rect.x, rect.x + rect.w]))
+  const ys = uniqueSorted(validRects.flatMap((rect) => [rect.y, rect.y + rect.h]))
+  const cells: PreviewWorldRect[] = []
+
+  for (let yi = 0; yi < ys.length - 1; yi += 1) {
+    const y = ys[yi]
+    const h = ys[yi + 1] - y
+    if (h <= 0) continue
+
+    for (let xi = 0; xi < xs.length - 1; xi += 1) {
+      const x = xs[xi]
+      const w = xs[xi + 1] - x
+      if (w <= 0) continue
+
+      if (validRects.some((rect) => rectContains(rect, x, y, w, h))) {
+        cells.push({ x, y, w, h })
+      }
+    }
+  }
+
+  return mergeHorizontal(cells)
+}
+
+export function buildTechPreviewRenderGroups(
+  geometry: TechPreviewGeometry,
+  layers: TechLayer[] = [],
+): TechPreviewRenderGroup[] {
+  const layerById = new Map(layers.map((layer) => [layer.id, layer]))
+  const layerOrder = new Map(
+    [...layers]
+      .sort((a, b) => a.order - b.order)
+      .map((layer, index) => [layer.id, index]),
+  )
+  const groups = new Map<string, TechPreviewRenderGroup>()
+
+  for (const rect of geometry.rects) {
+    const fallbackIndex = layerOrder.get(rect.layerId) ?? groups.size
+    const style = styleForRect(rect, layerById.get(rect.layerId), fallbackIndex)
+    const key = `${rect.layerId}:${rect.kind}`
+    let group = groups.get(key)
+    if (!group) {
+      group = {
+        key,
+        layerId: rect.layerId,
+        kind: rect.kind,
+        rects: [],
+        drawRects: [],
+        ...style,
+      }
+      groups.set(key, group)
+    }
+    group.rects.push(rect)
+  }
+
+  return [...groups.values()].map((group) => ({
+    ...group,
+    drawRects: decomposeToNonOverlappingRects(group.rects.map((rect) => rect.world)),
+  }))
+}

--- a/ecos/gui/apps/renderer/src/applications/editor/tech-library/types.ts
+++ b/ecos/gui/apps/renderer/src/applications/editor/tech-library/types.ts
@@ -1,0 +1,93 @@
+export type TechBBox = [number, number, number, number]
+export type TechPoint = [number, number]
+
+export interface TechJsonFile {
+  schema?: unknown
+  kind?: unknown
+  count?: unknown
+  data?: unknown
+  name_to_id?: Record<string, number>
+}
+
+export interface TechLayer {
+  id: number
+  name: string
+  type: string
+  order: number
+  direction: string
+}
+
+export interface TechSite {
+  id: number
+  name: string
+  class: string
+  size: TechPoint
+  orient: string
+  symmetry: string[]
+}
+
+export interface TechLayerRects {
+  layer_id: number
+  rects: TechBBox[]
+}
+
+export interface TechViaMaster {
+  id: number
+  name: string
+  type: string
+  is_default: boolean
+  cut_rows: number
+  cut_cols: number
+  shapes: TechLayerRects[]
+}
+
+export interface TechPin {
+  name: string
+  direction: string
+  use: string
+  ports: TechLayerRects[]
+}
+
+export interface TechCellMaster {
+  id: number
+  name: string
+  type: string
+  origin: TechPoint
+  size: TechPoint
+  site: string
+  symmetry: string[]
+  pins: TechPin[]
+  obs: TechLayerRects[]
+}
+
+export interface TechLibrarySummary {
+  pdk: string
+  design: string
+  packageRoot: string
+  layerCount: number
+  siteCount: number
+  viaCount: number
+  cellMasterCount: number
+}
+
+export interface TechLibraryData {
+  summary: TechLibrarySummary
+  layers: TechLayer[]
+  sites: TechSite[]
+  vias: TechViaMaster[]
+  cellMasters: TechCellMaster[]
+  layerById: Map<number, TechLayer>
+  cellMasterById: Map<number, TechCellMaster>
+}
+
+export interface TechPreviewRect {
+  layerId: number
+  kind: 'pin' | 'obs' | 'via'
+  name: string
+  world: { x: number; y: number; w: number; h: number }
+}
+
+export interface TechPreviewGeometry {
+  bounds: { x: number; y: number; w: number; h: number }
+  rects: TechPreviewRect[]
+}

--- a/ecos/gui/apps/renderer/src/components/TechPreviewCanvas.vue
+++ b/ecos/gui/apps/renderer/src/components/TechPreviewCanvas.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { Application, Container, Graphics } from 'pixi.js'
+import { markRaw, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import type { TechCellMaster, TechLayer, TechPreviewGeometry, TechViaMaster } from '@/applications/editor/tech-library/types'
+import { buildCellPreviewGeometry, buildViaPreviewGeometry } from '@/applications/editor/tech-library/previewGeometry'
+import { buildTechPreviewRenderGroups } from '@/applications/editor/tech-library/previewRendering'
+
+const props = defineProps<{
+  mode: 'cell' | 'via' | 'empty'
+  cell?: TechCellMaster | null
+  via?: TechViaMaster | null
+  layers?: TechLayer[]
+}>()
+
+const host = ref<HTMLDivElement | null>(null)
+let app: Application | null = null
+let root: Container | null = null
+let resizeObserver: ResizeObserver | null = null
+
+async function ensurePixi(): Promise<void> {
+  if (!host.value || app) return
+  const bounds = host.value.getBoundingClientRect()
+  app = markRaw(new Application())
+  await app.init({
+    width: Math.max(1, Math.floor(bounds.width)),
+    height: Math.max(1, Math.floor(bounds.height)),
+    backgroundAlpha: 0,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+  })
+  root = markRaw(new Container())
+  app.stage.addChild(root)
+  host.value.appendChild(app.canvas as HTMLCanvasElement)
+  resizeObserver = new ResizeObserver(() => resizeCanvas())
+  resizeObserver.observe(host.value)
+}
+
+function resizeCanvas(): void {
+  if (!host.value || !app) return
+  const bounds = host.value.getBoundingClientRect()
+  app.renderer.resize(Math.max(1, Math.floor(bounds.width)), Math.max(1, Math.floor(bounds.height)))
+  draw()
+}
+
+function geometryForSelection(): TechPreviewGeometry | null {
+  if (props.mode === 'cell' && props.cell) return buildCellPreviewGeometry(props.cell)
+  if (props.mode === 'via' && props.via) return buildViaPreviewGeometry(props.via)
+  return null
+}
+
+function fitGraphics(g: Graphics, geometry: TechPreviewGeometry): void {
+  if (!app) return
+  const screenW = app.screen.width
+  const screenH = app.screen.height
+  const padding = 26
+  const scale = Math.min(
+    (screenW - padding * 2) / Math.max(geometry.bounds.w, 1),
+    (screenH - padding * 2) / Math.max(geometry.bounds.h, 1),
+  )
+  g.scale.set(Math.max(scale, 0.001))
+  g.position.set(
+    (screenW - geometry.bounds.w * g.scale.x) / 2,
+    (screenH - geometry.bounds.h * g.scale.y) / 2,
+  )
+}
+
+function draw(): void {
+  if (!root) return
+  root.removeChildren().forEach((child) => child.destroy())
+  const geometry = geometryForSelection()
+  if (!geometry) return
+
+  const boundsGraphics = new Graphics()
+  boundsGraphics.rect(geometry.bounds.x, geometry.bounds.y, geometry.bounds.w, geometry.bounds.h)
+    .fill({ color: 0x111827, alpha: 0.12 })
+    .stroke({ color: 0x9ca3af, alpha: 0.75, width: 1 })
+  fitGraphics(boundsGraphics, geometry)
+  root.addChild(boundsGraphics)
+
+  const groups = buildTechPreviewRenderGroups(geometry, props.layers ?? [])
+  for (const group of groups) {
+    const g = new Graphics()
+    for (const rect of group.drawRects) {
+      g.rect(rect.x, rect.y, rect.w, rect.h)
+    }
+    g.fill({ color: group.color, alpha: group.fillAlpha })
+    g.stroke({ color: group.color, alpha: group.strokeAlpha, width: 1 })
+    fitGraphics(g, geometry)
+    root.addChild(g)
+  }
+}
+
+watch(
+  () => [props.mode, props.cell?.id, props.via?.id, props.layers?.length ?? 0],
+  async () => {
+    await nextTick()
+    await ensurePixi()
+    draw()
+  },
+  { immediate: true },
+)
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  app?.destroy(true, { children: true })
+  app = null
+  root = null
+})
+</script>
+
+<template>
+  <div ref="host" class="tech-preview-canvas">
+    <div v-if="mode === 'empty'" class="preview-empty">
+      <i class="ri-crosshair-2-line"></i>
+      <span>Select a via or cell master</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tech-preview-canvas {
+  position: relative;
+  width: 100%;
+  height: 280px;
+  min-height: 220px;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-primary) 64%, var(--bg-secondary));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bg-primary) 72%, transparent);
+}
+
+.tech-preview-canvas :deep(canvas) {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.preview-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.preview-empty i {
+  font-size: 26px;
+  opacity: 0.8;
+}
+</style>

--- a/ecos/gui/apps/renderer/src/composables/useCurrentStage.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useCurrentStage.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getWorkspaceStageFlags } from './useCurrentStage'
+
+describe('getWorkspaceStageFlags', () => {
+  it('treats tech as a workspace setup page instead of a flow step', () => {
+    expect(getWorkspaceStageFlags('tech')).toEqual({
+      showProgressPanel: false,
+      showOverviewPanel: false,
+      showSubflowPanel: false,
+      isHome: false,
+      isConfigure: false,
+      isTech: true,
+      isFlowStep: false,
+    })
+  })
+})

--- a/ecos/gui/apps/renderer/src/composables/useCurrentStage.ts
+++ b/ecos/gui/apps/renderer/src/composables/useCurrentStage.ts
@@ -1,6 +1,33 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
+export interface WorkspaceStageFlags {
+  showProgressPanel: boolean
+  showOverviewPanel: boolean
+  showSubflowPanel: boolean
+  isHome: boolean
+  isConfigure: boolean
+  isTech: boolean
+  isFlowStep: boolean
+}
+
+export function getWorkspaceStageFlags(stage: string): WorkspaceStageFlags {
+  const isHome = stage === 'home'
+  const isConfigure = stage === 'configure'
+  const isTech = stage === 'tech'
+  const isWorkspaceTool = isConfigure || isTech
+
+  return {
+    showProgressPanel: !isWorkspaceTool,
+    showOverviewPanel: isHome,
+    showSubflowPanel: !isWorkspaceTool && !isHome,
+    isHome,
+    isConfigure,
+    isTech,
+    isFlowStep: !isHome && !isWorkspaceTool,
+  }
+}
+
 // ============ Composable ============
 
 /**
@@ -18,28 +45,31 @@ export function useCurrentStage() {
 
   /** 是否显示进度面板 (Configure 页面不显示) */
   const showProgressPanel = computed(() => {
-    return currentStage.value !== 'configure'
+    return getWorkspaceStageFlags(currentStage.value).showProgressPanel
   })
 
   /** 是否显示概览面板 (Home 页面显示概览) */
   const showOverviewPanel = computed(() => {
-    return currentStage.value === 'home'
+    return getWorkspaceStageFlags(currentStage.value).showOverviewPanel
   })
 
   /** 是否显示子流程面板 (非 Home 和非 Configure 页面显示) */
   const showSubflowPanel = computed(() => {
-    return currentStage.value !== 'configure' && currentStage.value !== 'home'
+    return getWorkspaceStageFlags(currentStage.value).showSubflowPanel
   })
 
   /** 是否在首页 */
-  const isHome = computed(() => currentStage.value === 'home')
+  const isHome = computed(() => getWorkspaceStageFlags(currentStage.value).isHome)
 
   /** 是否在配置页 */
-  const isConfigure = computed(() => currentStage.value === 'configure')
+  const isConfigure = computed(() => getWorkspaceStageFlags(currentStage.value).isConfigure)
+
+  /** 是否在 Tech Library 页 */
+  const isTech = computed(() => getWorkspaceStageFlags(currentStage.value).isTech)
 
   /** 是否在流程步骤页面 */
   const isFlowStep = computed(() => {
-    return !isHome.value && !isConfigure.value
+    return getWorkspaceStageFlags(currentStage.value).isFlowStep
   })
 
   /**
@@ -64,6 +94,7 @@ export function useCurrentStage() {
     showSubflowPanel,
     isHome,
     isConfigure,
+    isTech,
     isFlowStep,
 
     // 方法

--- a/ecos/gui/apps/renderer/src/router/index.test.ts
+++ b/ecos/gui/apps/renderer/src/router/index.test.ts
@@ -48,3 +48,18 @@ describe('router SoC welcome routes', () => {
     expect(existsSync(resolve(routerDir, detailImportPath))).toBe(true)
   })
 })
+
+describe('router workspace Tech Library route', () => {
+  it('resolves /workspace/tech as a fixed workspace page before the dynamic step route', () => {
+    const techRoute = router.resolve('/workspace/tech')
+
+    expect(techRoute.name).toBe('TechLibrary')
+    expect(techRoute.matched.map((record) => record.path)).toEqual(['/workspace', '/workspace/tech'])
+
+    const techRecord = router.getRoutes().find((record) => record.name === 'TechLibrary')
+    expect(techRecord?.components?.default).toBeTypeOf('function')
+    expect(routerSource).toContain(
+      `{ path: 'tech', name: 'TechLibrary', component: () => import('../views/TechLibraryView.vue') }`,
+    )
+  })
+})

--- a/ecos/gui/apps/renderer/src/router/index.ts
+++ b/ecos/gui/apps/renderer/src/router/index.ts
@@ -26,6 +26,7 @@ const routes: RouteRecordRaw[] = [
     children: [
       // 固定的设置页面
       { path: 'home', name: 'Home', component: () => import('../views/HomeView.vue') },
+      { path: 'tech', name: 'TechLibrary', component: () => import('../views/TechLibraryView.vue') },
       { path: 'configure', name: 'Configure', component: () => import('../views/ConfigureView.vue') },
       // 动态步骤路由：匹配所有 flow 步骤
       // 路由验证放宽，允许任何步骤路径（由 flow.json 动态决定）

--- a/ecos/gui/apps/renderer/src/views/TechLibraryView.vue
+++ b/ecos/gui/apps/renderer/src/views/TechLibraryView.vue
@@ -1,0 +1,1217 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { getWorkspaceResourceIndexApi } from '@/api/workspaceResources'
+import { useWorkspace } from '@/composables/useWorkspace'
+import { loadTechLibrary } from '@/applications/editor/tech-library/loader'
+import type {
+  TechCellMaster,
+  TechLayer,
+  TechLibraryData,
+  TechSite,
+  TechViaMaster,
+} from '@/applications/editor/tech-library/types'
+import TechPreviewCanvas from '@/components/TechPreviewCanvas.vue'
+
+type TechSection = 'overview' | 'layers' | 'sites' | 'vias' | 'cells'
+type SelectableTech = TechLayer | TechSite | TechViaMaster | TechCellMaster | null
+
+interface TechSectionConfig {
+  id: TechSection
+  label: string
+  shortLabel: string
+  icon: string
+}
+
+const sections: TechSectionConfig[] = [
+  { id: 'overview', label: 'Overview', shortLabel: 'Overview', icon: 'ri-dashboard-3-line' },
+  { id: 'layers', label: 'Layers', shortLabel: 'Layers', icon: 'ri-stack-line' },
+  { id: 'sites', label: 'Sites', shortLabel: 'Sites', icon: 'ri-grid-line' },
+  { id: 'vias', label: 'Via Masters', shortLabel: 'Vias', icon: 'ri-node-tree' },
+  { id: 'cells', label: 'Cell Masters', shortLabel: 'Cells', icon: 'ri-layout-grid-2-line' },
+]
+
+const { currentProject, resourceVersions } = useWorkspace()
+const activeSection = ref<TechSection>('overview')
+const search = ref('')
+const techData = ref<TechLibraryData | null>(null)
+const selected = ref<SelectableTech>(null)
+const isLoading = ref(false)
+const error = ref('')
+
+function itemName(item: SelectableTech): string {
+  return item && 'name' in item ? item.name : ''
+}
+
+function matchesSearch(item: SelectableTech): boolean {
+  const query = search.value.trim().toLowerCase()
+  if (!query) return true
+  return itemName(item).toLowerCase().includes(query)
+}
+
+function sectionCount(section: TechSection): number | null {
+  const data = techData.value
+  if (!data) return null
+  switch (section) {
+    case 'layers':
+      return data.summary.layerCount
+    case 'sites':
+      return data.summary.siteCount
+    case 'vias':
+      return data.summary.viaCount
+    case 'cells':
+      return data.summary.cellMasterCount
+    default:
+      return null
+  }
+}
+
+const activeSectionConfig = computed(() =>
+  sections.find((section) => section.id === activeSection.value) ?? sections[0],
+)
+const resourceSections = computed(() =>
+  sections.filter((section) => section.id !== 'overview'),
+)
+
+const activeRows = computed(() => {
+  const data = techData.value
+  if (!data) return []
+  switch (activeSection.value) {
+    case 'layers':
+      return data.layers.filter(matchesSearch)
+    case 'sites':
+      return data.sites.filter(matchesSearch)
+    case 'vias':
+      return data.vias.filter(matchesSearch)
+    case 'cells':
+      return data.cellMasters.filter(matchesSearch)
+    default:
+      return []
+  }
+})
+
+const selectedVia = computed(() =>
+  activeSection.value === 'vias' ? selected.value as TechViaMaster | null : null,
+)
+const selectedCell = computed(() =>
+  activeSection.value === 'cells' ? selected.value as TechCellMaster | null : null,
+)
+const previewMode = computed<'cell' | 'via' | 'empty'>(() => {
+  if (selectedCell.value) return 'cell'
+  if (selectedVia.value) return 'via'
+  return 'empty'
+})
+const hasPreview = computed(() =>
+  activeSection.value === 'vias' || activeSection.value === 'cells',
+)
+const detailEmptyText = computed(() => {
+  switch (activeSection.value) {
+    case 'layers':
+      return 'Select a layer to inspect routing attributes.'
+    case 'sites':
+      return 'Select a site to inspect placement properties.'
+    case 'vias':
+      return 'Select a via master to inspect geometry.'
+    case 'cells':
+      return 'Select a cell master to inspect geometry.'
+    default:
+      return 'Select a row to inspect properties.'
+  }
+})
+
+const sourceLabel = computed(() => {
+  const root = techData.value?.summary.packageRoot
+  if (!root) return 'No package'
+  const parts = root.split(/[\\/]/).filter(Boolean)
+  return parts.slice(-4).join('/')
+})
+
+const tableHeader = computed(() => {
+  switch (activeSection.value) {
+    case 'layers':
+      return ['ID', 'Name', 'Type', 'Direction']
+    case 'sites':
+      return ['ID', 'Name', 'Class', 'Size']
+    case 'vias':
+      return ['ID', 'Name', 'Type', 'Cuts']
+    case 'cells':
+      return ['ID', 'Name', 'Site', 'Footprint']
+    default:
+      return []
+  }
+})
+
+const overviewRows = computed(() => {
+  const data = techData.value
+  if (!data) return []
+  return [
+    ['Design', data.summary.design || 'Unknown'],
+    ['PDK', data.summary.pdk || 'Unknown'],
+    ['Package root', data.summary.packageRoot],
+    ['Source', 'iEDA view package tech files'],
+  ]
+})
+
+const detailRows = computed(() => {
+  const item = selected.value
+  if (!item) return []
+  if (activeSection.value === 'layers') {
+    const layer = item as TechLayer
+    return [
+      ['ID', String(layer.id)],
+      ['Name', layer.name],
+      ['Type', layer.type],
+      ['Order', String(layer.order)],
+      ['Direction', layer.direction || 'none'],
+    ]
+  }
+  if (activeSection.value === 'sites') {
+    const site = item as TechSite
+    return [
+      ['ID', String(site.id)],
+      ['Name', site.name],
+      ['Class', site.class],
+      ['Size', site.size.join(' x ')],
+      ['Orient', site.orient],
+      ['Symmetry', site.symmetry.length ? site.symmetry.join(', ') : 'none'],
+    ]
+  }
+  if (activeSection.value === 'vias') {
+    const via = item as TechViaMaster
+    return [
+      ['ID', String(via.id)],
+      ['Name', via.name],
+      ['Type', via.type],
+      ['Default', via.is_default ? 'yes' : 'no'],
+      ['Cut array', `${via.cut_rows} x ${via.cut_cols}`],
+      ['Layer shapes', String(via.shapes.length)],
+    ]
+  }
+  const cell = item as TechCellMaster
+  return [
+    ['ID', String(cell.id)],
+    ['Name', cell.name],
+    ['Type', cell.type],
+    ['Site', cell.site],
+    ['Origin', cell.origin.join(', ')],
+    ['Size', cell.size.join(' x ')],
+    ['Pins', String(cell.pins.length)],
+    ['Obs layers', String(cell.obs.length)],
+  ]
+})
+
+function rowCells(row: Exclude<SelectableTech, null>): [string, string, string, string] {
+  if (activeSection.value === 'layers') {
+    const layer = row as TechLayer
+    return [String(layer.id), layer.name, layer.type, layer.direction || 'none']
+  }
+  if (activeSection.value === 'sites') {
+    const site = row as TechSite
+    return [String(site.id), site.name, site.class, site.size.join(' x ')]
+  }
+  if (activeSection.value === 'vias') {
+    const via = row as TechViaMaster
+    return [String(via.id), via.name, via.type, `${via.cut_rows} x ${via.cut_cols}`]
+  }
+  const cell = row as TechCellMaster
+  return [String(cell.id), cell.name, cell.site, cell.size.join(' x ')]
+}
+
+function selectFirstVisibleRow(): void {
+  selected.value = activeSection.value === 'overview' ? null : activeRows.value[0] as SelectableTech ?? null
+}
+
+function setSection(section: TechSection): void {
+  activeSection.value = section
+  search.value = ''
+  selected.value = null
+}
+
+async function loadTech(): Promise<void> {
+  const projectPath = currentProject.value?.path
+  if (!projectPath) {
+    techData.value = null
+    error.value = 'Open a workspace to inspect its Tech Library.'
+    return
+  }
+
+  isLoading.value = true
+  error.value = ''
+  try {
+    const index = await getWorkspaceResourceIndexApi()
+    techData.value = await loadTechLibrary(index, { projectPath })
+    selectFirstVisibleRow()
+  } catch (err) {
+    techData.value = null
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+watch(activeSection, selectFirstVisibleRow)
+watch(search, selectFirstVisibleRow)
+watch(
+  () => [currentProject.value?.path, resourceVersions.value.all, resourceVersions.value.home] as const,
+  () => void loadTech(),
+)
+
+onMounted(() => {
+  void loadTech()
+})
+</script>
+
+<template>
+  <div class="tech-library-view">
+    <header class="tech-topbar">
+      <div class="title-block">
+        <h1>Tech Library</h1>
+        <div class="source-pill" :title="techData?.summary.packageRoot || ''">
+          <i class="ri-database-2-line"></i>
+          <span>{{ techData ? sourceLabel : 'Workspace tech package' }}</span>
+        </div>
+      </div>
+      <button class="reload-button" type="button" :disabled="isLoading" @click="loadTech">
+        <i :class="isLoading ? 'ri-loader-4-line spin' : 'ri-refresh-line'"></i>
+        <span>Reload</span>
+      </button>
+    </header>
+
+    <main
+      v-if="techData"
+      class="tech-workbench"
+      :class="{ overview: activeSection === 'overview' }"
+    >
+      <aside class="tech-nav" aria-label="Tech Library sections">
+        <button
+          v-for="section in sections"
+          :key="section.id"
+          type="button"
+          class="nav-item"
+          :class="{ active: activeSection === section.id }"
+          @click="setSection(section.id)"
+        >
+          <span class="nav-label">
+            <i :class="section.icon"></i>
+            <span>{{ section.label }}</span>
+          </span>
+          <span v-if="sectionCount(section.id) !== null" class="count-badge">
+            {{ sectionCount(section.id) }}
+          </span>
+        </button>
+      </aside>
+
+      <section class="tech-main">
+        <div class="summary-bar">
+          <div class="summary-source">
+            <span class="summary-label">PDK</span>
+            <strong>{{ techData.summary.pdk || 'Unknown' }}</strong>
+            <span>{{ techData.summary.design || 'Unknown design' }}</span>
+          </div>
+          <div class="summary-metrics" aria-label="Tech resource counts">
+            <div>
+              <span>Layers</span>
+              <strong>{{ techData.summary.layerCount }}</strong>
+            </div>
+            <div>
+              <span>Sites</span>
+              <strong>{{ techData.summary.siteCount }}</strong>
+            </div>
+            <div>
+              <span>Vias</span>
+              <strong>{{ techData.summary.viaCount }}</strong>
+            </div>
+            <div>
+              <span>Cells</span>
+              <strong>{{ techData.summary.cellMasterCount }}</strong>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="activeSection === 'overview'" class="overview-panel">
+          <section class="package-summary">
+            <div class="panel-heading">
+              <i class="ri-file-list-3-line"></i>
+              <div>
+                <h2>Package Summary</h2>
+                <p>Workspace-level technology data loaded from the view package.</p>
+              </div>
+            </div>
+            <dl class="overview-list">
+              <div v-for="[key, value] in overviewRows" :key="key">
+                <dt>{{ key }}</dt>
+                <dd :class="{ selectable: key === 'Package root' }">{{ value }}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section class="resource-summary" aria-label="Tech Library resources">
+            <div class="resource-summary-header">
+              <span>Resources</span>
+              <strong>4 groups</strong>
+            </div>
+            <button
+              v-for="section in resourceSections"
+              :key="section.id"
+              type="button"
+              class="resource-row"
+              @click="setSection(section.id)"
+            >
+              <span class="resource-name">
+                <i :class="section.icon"></i>
+                <span>{{ section.label }}</span>
+              </span>
+              <strong>{{ sectionCount(section.id) }}</strong>
+              <i class="ri-arrow-right-s-line"></i>
+            </button>
+          </section>
+        </div>
+
+        <template v-else>
+          <div class="table-toolbar">
+            <div class="section-title">
+              <i :class="activeSectionConfig.icon"></i>
+              <div>
+                <h2>{{ activeSectionConfig.label }}</h2>
+                <span>{{ activeRows.length }} shown</span>
+              </div>
+            </div>
+            <label class="search-box">
+              <i class="ri-search-line"></i>
+              <input v-model="search" type="search" placeholder="Search by name" />
+            </label>
+          </div>
+
+          <div class="data-table" role="grid" :aria-label="activeSectionConfig.label">
+            <div class="data-table-header" role="row">
+              <span v-for="column in tableHeader" :key="column" role="columnheader">{{ column }}</span>
+            </div>
+            <div v-if="activeRows.length" class="data-table-body" role="rowgroup">
+              <button
+                v-for="row in activeRows"
+                :key="`${activeSection}-${'id' in row ? row.id : itemName(row)}`"
+                type="button"
+                class="data-row"
+                :class="{ selected: selected === row }"
+                role="row"
+                :aria-selected="selected === row"
+                @click="selected = row"
+              >
+                <span
+                  v-for="(cell, index) in rowCells(row)"
+                  :key="`${index}-${cell}`"
+                  :class="index === 0 ? 'row-id' : index === 1 ? 'row-name' : 'row-meta'"
+                  role="gridcell"
+                >
+                  {{ cell }}
+                </span>
+              </button>
+            </div>
+            <div v-else class="table-empty">
+              <i class="ri-search-eye-line"></i>
+              <span>No {{ activeSectionConfig.shortLabel.toLowerCase() }} match this search.</span>
+            </div>
+          </div>
+        </template>
+      </section>
+
+      <aside
+        v-if="activeSection !== 'overview'"
+        class="tech-inspector"
+        :class="{ fieldsOnly: !hasPreview }"
+      >
+        <section v-if="hasPreview" class="preview-panel">
+          <div class="inspector-heading">
+            <div>
+              <span>Preview</span>
+              <strong>{{ selected ? itemName(selected) : 'No selection' }}</strong>
+            </div>
+            <span class="mode-chip">{{ previewMode }}</span>
+          </div>
+          <TechPreviewCanvas
+            :mode="previewMode"
+            :cell="selectedCell"
+            :via="selectedVia"
+            :layers="techData.layers"
+          />
+        </section>
+
+        <section class="inspector-fields">
+          <div class="inspector-heading">
+            <div>
+              <span>Inspector</span>
+              <strong>{{ activeSectionConfig.label }}</strong>
+            </div>
+          </div>
+          <dl v-if="detailRows.length" class="detail-list">
+            <div v-for="[key, value] in detailRows" :key="key">
+              <dt>{{ key }}</dt>
+              <dd>{{ value }}</dd>
+            </div>
+          </dl>
+          <p v-else class="detail-empty">{{ detailEmptyText }}</p>
+        </section>
+      </aside>
+    </main>
+
+    <main v-else class="empty-state">
+      <i :class="isLoading ? 'ri-loader-4-line spin' : 'ri-database-2-line'"></i>
+      <h2>{{ isLoading ? 'Loading Tech Library' : 'No Tech Library Available' }}</h2>
+      <p>{{ error || 'Expected a view package such as gcd_view or place_dreamplace/output/gcd_place_view.' }}</p>
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.tech-library-view {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.tech-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 62px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-secondary));
+}
+
+.title-block {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 14px;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 760;
+}
+
+h2 {
+  font-size: 15px;
+  font-weight: 760;
+}
+
+.source-pill,
+.reload-button,
+.mode-chip {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+}
+
+.source-pill {
+  display: inline-flex;
+  min-width: 0;
+  max-width: min(520px, 48vw);
+  align-items: center;
+  gap: 8px;
+  height: 32px;
+  padding: 0 10px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.source-pill span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-pill i {
+  color: var(--accent-color);
+}
+
+.reload-button,
+.nav-item,
+.data-row,
+.resource-row {
+  border: 0;
+  font: inherit;
+}
+
+.reload-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.reload-button:hover {
+  border-color: color-mix(in srgb, var(--accent-color) 48%, var(--border-color));
+}
+
+.reload-button:active,
+.nav-item:active,
+.data-row:active,
+.resource-row:active {
+  transform: translateY(1px);
+}
+
+.reload-button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.reload-button:focus-visible,
+.nav-item:focus-visible,
+.data-row:focus-visible,
+.resource-row:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-color) 58%, transparent);
+  outline-offset: -2px;
+}
+
+.tech-workbench {
+  display: grid;
+  grid-template-columns: 196px minmax(420px, 1fr) 390px;
+  min-height: 0;
+  flex: 1;
+}
+
+.tech-workbench.overview {
+  grid-template-columns: 196px minmax(620px, 1fr);
+}
+
+.tech-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border-right: 1px solid var(--border-color);
+  background: var(--bg-sidebar);
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 36px;
+  padding: 0 10px;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-align: left;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.nav-item:hover {
+  background: color-mix(in srgb, var(--bg-primary) 72%, var(--bg-secondary));
+  color: var(--text-primary);
+}
+
+.nav-item.active {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 32%, var(--border-color));
+}
+
+.nav-label {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+.nav-label span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nav-item.active i {
+  color: var(--accent-color);
+}
+
+.count-badge {
+  min-width: 30px;
+  max-width: 58px;
+  overflow: hidden;
+  text-align: right;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.tech-main {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+.summary-bar {
+  display: grid;
+  grid-template-columns: minmax(210px, 0.95fr) minmax(320px, 1.55fr);
+  min-height: 72px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.summary-source {
+  display: grid;
+  align-content: center;
+  gap: 2px;
+  padding: 12px 16px;
+  border-right: 1px solid var(--border-color);
+}
+
+.summary-label,
+.summary-metrics span,
+.inspector-heading span,
+dt {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.summary-source strong {
+  font-size: 18px;
+}
+
+.summary-source > span:last-child {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.summary-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.summary-metrics div {
+  display: grid;
+  align-content: center;
+  gap: 3px;
+  padding: 12px 14px;
+  border-right: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+}
+
+.summary-metrics div:last-child {
+  border-right: 0;
+}
+
+.summary-metrics strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 18px;
+  font-variant-numeric: tabular-nums;
+}
+
+.overview-panel {
+  display: grid;
+  grid-template-columns: minmax(320px, 1.1fr) minmax(260px, 0.9fr);
+  gap: 16px;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px;
+}
+
+.package-summary,
+.inspector-fields,
+.preview-panel {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+}
+
+.package-summary {
+  min-width: 0;
+  padding: 16px;
+}
+
+.panel-heading,
+.inspector-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel-heading {
+  justify-content: flex-start;
+  margin-bottom: 18px;
+}
+
+.panel-heading i {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--accent-color) 30%, var(--border-color));
+  border-radius: 8px;
+  color: var(--accent-color);
+}
+
+.panel-heading p {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.overview-list,
+.detail-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+}
+
+.overview-list div,
+.detail-list div {
+  display: grid;
+  grid-template-columns: 118px minmax(0, 1fr);
+  gap: 12px;
+  align-items: baseline;
+  padding: 9px 0;
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+}
+
+dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 13px;
+}
+
+.resource-summary {
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+}
+
+.resource-summary-header,
+.resource-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(42px, auto) 20px;
+  align-items: center;
+  gap: 12px;
+}
+
+.resource-summary-header {
+  min-height: 40px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.resource-summary-header span {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.resource-summary-header strong {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 560;
+}
+
+.resource-row {
+  display: grid;
+  min-height: 48px;
+  padding: 0 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 68%, transparent);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.resource-row:last-child {
+  border-bottom: 0;
+}
+
+.resource-row:hover {
+  background: color-mix(in srgb, var(--accent-color) 7%, transparent);
+}
+
+.resource-name {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+.resource-name i {
+  color: var(--accent-color);
+  font-size: 16px;
+}
+
+.resource-name span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 620;
+}
+
+.resource-row strong {
+  text-align: right;
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+}
+
+.resource-row > i:last-child {
+  color: var(--text-secondary);
+  justify-self: end;
+}
+
+.table-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-title {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.section-title i {
+  color: var(--accent-color);
+  font-size: 18px;
+}
+
+.section-title span {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: min(300px, 48%);
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.search-box:focus-within {
+  border-color: color-mix(in srgb, var(--accent-color) 56%, var(--border-color));
+}
+
+.search-box input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+}
+
+.data-table {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.data-table-header,
+.data-row {
+  display: grid;
+  grid-template-columns: 70px minmax(180px, 1.2fr) minmax(110px, 0.7fr) minmax(120px, 0.8fr);
+  align-items: center;
+  gap: 12px;
+}
+
+.data-table-header {
+  min-height: 32px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-secondary) 82%, var(--bg-primary));
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.data-table-body {
+  min-height: 0;
+  overflow: auto;
+}
+
+.data-row {
+  width: 100%;
+  min-height: 38px;
+  padding: 0 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 64%, transparent);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+  transition: background 120ms ease, box-shadow 120ms ease;
+}
+
+.data-row:hover {
+  background: color-mix(in srgb, var(--accent-color) 7%, transparent);
+}
+
+.data-row.selected {
+  background: color-mix(in srgb, var(--accent-color) 11%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 44%, var(--border-color));
+}
+
+.row-id {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.row-name,
+.row-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-name {
+  font-weight: 680;
+}
+
+.row-meta {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.table-empty {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.tech-inspector {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 12px;
+  overflow: auto;
+  padding: 12px;
+  border-left: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-secondary));
+}
+
+.tech-inspector.fieldsOnly {
+  background: var(--bg-primary);
+}
+
+.preview-panel,
+.inspector-fields {
+  min-width: 0;
+  padding: 12px;
+}
+
+.preview-panel {
+  display: grid;
+  gap: 10px;
+}
+
+.inspector-heading strong {
+  display: block;
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.mode-chip {
+  padding: 3px 7px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.inspector-fields {
+  display: grid;
+  gap: 12px;
+}
+
+.detail-empty {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  text-align: center;
+  padding: 24px;
+}
+
+.empty-state i {
+  color: var(--accent-color);
+  font-size: 34px;
+}
+
+.empty-state h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 18px;
+}
+
+.empty-state p {
+  max-width: 520px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.selectable {
+  user-select: text;
+}
+
+.spin {
+  animation: spin 0.9s linear infinite;
+}
+
+@media (max-width: 1180px) {
+  .tech-workbench {
+    grid-template-columns: 172px minmax(360px, 1fr);
+    grid-template-rows: minmax(0, 1fr) minmax(280px, 38%);
+  }
+
+  .tech-workbench.overview {
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  .tech-nav {
+    grid-row: 1 / 3;
+  }
+
+  .tech-workbench.overview .tech-nav {
+    grid-row: 1;
+  }
+
+  .tech-inspector {
+    grid-column: 2;
+    flex-direction: row;
+    border-top: 1px solid var(--border-color);
+    border-left: 0;
+  }
+
+  .preview-panel,
+  .inspector-fields {
+    flex: 1 1 0;
+  }
+}
+
+@media (max-width: 820px) {
+  .tech-topbar,
+  .table-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .title-block {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .source-pill,
+  .search-box {
+    width: 100%;
+    max-width: none;
+  }
+
+  .tech-workbench {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+  }
+
+  .tech-workbench.overview {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .tech-nav {
+    grid-row: auto;
+    flex-direction: row;
+    overflow-x: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .nav-item {
+    flex: 0 0 auto;
+  }
+
+  .summary-bar,
+  .overview-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .data-table-header,
+  .data-row {
+    grid-template-columns: 54px minmax(150px, 1fr) minmax(112px, 0.7fr) minmax(112px, 0.7fr);
+  }
+
+  .tech-inspector {
+    grid-column: auto;
+    flex-direction: column;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/ecos/gui/apps/renderer/src/views/TechLibraryView.workbench.test.ts
+++ b/ecos/gui/apps/renderer/src/views/TechLibraryView.workbench.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import source from './TechLibraryView.vue?raw'
+
+describe('TechLibraryView workbench UI', () => {
+  it('exposes the Tech Workbench structure for scanning and inspection', () => {
+    expect(source).toContain('class="tech-workbench"')
+    expect(source).toContain('class="source-pill"')
+    expect(source).toContain('class="count-badge"')
+    expect(source).toContain('class="resource-summary"')
+    expect(source).toContain('class="resource-row"')
+    expect(source).toContain('class="data-table-header"')
+    expect(source).toContain('class="tech-inspector"')
+    expect(source).toContain(`v-if="activeSection !== 'overview'"`)
+    expect(source).toContain(`:class="{ overview: activeSection === 'overview' }"`)
+    expect(source).toContain(`v-if="hasPreview"`)
+    expect(source).toContain('class="preview-panel"')
+    expect(source).toContain('@media (max-width: 1180px)')
+  })
+
+  it('keeps table selection and inspector empty copy section-aware', () => {
+    expect(source).toContain(':aria-selected="selected === row"')
+    expect(source).toContain('detailEmptyText')
+    expect(source).not.toContain('Select a via or cell master to inspect geometry.')
+  })
+})

--- a/ecos/gui/packages/shared/src/index.ts
+++ b/ecos/gui/packages/shared/src/index.ts
@@ -64,6 +64,7 @@ export type {
   WorkspaceStepInfoRequest,
   WorkspaceStepInfoResult,
   WorkspaceStepResource,
+  WorkspaceTechResources,
 } from './types/workspaceResources.ts';
 export type { TileGenerationRequest, TileGenerationResult } from './types/tile.ts';
 export {

--- a/ecos/gui/packages/shared/src/types/workspaceResources.ts
+++ b/ecos/gui/packages/shared/src/types/workspaceResources.ts
@@ -11,6 +11,7 @@ export interface WorkspaceResourceFile {
     | 'layout-image'
     | 'layout-json'
     | 'view-json'
+    | 'tech-json'
     | 'metrics'
     | 'analysis'
     | 'subflow'
@@ -45,6 +46,17 @@ export interface WorkspaceStepResource {
   };
 }
 
+export interface WorkspaceTechResources {
+  packageRoot: string;
+  source: 'view-package';
+  manifest: WorkspaceResourceFile;
+  meta?: WorkspaceResourceFile;
+  layers: WorkspaceResourceFile;
+  sites: WorkspaceResourceFile;
+  vias: WorkspaceResourceFile;
+  cellMasters: WorkspaceResourceFile;
+}
+
 export interface WorkspaceResourceIndex {
   root: string;
   design: string;
@@ -61,6 +73,7 @@ export interface WorkspaceResourceIndex {
   flow: {
     steps: WorkspaceStepResource[];
   };
+  tech?: WorkspaceTechResources;
   status: WorkspaceResourceStatus;
   messages: string[];
 }


### PR DESCRIPTION
## Summary
- Add workspace-level Tech Library discovery and shared resource typing for view-package tech data.
- Add the Tech Library route, sidebar entry, loader, and UI for overview/layers/sites/via masters/cell masters.
- Render via/cell previews with Pixi using view-json-style grouped fill passes so same-color overlaps do not compound alpha into a darker third color.

## Tests
- pnpm --filter @ecos-studio/renderer exec vitest run src/applications/editor/tech-library/loader.test.ts src/applications/editor/tech-library/previewRendering.test.ts src/applications/editor/tech-library/previewGeometry.test.ts src/views/TechLibraryView.workbench.test.ts src/router/index.test.ts src/composables/useCurrentStage.test.ts src/api/type.tech.test.ts src/applications/editor/view-json/overview.test.ts src/applications/editor/view-json/gpuInstances.test.ts
- pnpm --filter @ecos-studio/renderer run typecheck
- pnpm --filter @ecos-studio/desktop-electron test
- pnpm --filter @ecos-studio/desktop-electron typecheck

## Notes
- Base branch: ekko/feat-view-json-rendering