### PR TITLE
fix(gui): stop stale preview image loading

### DIFF
--- a/ecos/gui/apps/renderer/src/components/DrawingArea.runtime.test.ts
+++ b/ecos/gui/apps/renderer/src/components/DrawingArea.runtime.test.ts
@@ -895,6 +895,57 @@ describe('DrawingArea runtime guards', () => {
     expect(container.querySelector('.to-layout-mode')).toBeNull()
   })
 
+  it('stops preview image loading when the image resource cannot be read', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    resolveWorkspaceStepInfoApi.mockResolvedValue({
+      response: 'available',
+      info: {
+        image: 'synth/output/missing.png',
+        json: 'synth/output/layout.json',
+      },
+    })
+    getResourceUrl.mockRejectedValue(new Error('ENOENT: missing preview image'))
+
+    try {
+      await mountDrawingArea('/workspace/Synthesis')
+
+      expect(getResourceUrl).toHaveBeenCalledWith(
+        'synth/output/missing.png',
+        '/workspace/demo',
+      )
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to load stage results:',
+        expect.any(Error),
+      )
+      expect(testState!.fakeEditor.setBackgroundImage).not.toHaveBeenCalled()
+      expect(testState!.fakeEditor.clearBackground).toHaveBeenCalled()
+      expect(testState!.layoutState.loadingState.value).toBe('idle')
+      expect(testState!.layoutState.loadingMessage.value).toBe('')
+      expect(testState!.layoutState.renderMode.value).toBe('image')
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('does not enter preview image loading when the stage has no image path', async () => {
+    resolveWorkspaceStepInfoApi.mockResolvedValue({
+      response: 'missing',
+      info: {
+        json: 'synth/output/layout.json',
+      },
+      missing: ['synth/output/gcd_synth.png'],
+    })
+
+    await mountDrawingArea('/workspace/Synthesis')
+
+    expect(getResourceUrl).not.toHaveBeenCalled()
+    expect(testState!.fakeEditor.setBackgroundImage).not.toHaveBeenCalled()
+    expect(testState!.fakeEditor.clearBackground).toHaveBeenCalled()
+    expect(testState!.layoutState.loadingState.value).toBe('idle')
+    expect(testState!.layoutState.loadingMessage.value).toBe('')
+    expect(testState!.layoutState.renderMode.value).toBe('image')
+  })
+
   it('does not let a stale preview image load from the previous route overwrite the current stage', async () => {
     const staleImage = deferred<string>()
     resolveWorkspaceStepInfoApi.mockImplementation(async ({ step }: { step: string }) => {

--- a/ecos/gui/apps/renderer/src/components/DrawingArea.vue
+++ b/ecos/gui/apps/renderer/src/components/DrawingArea.vue
@@ -617,11 +617,17 @@ async function onPreviewModeChange(mode: 'layout' | 'image'): Promise<void> {
   try {
     if (mode === 'image') {
       const imagePath = previewImageRelativePath.value
-      if (!imagePath) return
+      if (!imagePath) {
+        if (guard.isCurrent()) resetLoadingState()
+        return
+      }
       await loadStepImagePreview(imagePath, guard)
     } else {
       const packageRoot = currentViewJsonPackageRoot.value
-      if (!packageRoot) return
+      if (!packageRoot) {
+        if (guard.isCurrent()) resetLoadingState()
+        return
+      }
       const overview = await loadStepViewJsonOverview(packageRoot, guard)
       if (!overview) return
       showViewJsonLayout(overview, guard)
@@ -666,7 +672,10 @@ const handleStageChange = async (stage: string) => {
         ?? null
       const imagePath = typeof info.image === 'string' && info.image.length > 0 ? info.image : null
       if (!imagePath) {
-        throw new Error(`Preview image is not available for ${stepEnum}.`)
+        editor.value?.clearBackground()
+        cleanupLayout()
+        clearCurrentViewJsonOverview()
+        return
       }
       const viewJsonPackageRoot = pickViewJsonPackageRoot(info)
       cleanupLayout()
@@ -686,11 +695,13 @@ const handleStageChange = async (stage: string) => {
     drcJsonRelativePath.value = null
   } catch (error) {
     console.error('Failed to load stage results:', error)
+    if (!guard.isCurrent()) return
     editor.value?.clearBackground()
     cleanupLayout()
     clearCurrentViewJsonOverview()
     layoutJsonRelativePath.value = null
     drcJsonRelativePath.value = null
+    resetLoadingState()
   }
 }
 


### PR DESCRIPTION
## Summary
- Reset DrawingArea loading state when preview image resources are unavailable or fail to load.
- Clear stale preview state for missing image paths without surfacing a permanent loading overlay.
- Add runtime regression coverage for missing and unreadable preview images.

## Tests
- pnpm --dir ecos/gui/apps/renderer test
- pnpm --dir ecos/gui/apps/renderer typecheck
- git diff --check