### PR TITLE
feat: add shared runtime manager

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderContract.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderContract.ts
@@ -1,0 +1,28 @@
+import type {
+  DesktopAgentEvent,
+  DesktopAgentListSessionsRequest,
+  DesktopAgentListSessionsResponse,
+  DesktopAgentProviderRequest,
+  DesktopAgentResumeSessionRequest,
+  DesktopAgentResumeSessionResponse,
+  DesktopAgentSendMessageRequest,
+  DesktopAgentSendMessageResponse,
+  DesktopAgentSetModeRequest,
+  DesktopAgentStartRequest,
+  DesktopAgentStartSessionRequest,
+  DesktopAgentStartSessionResponse,
+  DesktopAgentStatus,
+} from '@ecos-studio/shared'
+
+export interface AgentProviderRuntime {
+  start(request?: DesktopAgentStartRequest): Promise<void>
+  startSession(request: DesktopAgentStartSessionRequest): Promise<DesktopAgentStartSessionResponse>
+  sendMessage(request: DesktopAgentSendMessageRequest): Promise<DesktopAgentSendMessageResponse>
+  interrupt(request?: DesktopAgentProviderRequest): Promise<void>
+  getStatus(request?: DesktopAgentProviderRequest): Promise<DesktopAgentStatus>
+  setMode(request: DesktopAgentSetModeRequest): Promise<DesktopAgentStatus>
+  listSessions(request: DesktopAgentListSessionsRequest): Promise<DesktopAgentListSessionsResponse>
+  resumeSession(request: DesktopAgentResumeSessionRequest): Promise<DesktopAgentResumeSessionResponse>
+  stop(request?: DesktopAgentProviderRequest): Promise<void>
+  onEvent(listener: (event: DesktopAgentEvent) => void): () => void
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderPlugin.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderPlugin.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  discoverAgentProviderManifests,
+  supportedAgentProviderProtocolVersion,
+} from './agentProviderPlugin'
+
+describe('agent provider plugin manifests', () => {
+  it('discovers provider manifests from plugin roots and resolves command cwd', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'ecos-agent-provider-'))
+    try {
+      const pluginRoot = path.join(root, 'codex')
+      await mkdir(pluginRoot)
+      await writeFile(path.join(pluginRoot, 'agent-provider.json'), JSON.stringify({
+        args: ['--stdio'],
+        command: './bin/codex-provider',
+        displayName: 'Codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      }))
+
+      await expect(discoverAgentProviderManifests([root])).resolves.toEqual([
+        {
+          args: ['--stdio'],
+          command: './bin/codex-provider',
+          displayName: 'Codex',
+          manifestPath: path.join(pluginRoot, 'agent-provider.json'),
+          pluginRoot,
+          providerId: 'codex',
+          protocolVersion: supportedAgentProviderProtocolVersion,
+        },
+      ])
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('rejects provider manifests with unsupported protocol versions', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'ecos-agent-provider-'))
+    try {
+      await writeFile(path.join(root, 'agent-provider.json'), JSON.stringify({
+        command: 'codex-provider',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion + 1,
+      }))
+
+      await expect(discoverAgentProviderManifests([root])).rejects.toThrow(
+        'Unsupported agent provider protocol version',
+      )
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderPlugin.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderPlugin.ts
@@ -1,0 +1,125 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export const supportedAgentProviderProtocolVersion = 1
+export const agentProviderManifestFileName = 'agent-provider.json'
+
+export interface AgentProviderManifest {
+  args?: string[]
+  command: string
+  displayName?: string
+  providerId: string
+  protocolVersion: number
+}
+
+export interface ResolvedAgentProviderManifest extends AgentProviderManifest {
+  manifestPath: string
+  pluginRoot: string
+}
+
+export async function discoverAgentProviderManifests(
+  roots: string[],
+): Promise<ResolvedAgentProviderManifest[]> {
+  const manifests: ResolvedAgentProviderManifest[] = []
+  const seenManifestPaths = new Set<string>()
+
+  for (const root of roots) {
+    for (const manifestPath of await manifestPathsForRoot(root)) {
+      if (seenManifestPaths.has(manifestPath)) continue
+      seenManifestPaths.add(manifestPath)
+      const manifest = await readAgentProviderManifest(manifestPath)
+      if (manifest) {
+        manifests.push(manifest)
+      }
+    }
+  }
+
+  return manifests.sort((first, second) => first.providerId.localeCompare(second.providerId))
+}
+
+async function manifestPathsForRoot(root: string): Promise<string[]> {
+  const paths = [path.join(root, agentProviderManifestFileName)]
+
+  try {
+    const entries = await readdir(root, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        paths.push(path.join(root, entry.name, agentProviderManifestFileName))
+      }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  return paths
+}
+
+async function readAgentProviderManifest(
+  manifestPath: string,
+): Promise<ResolvedAgentProviderManifest | null> {
+  let raw: string
+  try {
+    raw = await readFile(manifestPath, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+
+  const manifest = validateAgentProviderManifest(JSON.parse(raw), manifestPath)
+  return {
+    ...manifest,
+    manifestPath,
+    pluginRoot: path.dirname(manifestPath),
+  }
+}
+
+function validateAgentProviderManifest(
+  value: unknown,
+  manifestPath: string,
+): AgentProviderManifest {
+  const record = readRecord(value)
+  const providerId = readString(record.providerId)
+  const command = readString(record.command)
+  const displayName = readOptionalString(record.displayName)
+  const protocolVersion = record.protocolVersion
+  const args = readStringArray(record.args)
+
+  if (!providerId) {
+    throw new Error(`Agent provider manifest is missing providerId: ${manifestPath}`)
+  }
+  if (!command) {
+    throw new Error(`Agent provider manifest is missing command: ${manifestPath}`)
+  }
+  if (protocolVersion !== supportedAgentProviderProtocolVersion) {
+    throw new Error(
+      `Unsupported agent provider protocol version in ${manifestPath}: ${String(protocolVersion)}`,
+    )
+  }
+
+  return {
+    ...(args ? { args } : {}),
+    command,
+    ...(displayName ? { displayName } : {}),
+    providerId,
+    protocolVersion,
+  }
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {}
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value.map((item) => String(item))
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
@@ -8,12 +8,14 @@ import {
 } from './agentProviderProcessRuntime'
 import { supportedAgentProviderProtocolVersion } from './agentProviderPlugin'
 
+class FakeStdin extends EventEmitter {
+  readonly write = vi.fn()
+}
+
 class FakeChild extends EventEmitter {
   readonly stdout = new EventEmitter()
   readonly stderr = new EventEmitter()
-  readonly stdin = {
-    write: vi.fn(),
-  }
+  readonly stdin = new FakeStdin()
   readonly kill = vi.fn()
 }
 
@@ -138,6 +140,109 @@ describe('AgentProviderProcessRuntime', () => {
     await expect(response).rejects.toThrow(
       'Agent provider codex exited with code 1',
     )
+  })
+
+  it('rejects pending requests when provider stdin writes fail', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+
+    const response = runtime.getStatus({ providerId: 'codex' })
+    const error = new Error('write EPIPE') as NodeJS.ErrnoException
+    error.code = 'EPIPE'
+
+    expect(() => {
+      harness.children[0].stdin.emit('error', error)
+    }).not.toThrow()
+
+    await expect(response).rejects.toThrow('write EPIPE')
+    expect(harness.children[0].kill).toHaveBeenCalled()
+  })
+
+  it('kills the provider when stdin write callbacks fail', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+    const error = new Error('write EPIPE') as NodeJS.ErrnoException
+    error.code = 'EPIPE'
+
+    const response = runtime.getStatus({ providerId: 'codex' })
+    harness.children[0].stdin.write.mock.calls[0][1]?.(error)
+
+    await expect(response).rejects.toThrow('write EPIPE')
+    expect(harness.children[0].kill).toHaveBeenCalled()
+
+    const nextResponse = runtime.getStatus({ providerId: 'codex' })
+    expect(harness.children).toHaveLength(2)
+    const secondRequest = readProtocolRequest(harness.children[1])
+    harness.children[1].stdout.emit('data', `${JSON.stringify({
+      id: secondRequest.id,
+      result: {
+        providerId: 'codex',
+        state: 'ready',
+      },
+    })}\n`)
+
+    await expect(nextResponse).resolves.toEqual({
+      providerId: 'codex',
+      state: 'ready',
+    })
+  })
+
+  it('ignores stdout from failed providers after respawning', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+    const error = new Error('write EPIPE') as NodeJS.ErrnoException
+    error.code = 'EPIPE'
+
+    const firstResponse = runtime.getStatus({ providerId: 'codex' })
+    harness.children[0].stdin.write.mock.calls[0][1]?.(error)
+    await expect(firstResponse).rejects.toThrow('write EPIPE')
+
+    const secondResponse = runtime.getStatus({ providerId: 'codex' })
+    const secondRequest = readProtocolRequest(harness.children[1])
+
+    expect(() => {
+      harness.children[0].stdout.emit('data', 'not json\n')
+    }).not.toThrow()
+
+    harness.children[1].stdout.emit('data', `${JSON.stringify({
+      id: secondRequest.id,
+      result: {
+        providerId: 'codex',
+        state: 'ready',
+      },
+    })}\n`)
+
+    await expect(secondResponse).resolves.toEqual({
+      providerId: 'codex',
+      state: 'ready',
+    })
   })
 
   it('drops partial stdout from a crashed provider before respawning', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
@@ -140,6 +140,43 @@ describe('AgentProviderProcessRuntime', () => {
     )
   })
 
+  it('drops partial stdout from a crashed provider before respawning', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+
+    const firstResponse = runtime.getStatus({ providerId: 'codex' })
+    harness.children[0].stdout.emit('data', '{"id":')
+    harness.children[0].emit('close', 1, null)
+    await expect(firstResponse).rejects.toThrow(
+      'Agent provider codex exited with code 1',
+    )
+
+    const secondResponse = runtime.getStatus({ providerId: 'codex' })
+    const secondChild = harness.children[1]
+    const secondRequest = readProtocolRequest(secondChild)
+    secondChild.stdout.emit('data', `${JSON.stringify({
+      id: secondRequest.id,
+      result: {
+        providerId: 'codex',
+        state: 'ready',
+      },
+    })}\n`)
+
+    await expect(secondResponse).resolves.toEqual({
+      providerId: 'codex',
+      state: 'ready',
+    })
+  })
+
   it('drains provider stderr so diagnostics cannot block the child process', () => {
     const harness = createSpawnHarness()
     const runtime = new AgentProviderProcessRuntime({

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
@@ -265,4 +265,56 @@ describe('AgentProviderProcessRuntime', () => {
       state: 'ready',
     })
   })
+
+  it('continues parsing batched stdout after a provider event listener throws', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+    const manager = new AgentRuntimeManager({
+      providers: [
+        { providerId: 'codex', runtime },
+      ],
+    })
+    manager.onEvent(() => {
+      throw new Error('listener failed')
+    })
+
+    const response = runtime.getStatus({ providerId: 'codex' })
+    const child = harness.children[0]
+    const request = readProtocolRequest(child)
+
+    expect(() => {
+      child.stdout.emit('data', `${JSON.stringify({
+        event: {
+          text: 'working',
+          type: 'message',
+        },
+        type: 'event',
+      })}\n${JSON.stringify({
+        id: request.id,
+        result: {
+          providerId: 'codex',
+          state: 'ready',
+        },
+      })}\n`)
+    }).toThrow('listener failed')
+
+    await expect(Promise.race([
+      response,
+      new Promise((resolve) => {
+        setTimeout(() => resolve({ timedOut: true }), 25)
+      }),
+    ])).resolves.toEqual({
+      providerId: 'codex',
+      state: 'ready',
+    })
+  })
 })

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
@@ -1,0 +1,142 @@
+import { EventEmitter } from 'node:events'
+import type { spawn as spawnChild } from 'node:child_process'
+import { describe, expect, it, vi } from 'vitest'
+import { AgentRuntimeManager } from './agentRuntimeManager'
+import {
+  AgentProviderProcessRuntime,
+  type AgentProviderProtocolRequest,
+} from './agentProviderProcessRuntime'
+import { supportedAgentProviderProtocolVersion } from './agentProviderPlugin'
+
+class FakeChild extends EventEmitter {
+  readonly stdout = new EventEmitter()
+  readonly stderr = new EventEmitter()
+  readonly stdin = {
+    write: vi.fn(),
+  }
+  readonly kill = vi.fn()
+}
+
+function createSpawnHarness() {
+  const children: FakeChild[] = []
+  const spawn = vi.fn((command: string, args: string[], options: unknown) => {
+    const child = new FakeChild()
+    children.push(child)
+    return child as never
+  })
+
+  return {
+    children,
+    spawn: spawn as unknown as typeof spawnChild,
+  }
+}
+
+function readProtocolRequest(child: FakeChild, callIndex = 0): AgentProviderProtocolRequest {
+  const raw = String(child.stdin.write.mock.calls[callIndex][0]).trim()
+  return JSON.parse(raw) as AgentProviderProtocolRequest
+}
+
+describe('AgentProviderProcessRuntime', () => {
+  it('uses stdio JSON-RPC requests and resolves provider responses', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        args: ['--stdio'],
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+
+    const response = runtime.startSession({
+      directory: '/work/demo',
+      providerId: 'codex',
+    })
+    const child = harness.children[0]
+    const request = readProtocolRequest(child)
+
+    expect(harness.spawn).toHaveBeenCalledWith('codex-provider', ['--stdio'], {
+      cwd: '/plugins/codex',
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    expect(request).toEqual({
+      id: expect.any(String),
+      method: 'startSession',
+      params: {
+        directory: '/work/demo',
+        providerId: 'codex',
+      },
+    })
+
+    child.stdout.emit('data', `${JSON.stringify({
+      id: request.id,
+      result: { sessionId: 'session-1' },
+    })}\n`)
+
+    await expect(response).resolves.toEqual({
+      sessionId: 'session-1',
+    })
+  })
+
+  it('forwards provider events from process stdout through AgentRuntimeManager', () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'local-provider',
+        manifestPath: '/plugins/local/agent-provider.json',
+        pluginRoot: '/plugins/local',
+        providerId: 'local',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+    const manager = new AgentRuntimeManager({
+      providers: [
+        { providerId: 'local', runtime },
+      ],
+    })
+    const listener = vi.fn()
+    manager.onEvent(listener)
+
+    void runtime.getStatus({ providerId: 'local' })
+    const child = harness.children[0]
+    child.stdout.emit('data', `${JSON.stringify({
+      event: {
+        text: 'working',
+        type: 'message',
+      },
+      type: 'event',
+    })}\n`)
+
+    expect(listener).toHaveBeenCalledWith({
+      providerId: 'local',
+      text: 'working',
+      type: 'message',
+    })
+  })
+
+  it('rejects pending requests when the provider process exits', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+
+    const response = runtime.getStatus({ providerId: 'codex' })
+    harness.children[0].emit('close', 1, null)
+
+    await expect(response).rejects.toThrow(
+      'Agent provider codex exited with code 1',
+    )
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.test.ts
@@ -139,4 +139,93 @@ describe('AgentProviderProcessRuntime', () => {
       'Agent provider codex exited with code 1',
     )
   })
+
+  it('drains provider stderr so diagnostics cannot block the child process', () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+
+    void runtime.getStatus({ providerId: 'codex' })
+    expect(harness.children[0].stderr.listenerCount('data')).toBe(1)
+  })
+
+  it('rejects pending requests instead of throwing on malformed provider stdout', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+
+    const response = runtime.getStatus({ providerId: 'codex' })
+    expect(() => {
+      harness.children[0].stdout.emit('data', 'not json\n')
+    }).not.toThrow()
+
+    await expect(response).rejects.toThrow(
+      'Invalid JSON from agent provider codex',
+    )
+  })
+
+  it('does not reject pending requests when a provider event listener throws', async () => {
+    const harness = createSpawnHarness()
+    const runtime = new AgentProviderProcessRuntime({
+      manifest: {
+        command: 'codex-provider',
+        manifestPath: '/plugins/codex/agent-provider.json',
+        pluginRoot: '/plugins/codex',
+        providerId: 'codex',
+        protocolVersion: supportedAgentProviderProtocolVersion,
+      },
+      spawn: harness.spawn,
+    })
+    const manager = new AgentRuntimeManager({
+      providers: [
+        { providerId: 'codex', runtime },
+      ],
+    })
+    manager.onEvent(() => {
+      throw new Error('listener failed')
+    })
+
+    const response = runtime.getStatus({ providerId: 'codex' })
+    const child = harness.children[0]
+    const request = readProtocolRequest(child)
+
+    expect(() => {
+      child.stdout.emit('data', `${JSON.stringify({
+        event: {
+          text: 'working',
+          type: 'message',
+        },
+        type: 'event',
+      })}\n`)
+    }).toThrow('listener failed')
+
+    child.stdout.emit('data', `${JSON.stringify({
+      id: request.id,
+      result: {
+        providerId: 'codex',
+        state: 'ready',
+      },
+    })}\n`)
+
+    await expect(response).resolves.toEqual({
+      providerId: 'codex',
+      state: 'ready',
+    })
+  })
 })

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
@@ -168,10 +168,24 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
     this.stdoutBuffer += text
     const lines = this.stdoutBuffer.split(/\r?\n/)
     this.stdoutBuffer = lines.pop() ?? ''
+    let deferredError: unknown
+    let hasDeferredError = false
 
     for (const line of lines) {
       const record = this.readProtocolLine(line)
-      if (record) this.handleProtocolRecord(record)
+      if (!record) continue
+      try {
+        this.handleProtocolRecord(record)
+      } catch (error) {
+        if (!hasDeferredError) {
+          deferredError = error
+          hasDeferredError = true
+        }
+      }
+    }
+
+    if (hasDeferredError) {
+      throw deferredError
     }
   }
 

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
@@ -127,6 +127,7 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
   private ensureChild(): ReturnType<SpawnLike> {
     if (this.child) return this.child
 
+    this.stdoutBuffer = ''
     const child = this.spawnImpl(
       this.manifest.command,
       this.manifest.args ?? [],
@@ -145,15 +146,19 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
       // Drain diagnostics so provider stderr cannot fill its pipe and block stdout responses.
     })
     child.once('error', (error) => {
+      if (this.child !== child) return
       this.rejectPending(error instanceof Error ? error : new Error(String(error)))
       this.child = null
+      this.stdoutBuffer = ''
     })
     child.once('close', (code, signal) => {
+      if (this.child !== child) return
       const message = signal
         ? `Agent provider ${this.manifest.providerId} exited with signal ${signal}`
         : `Agent provider ${this.manifest.providerId} exited with code ${code ?? 'unknown'}`
       this.rejectPending(new Error(message))
       this.child = null
+      this.stdoutBuffer = ''
     })
 
     return child

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
@@ -141,6 +141,9 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
     child.stdout?.on('data', (data: unknown) => {
       this.handleStdout(dataToString(data))
     })
+    child.stderr?.on('data', () => {
+      // Drain diagnostics so provider stderr cannot fill its pipe and block stdout responses.
+    })
     child.once('error', (error) => {
       this.rejectPending(error instanceof Error ? error : new Error(String(error)))
       this.child = null
@@ -162,14 +165,27 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
     this.stdoutBuffer = lines.pop() ?? ''
 
     for (const line of lines) {
-      this.handleProtocolLine(line)
+      const record = this.readProtocolLine(line)
+      if (record) this.handleProtocolRecord(record)
     }
   }
 
-  private handleProtocolLine(line: string): void {
-    if (!line.trim()) return
+  private readProtocolLine(line: string): Record<string, unknown> | null {
+    if (!line.trim()) return null
 
-    const record = readRecord(JSON.parse(line))
+    try {
+      return readRecord(JSON.parse(line))
+    } catch (error) {
+      this.rejectPending(new Error(
+        `Invalid JSON from agent provider ${this.manifest.providerId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ))
+      return null
+    }
+  }
+
+  private handleProtocolRecord(record: Record<string, unknown>): void {
     if (record.type === 'event') {
       const event = readRecord(record.event) as Partial<DesktopAgentEvent>
       if (typeof event.type === 'string') {

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
@@ -111,6 +111,10 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
 
   private sendRequest(method: AgentProviderMethod, params?: unknown): Promise<unknown> {
     const child = this.ensureChild()
+    const stdin = child.stdin
+    if (!stdin || stdin.destroyed || stdin.writableEnded) {
+      return Promise.reject(new Error(`Agent provider ${this.manifest.providerId} stdin is closed`))
+    }
     const id = randomUUID()
     const request: AgentProviderProtocolRequest = {
       id,
@@ -120,7 +124,17 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
 
     return new Promise((resolve, reject) => {
       this.pendingRequests.set(id, { reject, resolve })
-      child.stdin?.write(`${JSON.stringify(request)}\n`)
+      try {
+        stdin.write(`${JSON.stringify(request)}\n`, (error?: Error | null) => {
+          if (error) {
+            this.handleChildFailure(child, error)
+            child.kill()
+          }
+        })
+      } catch (error) {
+        this.handleChildFailure(child, error instanceof Error ? error : new Error(String(error)))
+        child.kill()
+      }
     })
   }
 
@@ -140,25 +154,27 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
     this.child = child
 
     child.stdout?.on('data', (data: unknown) => {
+      if (this.child !== child) return
       this.handleStdout(dataToString(data))
     })
     child.stderr?.on('data', () => {
       // Drain diagnostics so provider stderr cannot fill its pipe and block stdout responses.
     })
+    child.stdin?.once('error', (error) => {
+      if (this.child !== child) return
+      this.handleChildFailure(child, error instanceof Error ? error : new Error(String(error)))
+      child.kill()
+    })
     child.once('error', (error) => {
       if (this.child !== child) return
-      this.rejectPending(error instanceof Error ? error : new Error(String(error)))
-      this.child = null
-      this.stdoutBuffer = ''
+      this.handleChildFailure(child, error instanceof Error ? error : new Error(String(error)))
     })
     child.once('close', (code, signal) => {
       if (this.child !== child) return
       const message = signal
         ? `Agent provider ${this.manifest.providerId} exited with signal ${signal}`
         : `Agent provider ${this.manifest.providerId} exited with code ${code ?? 'unknown'}`
-      this.rejectPending(new Error(message))
-      this.child = null
-      this.stdoutBuffer = ''
+      this.handleChildFailure(child, new Error(message))
     })
 
     return child
@@ -234,6 +250,13 @@ export class AgentProviderProcessRuntime implements AgentProviderRuntime {
       pending.reject(error)
     }
     this.pendingRequests.clear()
+  }
+
+  private handleChildFailure(child: ReturnType<SpawnLike>, error: Error): void {
+    if (this.child !== child) return
+    this.rejectPending(error)
+    this.child = null
+    this.stdoutBuffer = ''
   }
 }
 

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentProviderProcessRuntime.ts
@@ -1,0 +1,215 @@
+import { spawn as spawnChild } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import type {
+  DesktopAgentEvent,
+  DesktopAgentListSessionsRequest,
+  DesktopAgentListSessionsResponse,
+  DesktopAgentProviderRequest,
+  DesktopAgentResumeSessionRequest,
+  DesktopAgentResumeSessionResponse,
+  DesktopAgentSendMessageRequest,
+  DesktopAgentSendMessageResponse,
+  DesktopAgentSetModeRequest,
+  DesktopAgentStartRequest,
+  DesktopAgentStartSessionRequest,
+  DesktopAgentStartSessionResponse,
+  DesktopAgentStatus,
+} from '@ecos-studio/shared'
+import type { AgentProviderRuntime } from './agentProviderContract'
+import type { ResolvedAgentProviderManifest } from './agentProviderPlugin'
+import { RuntimeEventFanout } from '../runtime/runtimeEvents'
+
+type SpawnLike = typeof spawnChild
+type AgentProviderMethod =
+  | 'getStatus'
+  | 'interrupt'
+  | 'listSessions'
+  | 'resumeSession'
+  | 'sendMessage'
+  | 'setMode'
+  | 'start'
+  | 'startSession'
+  | 'stop'
+
+export interface AgentProviderProtocolRequest {
+  id: string
+  method: AgentProviderMethod
+  params?: unknown
+}
+
+interface AgentProviderProtocolResponse {
+  error?: string | { message?: string }
+  id?: string
+  result?: unknown
+}
+
+interface AgentProviderProcessRuntimeOptions {
+  env?: NodeJS.ProcessEnv
+  manifest: ResolvedAgentProviderManifest
+  spawn?: SpawnLike
+}
+
+interface PendingRequest {
+  reject(error: Error): void
+  resolve(value: unknown): void
+}
+
+export class AgentProviderProcessRuntime implements AgentProviderRuntime {
+  private readonly env: NodeJS.ProcessEnv
+  private readonly eventFanout = new RuntimeEventFanout<DesktopAgentEvent>()
+  private readonly manifest: ResolvedAgentProviderManifest
+  private readonly pendingRequests = new Map<string, PendingRequest>()
+  private readonly spawnImpl: SpawnLike
+  private child: ReturnType<SpawnLike> | null = null
+  private stdoutBuffer = ''
+
+  constructor(options: AgentProviderProcessRuntimeOptions) {
+    this.env = options.env ?? process.env
+    this.manifest = options.manifest
+    this.spawnImpl = options.spawn ?? spawnChild
+  }
+
+  async start(request?: DesktopAgentStartRequest): Promise<void> {
+    await this.sendRequest('start', request)
+  }
+
+  async startSession(request: DesktopAgentStartSessionRequest): Promise<DesktopAgentStartSessionResponse> {
+    return await this.sendRequest('startSession', request) as DesktopAgentStartSessionResponse
+  }
+
+  async sendMessage(request: DesktopAgentSendMessageRequest): Promise<DesktopAgentSendMessageResponse> {
+    return await this.sendRequest('sendMessage', request) as DesktopAgentSendMessageResponse
+  }
+
+  async interrupt(request?: DesktopAgentProviderRequest): Promise<void> {
+    await this.sendRequest('interrupt', request)
+  }
+
+  async getStatus(request?: DesktopAgentProviderRequest): Promise<DesktopAgentStatus> {
+    return await this.sendRequest('getStatus', request) as DesktopAgentStatus
+  }
+
+  async setMode(request: DesktopAgentSetModeRequest): Promise<DesktopAgentStatus> {
+    return await this.sendRequest('setMode', request) as DesktopAgentStatus
+  }
+
+  async listSessions(request: DesktopAgentListSessionsRequest): Promise<DesktopAgentListSessionsResponse> {
+    return await this.sendRequest('listSessions', request) as DesktopAgentListSessionsResponse
+  }
+
+  async resumeSession(request: DesktopAgentResumeSessionRequest): Promise<DesktopAgentResumeSessionResponse> {
+    return await this.sendRequest('resumeSession', request) as DesktopAgentResumeSessionResponse
+  }
+
+  async stop(request?: DesktopAgentProviderRequest): Promise<void> {
+    await this.sendRequest('stop', request)
+  }
+
+  onEvent(listener: (event: DesktopAgentEvent) => void): () => void {
+    return this.eventFanout.onEvent(listener)
+  }
+
+  private sendRequest(method: AgentProviderMethod, params?: unknown): Promise<unknown> {
+    const child = this.ensureChild()
+    const id = randomUUID()
+    const request: AgentProviderProtocolRequest = {
+      id,
+      method,
+      ...(params === undefined ? {} : { params }),
+    }
+
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { reject, resolve })
+      child.stdin?.write(`${JSON.stringify(request)}\n`)
+    })
+  }
+
+  private ensureChild(): ReturnType<SpawnLike> {
+    if (this.child) return this.child
+
+    const child = this.spawnImpl(
+      this.manifest.command,
+      this.manifest.args ?? [],
+      {
+        cwd: this.manifest.pluginRoot,
+        env: this.env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    )
+    this.child = child
+
+    child.stdout?.on('data', (data: unknown) => {
+      this.handleStdout(dataToString(data))
+    })
+    child.once('error', (error) => {
+      this.rejectPending(error instanceof Error ? error : new Error(String(error)))
+      this.child = null
+    })
+    child.once('close', (code, signal) => {
+      const message = signal
+        ? `Agent provider ${this.manifest.providerId} exited with signal ${signal}`
+        : `Agent provider ${this.manifest.providerId} exited with code ${code ?? 'unknown'}`
+      this.rejectPending(new Error(message))
+      this.child = null
+    })
+
+    return child
+  }
+
+  private handleStdout(text: string): void {
+    this.stdoutBuffer += text
+    const lines = this.stdoutBuffer.split(/\r?\n/)
+    this.stdoutBuffer = lines.pop() ?? ''
+
+    for (const line of lines) {
+      this.handleProtocolLine(line)
+    }
+  }
+
+  private handleProtocolLine(line: string): void {
+    if (!line.trim()) return
+
+    const record = readRecord(JSON.parse(line))
+    if (record.type === 'event') {
+      const event = readRecord(record.event) as Partial<DesktopAgentEvent>
+      if (typeof event.type === 'string') {
+        this.eventFanout.emit({
+          ...event,
+          providerId: event.providerId ?? this.manifest.providerId,
+        } as DesktopAgentEvent)
+      }
+      return
+    }
+
+    const response = record as AgentProviderProtocolResponse
+    if (!response.id) return
+    const pending = this.pendingRequests.get(response.id)
+    if (!pending) return
+    this.pendingRequests.delete(response.id)
+
+    if (response.error) {
+      pending.reject(new Error(errorMessage(response.error)))
+      return
+    }
+    pending.resolve(response.result)
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(error)
+    }
+    this.pendingRequests.clear()
+  }
+}
+
+function dataToString(data: unknown): string {
+  return Buffer.isBuffer(data) ? data.toString('utf8') : String(data)
+}
+
+function errorMessage(error: string | { message?: string }): string {
+  return typeof error === 'string' ? error : error.message ?? 'Agent provider request failed'
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {}
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.test.ts
@@ -8,10 +8,10 @@ import type {
 import { AgentRuntimeManager } from './agentRuntimeManager'
 import type { AgentProviderRuntime } from './agentProviderContract'
 
-function createProvider(): AgentProviderRuntime {
+function createProvider(providerId = 'codex'): AgentProviderRuntime {
   let listener: ((event: DesktopAgentEvent) => void) | undefined
   const status: DesktopAgentStatus = {
-    providerId: 'codex',
+    providerId,
     state: 'ready',
   }
 
@@ -114,5 +114,103 @@ describe('AgentRuntimeManager', () => {
       type: 'status',
     })
     expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes provider-scoped lifecycle calls to the requested provider', async () => {
+    const codexProvider = createProvider('codex')
+    const localProvider = createProvider('local')
+    const manager = new AgentRuntimeManager({
+      defaultProviderId: 'codex',
+      providers: [
+        { providerId: 'codex', runtime: codexProvider },
+        { providerId: 'local', runtime: localProvider },
+      ],
+    })
+
+    await manager.startSession({
+      directory: '/work/demo',
+      providerId: 'local',
+    })
+    await manager.sendMessage({
+      message: 'inspect this step',
+      providerId: 'codex',
+      sessionId: 'session-1',
+    })
+    await manager.interrupt({ providerId: 'local' })
+    await expect(manager.getStatus({ providerId: 'local' })).resolves.toEqual({
+      providerId: 'local',
+      state: 'ready',
+    })
+
+    expect(localProvider.startSession).toHaveBeenCalledWith({
+      directory: '/work/demo',
+      providerId: 'local',
+    })
+    expect(localProvider.interrupt).toHaveBeenCalledWith({ providerId: 'local' })
+    expect(codexProvider.sendMessage).toHaveBeenCalledWith({
+      message: 'inspect this step',
+      providerId: 'codex',
+      sessionId: 'session-1',
+    })
+    expect(codexProvider.startSession).not.toHaveBeenCalled()
+    expect(localProvider.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('adds provider identity to events emitted by each provider runtime', () => {
+    const codexProvider = createProvider('codex') as AgentProviderRuntime & {
+      emitForTest(event: DesktopAgentEvent): void
+    }
+    const localProvider = createProvider('local') as AgentProviderRuntime & {
+      emitForTest(event: DesktopAgentEvent): void
+    }
+    const manager = new AgentRuntimeManager({
+      defaultProviderId: 'codex',
+      providers: [
+        { providerId: 'codex', runtime: codexProvider },
+        { providerId: 'local', runtime: localProvider },
+      ],
+    })
+    const listener = vi.fn()
+    const unsubscribe = manager.onEvent(listener)
+
+    localProvider.emitForTest({
+      sessionId: 'local-session',
+      text: 'local response',
+      type: 'message',
+    })
+    codexProvider.emitForTest({
+      providerId: 'codex',
+      type: 'status',
+    })
+
+    expect(listener).toHaveBeenNthCalledWith(1, {
+      providerId: 'local',
+      sessionId: 'local-session',
+      text: 'local response',
+      type: 'message',
+    })
+    expect(listener).toHaveBeenNthCalledWith(2, {
+      providerId: 'codex',
+      type: 'status',
+    })
+
+    unsubscribe()
+    localProvider.emitForTest({
+      text: 'after unsubscribe',
+      type: 'message',
+    })
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects calls for unknown agent providers', async () => {
+    const manager = new AgentRuntimeManager({
+      providers: [
+        { providerId: 'codex', runtime: createProvider('codex') },
+      ],
+    })
+
+    await expect(manager.getStatus({ providerId: 'missing' })).rejects.toThrow(
+      'Unknown agent provider: missing',
+    )
   })
 })

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.test.ts
@@ -202,6 +202,32 @@ describe('AgentRuntimeManager', () => {
     expect(listener).toHaveBeenCalledTimes(2)
   })
 
+  it('attributes provider events to the registered provider runtime', () => {
+    const localProvider = createProvider('local') as AgentProviderRuntime & {
+      emitForTest(event: DesktopAgentEvent): void
+    }
+    const manager = new AgentRuntimeManager({
+      defaultProviderId: 'local',
+      providers: [
+        { providerId: 'local', runtime: localProvider },
+      ],
+    })
+    const listener = vi.fn()
+    manager.onEvent(listener)
+
+    localProvider.emitForTest({
+      providerId: 'codex',
+      text: 'reported by local provider',
+      type: 'message',
+    })
+
+    expect(listener).toHaveBeenCalledWith({
+      providerId: 'local',
+      text: 'reported by local provider',
+      type: 'message',
+    })
+  })
+
   it('rejects calls for unknown agent providers', async () => {
     const manager = new AgentRuntimeManager({
       providers: [

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  DesktopAgentEvent,
+  DesktopAgentProviderRequest,
+  DesktopAgentStartSessionRequest,
+  DesktopAgentStatus,
+} from '@ecos-studio/shared'
+import { AgentRuntimeManager } from './agentRuntimeManager'
+import type { AgentProviderRuntime } from './agentProviderContract'
+
+function createProvider(): AgentProviderRuntime {
+  let listener: ((event: DesktopAgentEvent) => void) | undefined
+  const status: DesktopAgentStatus = {
+    providerId: 'codex',
+    state: 'ready',
+  }
+
+  return {
+    getStatus: vi.fn(async () => status),
+    interrupt: vi.fn(async () => {}),
+    listSessions: vi.fn(async () => ({ sessions: [] })),
+    onEvent: vi.fn((nextListener) => {
+      listener = nextListener
+      return () => {
+        listener = undefined
+      }
+    }),
+    resumeSession: vi.fn(async (request) => ({
+      sessionId: request.sessionId,
+    })),
+    sendMessage: vi.fn(async (request) => ({
+      messageId: 'message-1',
+      sessionId: request.sessionId,
+    })),
+    setMode: vi.fn(async () => status),
+    start: vi.fn(async () => {}),
+    startSession: vi.fn(async () => ({
+      sessionId: 'session-1',
+    })),
+    stop: vi.fn(async () => {}),
+    emitForTest: (event: DesktopAgentEvent) => listener?.(event),
+  } as AgentProviderRuntime & { emitForTest(event: DesktopAgentEvent): void }
+}
+
+describe('AgentRuntimeManager', () => {
+  it('exposes the provider runtime contract without replacing the provider implementation', async () => {
+    const provider = createProvider()
+    const manager = new AgentRuntimeManager(provider)
+    const startRequest: DesktopAgentStartSessionRequest = {
+      directory: '/work/demo',
+      providerId: 'codex',
+    }
+
+    await expect(manager.startSession(startRequest)).resolves.toEqual({
+      sessionId: 'session-1',
+    })
+    expect(provider.startSession).toHaveBeenCalledWith(startRequest)
+
+    await expect(manager.sendMessage({
+      message: 'route this design',
+      providerId: 'codex',
+      sessionId: 'session-1',
+    })).resolves.toEqual({
+      messageId: 'message-1',
+      sessionId: 'session-1',
+    })
+  })
+
+  it('forwards provider lifecycle calls and typed status responses', async () => {
+    const provider = createProvider()
+    const manager = new AgentRuntimeManager(provider)
+    const request: DesktopAgentProviderRequest = {
+      providerId: 'codex',
+    }
+
+    await manager.start(request)
+    await expect(manager.getStatus(request)).resolves.toEqual({
+      providerId: 'codex',
+      state: 'ready',
+    })
+    await manager.interrupt(request)
+    await manager.stop(request)
+
+    expect(provider.start).toHaveBeenCalledWith(request)
+    expect(provider.getStatus).toHaveBeenCalledWith(request)
+    expect(provider.interrupt).toHaveBeenCalledWith(request)
+    expect(provider.stop).toHaveBeenCalledWith(request)
+  })
+
+  it('fans out provider events through the placeholder manager', () => {
+    const provider = createProvider() as AgentProviderRuntime & {
+      emitForTest(event: DesktopAgentEvent): void
+    }
+    const manager = new AgentRuntimeManager(provider)
+    const listener = vi.fn()
+    const unsubscribe = manager.onEvent(listener)
+
+    provider.emitForTest({
+      providerId: 'codex',
+      sessionId: 'session-1',
+      text: 'working',
+      type: 'message',
+    })
+    expect(listener).toHaveBeenCalledWith({
+      providerId: 'codex',
+      sessionId: 'session-1',
+      text: 'working',
+      type: 'message',
+    })
+
+    unsubscribe()
+    provider.emitForTest({
+      providerId: 'codex',
+      type: 'status',
+    })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.ts
@@ -65,7 +65,7 @@ export class AgentRuntimeManager implements AgentProviderRuntime {
       runtime.onEvent((event) => {
         this.eventFanout.emit({
           ...event,
-          providerId: event.providerId ?? providerId,
+          providerId,
         })
       })
     }

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.ts
@@ -1,0 +1,60 @@
+import type {
+  DesktopAgentEvent,
+  DesktopAgentListSessionsRequest,
+  DesktopAgentListSessionsResponse,
+  DesktopAgentProviderRequest,
+  DesktopAgentResumeSessionRequest,
+  DesktopAgentResumeSessionResponse,
+  DesktopAgentSendMessageRequest,
+  DesktopAgentSendMessageResponse,
+  DesktopAgentSetModeRequest,
+  DesktopAgentStartRequest,
+  DesktopAgentStartSessionRequest,
+  DesktopAgentStartSessionResponse,
+  DesktopAgentStatus,
+} from '@ecos-studio/shared'
+import type { AgentProviderRuntime } from './agentProviderContract'
+
+export class AgentRuntimeManager implements AgentProviderRuntime {
+  constructor(private readonly provider: AgentProviderRuntime) {}
+
+  start(request?: DesktopAgentStartRequest): Promise<void> {
+    return this.provider.start(request)
+  }
+
+  startSession(request: DesktopAgentStartSessionRequest): Promise<DesktopAgentStartSessionResponse> {
+    return this.provider.startSession(request)
+  }
+
+  sendMessage(request: DesktopAgentSendMessageRequest): Promise<DesktopAgentSendMessageResponse> {
+    return this.provider.sendMessage(request)
+  }
+
+  interrupt(request?: DesktopAgentProviderRequest): Promise<void> {
+    return this.provider.interrupt(request)
+  }
+
+  getStatus(request?: DesktopAgentProviderRequest): Promise<DesktopAgentStatus> {
+    return this.provider.getStatus(request)
+  }
+
+  setMode(request: DesktopAgentSetModeRequest): Promise<DesktopAgentStatus> {
+    return this.provider.setMode(request)
+  }
+
+  listSessions(request: DesktopAgentListSessionsRequest): Promise<DesktopAgentListSessionsResponse> {
+    return this.provider.listSessions(request)
+  }
+
+  resumeSession(request: DesktopAgentResumeSessionRequest): Promise<DesktopAgentResumeSessionResponse> {
+    return this.provider.resumeSession(request)
+  }
+
+  stop(request?: DesktopAgentProviderRequest): Promise<void> {
+    return this.provider.stop(request)
+  }
+
+  onEvent(listener: (event: DesktopAgentEvent) => void): () => void {
+    return this.provider.onEvent(listener)
+  }
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/agent/agentRuntimeManager.ts
@@ -14,47 +14,115 @@ import type {
   DesktopAgentStatus,
 } from '@ecos-studio/shared'
 import type { AgentProviderRuntime } from './agentProviderContract'
+import { RuntimeEventFanout } from '../runtime/runtimeEvents'
+
+export interface AgentRuntimeProviderRegistration {
+  providerId: string
+  runtime: AgentProviderRuntime
+}
+
+export interface AgentRuntimeManagerOptions {
+  defaultProviderId?: string
+  providers: AgentRuntimeProviderRegistration[]
+}
 
 export class AgentRuntimeManager implements AgentProviderRuntime {
-  constructor(private readonly provider: AgentProviderRuntime) {}
+  private readonly defaultProviderId: string
+  private readonly eventFanout = new RuntimeEventFanout<DesktopAgentEvent>()
+  private readonly providers = new Map<string, AgentProviderRuntime>()
 
-  start(request?: DesktopAgentStartRequest): Promise<void> {
-    return this.provider.start(request)
+  constructor(provider: AgentProviderRuntime)
+  constructor(options: AgentRuntimeManagerOptions)
+  constructor(input: AgentProviderRuntime | AgentRuntimeManagerOptions) {
+    const options = isAgentRuntimeManagerOptions(input)
+      ? input
+      : {
+          defaultProviderId: 'codex',
+          providers: [
+            {
+              providerId: 'codex',
+              runtime: input,
+            },
+          ],
+        }
+    if (options.providers.length === 0) {
+      throw new Error('AgentRuntimeManager requires at least one provider')
+    }
+
+    for (const { providerId, runtime } of options.providers) {
+      if (this.providers.has(providerId)) {
+        throw new Error(`Duplicate agent provider: ${providerId}`)
+      }
+      this.providers.set(providerId, runtime)
+    }
+
+    this.defaultProviderId = options.defaultProviderId ?? options.providers[0].providerId
+    if (!this.providers.has(this.defaultProviderId)) {
+      throw new Error(`Unknown default agent provider: ${this.defaultProviderId}`)
+    }
+
+    for (const { providerId, runtime } of options.providers) {
+      runtime.onEvent((event) => {
+        this.eventFanout.emit({
+          ...event,
+          providerId: event.providerId ?? providerId,
+        })
+      })
+    }
   }
 
-  startSession(request: DesktopAgentStartSessionRequest): Promise<DesktopAgentStartSessionResponse> {
-    return this.provider.startSession(request)
+  async start(request?: DesktopAgentStartRequest): Promise<void> {
+    return await this.providerForRequest(request).start(request)
   }
 
-  sendMessage(request: DesktopAgentSendMessageRequest): Promise<DesktopAgentSendMessageResponse> {
-    return this.provider.sendMessage(request)
+  async startSession(request: DesktopAgentStartSessionRequest): Promise<DesktopAgentStartSessionResponse> {
+    return await this.providerForRequest(request).startSession(request)
   }
 
-  interrupt(request?: DesktopAgentProviderRequest): Promise<void> {
-    return this.provider.interrupt(request)
+  async sendMessage(request: DesktopAgentSendMessageRequest): Promise<DesktopAgentSendMessageResponse> {
+    return await this.providerForRequest(request).sendMessage(request)
   }
 
-  getStatus(request?: DesktopAgentProviderRequest): Promise<DesktopAgentStatus> {
-    return this.provider.getStatus(request)
+  async interrupt(request?: DesktopAgentProviderRequest): Promise<void> {
+    return await this.providerForRequest(request).interrupt(request)
   }
 
-  setMode(request: DesktopAgentSetModeRequest): Promise<DesktopAgentStatus> {
-    return this.provider.setMode(request)
+  async getStatus(request?: DesktopAgentProviderRequest): Promise<DesktopAgentStatus> {
+    return await this.providerForRequest(request).getStatus(request)
   }
 
-  listSessions(request: DesktopAgentListSessionsRequest): Promise<DesktopAgentListSessionsResponse> {
-    return this.provider.listSessions(request)
+  async setMode(request: DesktopAgentSetModeRequest): Promise<DesktopAgentStatus> {
+    return await this.providerForRequest(request).setMode(request)
   }
 
-  resumeSession(request: DesktopAgentResumeSessionRequest): Promise<DesktopAgentResumeSessionResponse> {
-    return this.provider.resumeSession(request)
+  async listSessions(request: DesktopAgentListSessionsRequest): Promise<DesktopAgentListSessionsResponse> {
+    return await this.providerForRequest(request).listSessions(request)
   }
 
-  stop(request?: DesktopAgentProviderRequest): Promise<void> {
-    return this.provider.stop(request)
+  async resumeSession(request: DesktopAgentResumeSessionRequest): Promise<DesktopAgentResumeSessionResponse> {
+    return await this.providerForRequest(request).resumeSession(request)
+  }
+
+  async stop(request?: DesktopAgentProviderRequest): Promise<void> {
+    return await this.providerForRequest(request).stop(request)
   }
 
   onEvent(listener: (event: DesktopAgentEvent) => void): () => void {
-    return this.provider.onEvent(listener)
+    return this.eventFanout.onEvent(listener)
   }
+
+  private providerForRequest(request?: DesktopAgentProviderRequest): AgentProviderRuntime {
+    const providerId = request?.providerId ?? this.defaultProviderId
+    const provider = this.providers.get(providerId)
+    if (!provider) {
+      throw new Error(`Unknown agent provider: ${providerId}`)
+    }
+    return provider
+  }
+}
+
+function isAgentRuntimeManagerOptions(
+  input: AgentProviderRuntime | AgentRuntimeManagerOptions,
+): input is AgentRuntimeManagerOptions {
+  return Array.isArray((input as AgentRuntimeManagerOptions).providers)
 }

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from 'node:crypto'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
 import { describe, expect, it, vi } from 'vitest'
 import type { DesktopCliCommandResult } from '@ecos-studio/shared'
 import { DesktopRuntimeManager, type DesktopRuntimeManagerOptions } from './desktopRuntimeManager'
+import { runtimeLockName } from './runtime/runtimeLocks'
 
 function createManager(
   options: Omit<DesktopRuntimeManagerOptions, 'runtimeLockRoot'> & {
@@ -164,12 +165,13 @@ describe('DesktopRuntimeManager', () => {
   })
 
   it('allows overlapping long-running ECC commands for different workspace directories', async () => {
-    const releases: Array<() => void> = []
+    const releases = new Map<string, () => void>()
     const adapterExecute = vi.fn((request) => new Promise<DesktopCliCommandResult>((resolve) => {
-      releases.push(() => resolve(result({
+      const directory = String(request.data.directory)
+      releases.set(directory, () => resolve(result({
         cmd: request.cmd,
-        data: { directory: request.data.directory },
-        message: [`done ${request.data.directory}`],
+        data: { directory },
+        message: [`done ${directory}`],
       })))
     }))
     const manager = createManager({
@@ -193,13 +195,15 @@ describe('DesktopRuntimeManager', () => {
       expect(adapterExecute).toHaveBeenCalledTimes(2)
     })
 
-    releases[1]?.()
+    expect(releases.get('/work/b')).toBeDefined()
+    releases.get('/work/b')?.()
     await expect(second).resolves.toMatchObject({
       data: { directory: '/work/b' },
       ok: true,
     })
 
-    releases[0]?.()
+    expect(releases.get('/work/a')).toBeDefined()
+    releases.get('/work/a')?.()
     await expect(first).resolves.toMatchObject({
       data: { directory: '/work/a' },
       ok: true,
@@ -209,14 +213,15 @@ describe('DesktopRuntimeManager', () => {
   it('blocks overlapping long-running ECC commands for the same workspace directory', async () => {
     let release!: () => void
     const listener = vi.fn()
+    const adapterExecute = vi.fn(() => new Promise<DesktopCliCommandResult>((resolve) => {
+      release = () => resolve(result({
+        cmd: 'rtl2gds',
+        message: ['done'],
+      }))
+    }))
     const manager = createManager({
       adapter: {
-        execute: vi.fn(() => new Promise<DesktopCliCommandResult>((resolve) => {
-          release = () => resolve(result({
-            cmd: 'rtl2gds',
-            message: ['done'],
-          }))
-        })),
+        execute: adapterExecute,
       },
     })
 
@@ -244,6 +249,9 @@ describe('DesktopRuntimeManager', () => {
       type: 'failed',
     }))
 
+    await vi.waitFor(() => {
+      expect(adapterExecute).toHaveBeenCalledTimes(1)
+    })
     release()
     await expect(first).resolves.toMatchObject({ ok: true })
   })
@@ -294,6 +302,34 @@ describe('DesktopRuntimeManager', () => {
 
       releaseFirst()
       await expect(first).resolves.toMatchObject({ ok: true })
+    } finally {
+      await rm(runtimeLockRoot, { force: true, recursive: true })
+    }
+  })
+
+  it('blocks commands when a shared runtime lock is still initializing', async () => {
+    const runtimeLockRoot = await mkdtemp(path.join(tmpdir(), 'ecos-runtime-lock-test-'))
+    try {
+      await mkdir(path.join(runtimeLockRoot, `${runtimeLockName('/work/demo')}.lock`))
+      const adapterExecute = vi.fn(async (request) => result({
+        cmd: request.cmd,
+        message: ['should not run'],
+      }))
+      const manager = createManager({
+        adapter: { execute: adapterExecute },
+        runtimeLockRoot,
+      })
+
+      await expect(manager.execute({
+        cmd: 'run_step',
+        data: { directory: '/work/demo', step: 'place', rerun: false },
+        source: 'button',
+      })).resolves.toMatchObject({
+        cmd: 'run_step',
+        ok: false,
+        response: 'warning',
+      })
+      expect(adapterExecute).not.toHaveBeenCalled()
     } finally {
       await rm(runtimeLockRoot, { force: true, recursive: true })
     }

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
@@ -1,13 +1,19 @@
-import { createHash, randomUUID } from 'node:crypto'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
 import type {
   DesktopCliCommandEvent,
   DesktopCliCommandName,
   DesktopCliCommandRequest,
   DesktopCliCommandResult,
 } from '@ecos-studio/shared'
+import {
+  SharedRuntimeManager,
+  type RuntimeScope,
+  type SharedRuntimeAdapterContext,
+} from './runtime/sharedRuntimeManager'
+import {
+  globalRuntimeScopeRecord,
+  normalizeDirectoryScope,
+  workspaceRuntimeScope,
+} from './runtime/runtimeScopes'
 
 export type DesktopRuntimeEventListener = (event: DesktopCliCommandEvent) => void
 
@@ -67,161 +73,124 @@ function createResult(
   }
 }
 
-const globalLongRunningScope = '__global__'
-
-interface RuntimeLockHandle {
-  directory: string
-  release(): Promise<void>
-}
-
-interface RuntimeLockOwner {
-  jobId: string
-  pid: number
-  scope: string
-}
-
 function readString(value: unknown): string {
   return typeof value === 'string' ? value : ''
 }
 
-function normalizeDirectoryScope(directory: string): string {
-  const normalized = directory.trim().replace(/\\/g, '/')
-  return normalized.length > 1 && normalized.endsWith('/')
-    ? normalized.slice(0, -1)
-    : normalized
-}
-
-function workspaceScopeForRequest(request: DesktopCliCommandRequest): {
-  directory?: string
-  scope: string
-  workspaceId?: string
-} {
+function workspaceScopeForRequest(request: DesktopCliCommandRequest): RuntimeScope {
   const directory = normalizeDirectoryScope(readString(request.data.directory))
-  if (!directory) return { scope: globalLongRunningScope }
-  return {
-    directory,
-    scope: directory,
-    workspaceId: directory,
-  }
+  if (!directory) return globalRuntimeScopeRecord()
+  return workspaceRuntimeScope(directory)
 }
 
-function runtimeLockName(scope: string): string {
-  return createHash('sha256').update(scope).digest('hex').slice(0, 24)
-}
-
-function isProcessAlive(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) return false
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code
-    return code === 'EPERM'
-  }
-}
-
-async function readRuntimeLockOwner(lockDirectory: string): Promise<RuntimeLockOwner | null> {
-  try {
-    const raw = await readFile(path.join(lockDirectory, 'owner.json'), 'utf8')
-    const parsed = JSON.parse(raw) as Partial<RuntimeLockOwner>
-    if (
-      typeof parsed.jobId === 'string'
-      && typeof parsed.scope === 'string'
-      && typeof parsed.pid === 'number'
-    ) {
-      return {
-        jobId: parsed.jobId,
-        pid: parsed.pid,
-        scope: parsed.scope,
+function eventWorkspaceForScope(scope: RuntimeScope): Pick<DesktopCliCommandEvent, 'directory' | 'workspaceId'> {
+  return scope.directory
+    ? {
+        directory: scope.directory,
+        workspaceId: scope.workspaceId,
       }
-    }
-  } catch {
-    return null
-  }
-  return null
+    : {}
 }
 
-async function acquireRuntimeLock(
-  rootDirectory: string,
-  scope: string,
+function resultLifecycleEvent(
+  request: DesktopCliCommandRequest,
   jobId: string,
-): Promise<RuntimeLockHandle | null> {
-  await mkdir(rootDirectory, { recursive: true })
-  const lockDirectory = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
-  try {
-    await mkdir(lockDirectory)
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code
-    if (code !== 'EEXIST') throw error
-
-    const owner = await readRuntimeLockOwner(lockDirectory)
-    if (!owner || !isProcessAlive(owner.pid)) {
-      await rm(lockDirectory, { force: true, recursive: true })
-      return acquireRuntimeLock(rootDirectory, scope, jobId)
-    }
-    return null
-  }
-
-  await writeFile(
-    path.join(lockDirectory, 'owner.json'),
-    JSON.stringify({
-      jobId,
-      pid: process.pid,
-      scope,
-    }, null, 2),
-  )
-
+  scope: RuntimeScope,
+  result: DesktopCliCommandResult,
+): DesktopCliCommandEvent {
   return {
-    directory: lockDirectory,
-    release: async () => {
-      await rm(lockDirectory, { force: true, recursive: true })
-    },
+    cmd: request.cmd,
+    jobId,
+    ...eventWorkspaceForScope(scope),
+    result,
+    stream: result.ok ? 'system' : result.response === 'warning' ? 'system' : 'stderr',
+    text: result.message.join('\n'),
+    type: result.response === 'cancelled'
+      ? 'cancelled'
+      : result.ok ? 'completed' : 'failed',
   }
 }
+
+type DesktopSharedRuntimeManager = SharedRuntimeManager<
+  DesktopCliCommandRequest,
+  DesktopCliCommandResult,
+  DesktopCliCommandEvent,
+  DesktopRuntimeAdapterContext
+>
 
 export class DesktopRuntimeManager {
-  private readonly adapter: DesktopRuntimeAdapter
-  private readonly runtimeLockRoot: string
-  private readonly activeLongRunningJobsByScope = new Map<string, string>()
-  private readonly listeners = new Set<DesktopRuntimeEventListener>()
+  private readonly runtimeManager: DesktopSharedRuntimeManager
 
   constructor(options: DesktopRuntimeManagerOptions) {
-    this.adapter = options.adapter
-    this.runtimeLockRoot = options.runtimeLockRoot
-      ?? path.join(os.tmpdir(), 'ecos-studio-runtime-locks')
+    this.runtimeManager = new SharedRuntimeManager<
+      DesktopCliCommandRequest,
+      DesktopCliCommandResult,
+      DesktopCliCommandEvent,
+      DesktopRuntimeAdapterContext
+    >({
+      adapter: {
+        execute: async (request, context) => {
+          if (request.cmd === 'help') {
+            return createResult(request.cmd, 'success', ['Type "ecos help" to list available commands.'])
+          }
+          if (request.cmd === 'clear') {
+            return createResult(request.cmd, 'success', [])
+          }
+          return options.adapter.execute(request, context)
+        },
+      },
+      createAdapterContext: (context) => ({
+        emit: (event) => {
+          context.emit(event as DesktopCliCommandEvent)
+        },
+      }),
+      createBlockedResult: (request, message) => {
+        const result = createResult(request.cmd, 'warning', [message])
+        result.ok = false
+        return result
+      },
+      createFailedResult: (request, message) => createResult(request.cmd, 'error', [message]),
+      getRequestLabel: () => 'ECOS command',
+      isFailedResult: (result) => !result.ok && result.response !== 'cancelled',
+      isLongRunning: (request) => longRunningCommands.has(request.cmd),
+      resolveScope: workspaceScopeForRequest,
+      runtimeLockRoot: options.runtimeLockRoot,
+      toCompletedEvent: resultLifecycleEvent,
+      toFailedEvent: resultLifecycleEvent,
+      toQueuedEvent: (request, jobId, scope) => ({
+        cmd: request.cmd,
+        jobId,
+        ...eventWorkspaceForScope(scope),
+        stream: 'system',
+        text: `Queued ${request.cmd}`,
+        type: 'queued',
+      }),
+      toStartedEvent: (request, jobId, scope) => ({
+        cmd: request.cmd,
+        data: { ...request.data },
+        jobId,
+        ...eventWorkspaceForScope(scope),
+        stream: 'system',
+        text: `Started ${request.cmd}`,
+        type: 'started',
+      }),
+      withJobMetadata: (event, request, jobId, scope) => ({
+        ...event,
+        cmd: request.cmd,
+        jobId,
+        ...eventWorkspaceForScope(scope),
+      }),
+    })
   }
 
   onEvent(listener: DesktopRuntimeEventListener): () => void {
-    this.listeners.add(listener)
-
-    return () => {
-      this.listeners.delete(listener)
-    }
+    return this.runtimeManager.onEvent(listener)
   }
 
   async isWorkspaceRuntimeActive(directory: string): Promise<boolean> {
     const scope = normalizeDirectoryScope(directory)
     if (!scope) return false
-
-    if (this.activeLongRunningJobsByScope.has(scope)) return true
-
-    const lockDirectory = path.join(this.runtimeLockRoot, `${runtimeLockName(scope)}.lock`)
-    const owner = await readRuntimeLockOwner(lockDirectory)
-    if (!owner) return false
-
-    if (!isProcessAlive(owner.pid)) {
-      await rm(lockDirectory, { force: true, recursive: true })
-      return false
-    }
-
-    return true
-  }
-
-  private emit(event: DesktopCliCommandEvent, listener?: DesktopRuntimeEventListener): void {
-    listener?.(event)
-    for (const registeredListener of this.listeners) {
-      registeredListener(event)
-    }
+    return this.runtimeManager.isScopeActive(scope)
   }
 
   async execute(
@@ -238,132 +207,6 @@ export class DesktopRuntimeManager {
       }
     }
 
-    const jobId = randomUUID()
-    const isLongRunning = longRunningCommands.has(request.cmd)
-    const workspaceScope = workspaceScopeForRequest(request)
-    let runtimeLock: RuntimeLockHandle | null = null
-    const eventWorkspace = workspaceScope.directory
-      ? {
-          directory: workspaceScope.directory,
-          workspaceId: workspaceScope.workspaceId,
-        }
-      : {}
-
-    this.emit({
-      cmd: request.cmd,
-      jobId,
-      ...eventWorkspace,
-      stream: 'system',
-      text: `Queued ${request.cmd}`,
-      type: 'queued',
-    }, listener)
-
-    if (isLongRunning && this.activeLongRunningJobsByScope.has(workspaceScope.scope)) {
-      const result = createResult(
-        request.cmd,
-        'warning',
-        workspaceScope.directory
-          ? [`Another ECOS command is already running for ${workspaceScope.directory}. Wait for it to finish before starting a new one.`]
-          : ['Another ECOS command is already running. Wait for it to finish before starting a new one.'],
-      )
-      result.ok = false
-      this.emit({
-        cmd: request.cmd,
-        jobId,
-        ...eventWorkspace,
-        result,
-        stream: 'system',
-        text: result.message.join('\n'),
-        type: 'failed',
-      }, listener)
-      return result
-    }
-
-    if (isLongRunning) {
-      runtimeLock = await acquireRuntimeLock(this.runtimeLockRoot, workspaceScope.scope, jobId)
-      if (!runtimeLock) {
-        const result = createResult(
-          request.cmd,
-          'warning',
-          workspaceScope.directory
-            ? [`Another ECOS command is already running for ${workspaceScope.directory}. Wait for it to finish before starting a new one.`]
-            : ['Another ECOS command is already running. Wait for it to finish before starting a new one.'],
-        )
-        result.ok = false
-        this.emit({
-          cmd: request.cmd,
-          jobId,
-          ...eventWorkspace,
-          result,
-          stream: 'system',
-          text: result.message.join('\n'),
-          type: 'failed',
-        }, listener)
-        return result
-      }
-      this.activeLongRunningJobsByScope.set(workspaceScope.scope, jobId)
-    }
-
-    this.emit({
-      cmd: request.cmd,
-      data: { ...request.data },
-      jobId,
-      ...eventWorkspace,
-      stream: 'system',
-      text: `Started ${request.cmd}`,
-      type: 'started',
-    }, listener)
-
-    const context: DesktopRuntimeAdapterContext = {
-      emit: (event) => {
-        this.emit({
-          ...event,
-          cmd: request.cmd,
-          jobId,
-          ...eventWorkspace,
-        }, listener)
-      },
-    }
-
-    try {
-      const result = request.cmd === 'help'
-        ? createResult(request.cmd, 'success', ['Type "ecos help" to list available commands.'])
-        : request.cmd === 'clear'
-          ? createResult(request.cmd, 'success', [])
-          : await this.adapter.execute(request, context)
-      this.emit({
-        cmd: request.cmd,
-        jobId,
-        ...eventWorkspace,
-        result,
-        stream: result.ok ? 'system' : result.response === 'warning' ? 'system' : 'stderr',
-        text: result.message.join('\n'),
-        type: result.response === 'cancelled'
-          ? 'cancelled'
-          : result.ok ? 'completed' : 'failed',
-      }, listener)
-      return result
-    } catch (error) {
-      const result = createResult(
-        request.cmd,
-        'error',
-        [error instanceof Error ? error.message : String(error)],
-      )
-      this.emit({
-        cmd: request.cmd,
-        jobId,
-        ...eventWorkspace,
-        result,
-        stream: 'stderr',
-        text: result.message.join('\n'),
-        type: 'failed',
-      }, listener)
-      return result
-    } finally {
-      if (isLongRunning && this.activeLongRunningJobsByScope.get(workspaceScope.scope) === jobId) {
-        this.activeLongRunningJobsByScope.delete(workspaceScope.scope)
-      }
-      await runtimeLock?.release()
-    }
+    return this.runtimeManager.execute(request, listener)
   }
 }

--- a/ecos/gui/apps/desktop-electron/electron/services/eccDbRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccDbRuntimeManager.test.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  EccDbRuntimeManager,
+  type EccDbRuntimeAdapter,
+  type EccDbRuntimeResult,
+} from './eccDbRuntimeManager'
+import { WorkspaceService } from './workspaceService'
+
+const tempDirectories: string[] = []
+type ProjectScopeProviderDouble = ConstructorParameters<typeof WorkspaceService>[0]['projectScopeProvider']
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), prefix))
+  tempDirectories.push(directory)
+  return directory
+}
+
+function createProjectScopeProvider(
+  rootPath: string,
+  canonicalPath: string,
+): ProjectScopeProviderDouble {
+  return {
+    clearProjectRoot: vi.fn(),
+    getProjectRoot: vi.fn().mockResolvedValue(rootPath),
+    isProjectDirectory: vi.fn(),
+    registerProjectRoot: vi.fn(),
+    requestProjectPathAccess: vi.fn().mockResolvedValue(canonicalPath),
+    scanPdkDirectory: vi.fn(),
+  }
+}
+
+describe('EccDbRuntimeManager', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirectories.splice(0).map((directory) =>
+        rm(directory, { force: true, recursive: true }),
+      ),
+    )
+  })
+
+  it('represents mutating DB lifecycle work as active workspace runtime activity', async () => {
+    const workspaceRoot = await createTempDir('ecos-db-runtime-workspace-')
+    const runtimeLockRoot = await createTempDir('ecos-db-runtime-locks-')
+    const filePath = path.join(workspaceRoot, 'home', 'parameters.json')
+    await mkdir(path.dirname(filePath), { recursive: true })
+    const dbResult: EccDbRuntimeResult = {
+      ok: true,
+      operation: 'initialize',
+      status: 'success',
+    }
+    const pendingDb = createDeferred<EccDbRuntimeResult>()
+    const adapter: EccDbRuntimeAdapter = {
+      execute: vi.fn(async (_request, context) => {
+        context.emit({
+          message: 'initializing DB',
+          type: 'progress',
+        })
+        return await pendingDb.promise
+      }),
+    }
+    const manager = new EccDbRuntimeManager({
+      adapter,
+      runtimeLockRoot,
+    })
+    const workspaceService = new WorkspaceService({
+      projectScopeProvider: createProjectScopeProvider(workspaceRoot, filePath),
+      runtimeMutationGuard: manager,
+    })
+    const listener = vi.fn()
+
+    const run = manager.execute({
+      directory: workspaceRoot,
+      operation: 'initialize',
+      step: 'floorplan',
+    }, listener)
+
+    await vi.waitFor(async () => {
+      expect(adapter.execute).toHaveBeenCalledTimes(1)
+      await expect(manager.isWorkspaceRuntimeActive(workspaceRoot)).resolves.toBe(true)
+    })
+    await expect(
+      workspaceService.writeProjectTextFile('/workspace/home/parameters.json', '{"PDK":"ics55"}'),
+    ).rejects.toThrow('workspace flow is running')
+
+    pendingDb.resolve(dbResult)
+    await expect(run).resolves.toEqual(dbResult)
+    await expect(manager.isWorkspaceRuntimeActive(workspaceRoot)).resolves.toBe(false)
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+      directory: workspaceRoot,
+      operation: 'initialize',
+      step: 'floorplan',
+      type: 'progress',
+      workspaceId: workspaceRoot,
+    }))
+    const jobIds = listener.mock.calls.map(([event]) => event.jobId)
+    expect(new Set(jobIds).size).toBe(1)
+
+    await expect(
+      workspaceService.writeProjectTextFile('/workspace/home/parameters.json', '{"PDK":"ics55"}'),
+    ).resolves.toBeUndefined()
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('{"PDK":"ics55"}')
+  })
+
+  it('does not block protected workspace writes for non-mutating DB lifecycle work', async () => {
+    const workspaceRoot = await createTempDir('ecos-db-runtime-readonly-workspace-')
+    const runtimeLockRoot = path.join(tmpdir(), `ecos-db-runtime-locks-${randomUUID()}`)
+    const filePath = path.join(workspaceRoot, 'config', 'db_default_config.json')
+    await mkdir(path.dirname(filePath), { recursive: true })
+    const pendingDb = createDeferred<EccDbRuntimeResult>()
+    const adapter: EccDbRuntimeAdapter = {
+      execute: vi.fn(async () => await pendingDb.promise),
+    }
+    const manager = new EccDbRuntimeManager({
+      adapter,
+      runtimeLockRoot,
+    })
+    const workspaceService = new WorkspaceService({
+      projectScopeProvider: createProjectScopeProvider(workspaceRoot, filePath),
+      runtimeMutationGuard: manager,
+    })
+
+    const run = manager.execute({
+      directory: workspaceRoot,
+      mutatesWorkspace: false,
+      operation: 'export',
+    })
+
+    await vi.waitFor(async () => {
+      expect(adapter.execute).toHaveBeenCalledTimes(1)
+      await expect(manager.isWorkspaceRuntimeActive(workspaceRoot)).resolves.toBe(false)
+    })
+    await expect(
+      workspaceService.writeProjectTextFile('/workspace/config/db_default_config.json', '{}'),
+    ).resolves.toBeUndefined()
+
+    pendingDb.resolve({
+      ok: true,
+      operation: 'export',
+      status: 'success',
+    })
+    await expect(run).resolves.toEqual({
+      ok: true,
+      operation: 'export',
+      status: 'success',
+    })
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/eccDbRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccDbRuntimeManager.ts
@@ -1,0 +1,167 @@
+import {
+  SharedRuntimeManager,
+  type RuntimeScope,
+} from './runtime/sharedRuntimeManager'
+import {
+  normalizeDirectoryScope,
+  workspaceRuntimeScope,
+} from './runtime/runtimeScopes'
+
+export type EccDbRuntimeOperation = 'cleanup' | 'export' | 'initialize' | 'refresh'
+export type EccDbRuntimeResultStatus = 'error' | 'success' | 'warning'
+export type EccDbRuntimeEventType = 'completed' | 'failed' | 'progress' | 'queued' | 'started'
+
+export interface EccDbRuntimeRequest {
+  directory: string
+  mutatesWorkspace?: boolean
+  operation: EccDbRuntimeOperation
+  step?: string
+  workspaceId?: string
+}
+
+export interface EccDbRuntimeResult {
+  message?: string
+  ok: boolean
+  operation: EccDbRuntimeOperation
+  status: EccDbRuntimeResultStatus
+}
+
+export interface EccDbRuntimeEvent {
+  directory: string
+  jobId: string
+  message?: string
+  operation: EccDbRuntimeOperation
+  result?: EccDbRuntimeResult
+  step?: string
+  type: EccDbRuntimeEventType
+  workspaceId?: string
+}
+
+export interface EccDbRuntimeAdapterContext {
+  emit(event: Omit<EccDbRuntimeEvent, 'directory' | 'jobId' | 'operation' | 'step' | 'workspaceId'>): void
+}
+
+export interface EccDbRuntimeAdapter {
+  execute(
+    request: EccDbRuntimeRequest,
+    context: EccDbRuntimeAdapterContext,
+  ): Promise<EccDbRuntimeResult>
+}
+
+export interface EccDbRuntimeManagerOptions {
+  adapter: EccDbRuntimeAdapter
+  runtimeLockRoot?: string
+}
+
+type EccDbSharedRuntimeManager = SharedRuntimeManager<
+  EccDbRuntimeRequest,
+  EccDbRuntimeResult,
+  EccDbRuntimeEvent,
+  EccDbRuntimeAdapterContext
+>
+
+function createResult(
+  request: EccDbRuntimeRequest,
+  status: EccDbRuntimeResultStatus,
+  message?: string,
+): EccDbRuntimeResult {
+  return {
+    ...(message ? { message } : {}),
+    ok: status === 'success',
+    operation: request.operation,
+    status,
+  }
+}
+
+function scopeForRequest(request: EccDbRuntimeRequest): RuntimeScope {
+  const scope = workspaceRuntimeScope(normalizeDirectoryScope(request.directory))
+  return {
+    ...scope,
+    workspaceId: request.workspaceId ?? scope.workspaceId,
+  }
+}
+
+function withRequestMetadata(
+  event: Omit<EccDbRuntimeEvent, 'directory' | 'jobId' | 'operation' | 'step' | 'workspaceId'>,
+  request: EccDbRuntimeRequest,
+  jobId: string,
+  scope: RuntimeScope,
+): EccDbRuntimeEvent {
+  return {
+    ...event,
+    directory: scope.directory ?? request.directory,
+    jobId,
+    operation: request.operation,
+    ...(request.step ? { step: request.step } : {}),
+    ...(scope.workspaceId ? { workspaceId: scope.workspaceId } : {}),
+  }
+}
+
+function lifecycleEvent(
+  request: EccDbRuntimeRequest,
+  jobId: string,
+  scope: RuntimeScope,
+  type: EccDbRuntimeEventType,
+  message?: string,
+  result?: EccDbRuntimeResult,
+): EccDbRuntimeEvent {
+  return withRequestMetadata({
+    ...(message ? { message } : {}),
+    ...(result ? { result } : {}),
+    type,
+  }, request, jobId, scope)
+}
+
+export class EccDbRuntimeManager {
+  private readonly runtimeManager: EccDbSharedRuntimeManager
+
+  constructor(options: EccDbRuntimeManagerOptions) {
+    this.runtimeManager = new SharedRuntimeManager<
+      EccDbRuntimeRequest,
+      EccDbRuntimeResult,
+      EccDbRuntimeEvent,
+      EccDbRuntimeAdapterContext
+    >({
+      adapter: options.adapter,
+      createAdapterContext: (context) => ({
+        emit: (event) => {
+          context.emit(event as EccDbRuntimeEvent)
+        },
+      }),
+      createBlockedResult: (request, message) => createResult(request, 'warning', message),
+      createFailedResult: (request, message) => createResult(request, 'error', message),
+      getRequestLabel: (request) => `ECC DB ${request.operation}`,
+      isFailedResult: (result) => !result.ok,
+      isLongRunning: (request) => request.mutatesWorkspace !== false,
+      resolveScope: scopeForRequest,
+      runtimeLockRoot: options.runtimeLockRoot,
+      toCompletedEvent: (request, jobId, scope, result) =>
+        lifecycleEvent(request, jobId, scope, 'completed', result.message, result),
+      toFailedEvent: (request, jobId, scope, result) =>
+        lifecycleEvent(request, jobId, scope, 'failed', result.message, result),
+      toQueuedEvent: (request, jobId, scope) =>
+        lifecycleEvent(request, jobId, scope, 'queued', `Queued ECC DB ${request.operation}`),
+      toStartedEvent: (request, jobId, scope) =>
+        lifecycleEvent(request, jobId, scope, 'started', `Started ECC DB ${request.operation}`),
+      withJobMetadata: (event, request, jobId, scope) =>
+        withRequestMetadata(event, request, jobId, scope),
+    })
+  }
+
+  onEvent(listener: (event: EccDbRuntimeEvent) => void): () => void {
+    return this.runtimeManager.onEvent(listener)
+  }
+
+  async isWorkspaceRuntimeActive(directory: string): Promise<boolean> {
+    const scope = normalizeDirectoryScope(directory)
+    if (!scope) return false
+    return this.runtimeManager.isScopeActive(scope)
+  }
+
+  async execute(
+    request: EccDbRuntimeRequest,
+    listener?: (event: EccDbRuntimeEvent) => void,
+  ): Promise<EccDbRuntimeResult> {
+    return await this.runtimeManager.execute(request, listener)
+  }
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeEvents.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeEvents.ts
@@ -1,0 +1,19 @@
+export type RuntimeEventListener<TEvent> = (event: TEvent) => void
+
+export class RuntimeEventFanout<TEvent> {
+  private readonly listeners = new Set<RuntimeEventListener<TEvent>>()
+
+  onEvent(listener: RuntimeEventListener<TEvent>): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  emit(event: TEvent, listener?: RuntimeEventListener<TEvent>): void {
+    listener?.(event)
+    for (const registeredListener of this.listeners) {
+      registeredListener(event)
+    }
+  }
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
@@ -1,8 +1,8 @@
-import { mkdir, rm, utimes, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   acquireRuntimeLock,
   isProcessAlive,
@@ -30,6 +30,24 @@ describe('runtimeLocks', () => {
 
       await first?.release()
       await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(false)
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('creates directory-format locks with owner files for existing clients', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    try {
+      const lock = await acquireRuntimeLock(root, '/work/demo', 'job-1')
+      expect(lock).not.toBeNull()
+
+      await expect(stat(lockDirectory).then((stats) => stats.isDirectory())).resolves.toBe(true)
+      await expect(readFile(path.join(lockDirectory, 'owner.json'), 'utf8')).resolves.toContain(
+        '"jobId": "job-1"',
+      )
+
+      await lock?.release()
     } finally {
       await rm(root, { force: true, recursive: true })
     }
@@ -217,6 +235,226 @@ describe('runtimeLocks', () => {
       })
       await lock?.release()
     } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('does not remove a replacement lock when a stalled initializer cleanup resumes', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const scope = '/work/demo'
+    const lockDirectory = path.join(root, `${runtimeLockName(scope)}.lock`)
+    const ownerPath = path.join(lockDirectory, 'owner.json')
+    const replacementOwner = {
+      jobId: 'replacement-job',
+      pid: process.pid,
+      scope,
+    }
+
+    try {
+      let simulatedRace = false
+      vi.resetModules()
+      vi.doMock('node:fs/promises', async () => {
+        const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+        return {
+          ...actual,
+          writeFile: vi.fn(async (...args: Parameters<typeof actual.writeFile>) => {
+            const [target] = args
+            if (target === ownerPath && !simulatedRace) {
+              simulatedRace = true
+              await actual.rm(lockDirectory, { force: true, recursive: true })
+              await actual.mkdir(lockDirectory, { recursive: true })
+              await actual.writeFile(ownerPath, JSON.stringify(replacementOwner), { mode: 0o444 })
+              await actual.chmod(ownerPath, 0o444)
+              const error = new Error('permission denied') as NodeJS.ErrnoException
+              error.code = 'EACCES'
+              throw error
+            }
+            return actual.writeFile(...args)
+          }),
+        }
+      })
+      const locks = await import('./runtimeLocks')
+
+      await expect(locks.acquireRuntimeLock(root, scope, 'stalled-job')).resolves.toBeNull()
+      await expect(locks.readRuntimeLockOwner(lockDirectory)).resolves.toEqual(replacementOwner)
+    } finally {
+      vi.doUnmock('node:fs/promises')
+      vi.resetModules()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('does not replace an owner that races into a new lock directory', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const scope = '/work/demo'
+    const lockDirectory = path.join(root, `${runtimeLockName(scope)}.lock`)
+    const ownerPath = path.join(lockDirectory, 'owner.json')
+
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      const staleTime = new Date(Date.now() - runtimeLockInitializationGraceMs - 1_000)
+      await utimes(lockDirectory, staleTime, staleTime)
+
+      let simulatedRace = false
+      vi.resetModules()
+      vi.doMock('node:fs/promises', async () => {
+        const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+        return {
+          ...actual,
+          writeFile: vi.fn(async (...args: Parameters<typeof actual.writeFile>) => {
+            const [target] = args
+            if (target === ownerPath && !simulatedRace) {
+              simulatedRace = true
+              await actual.writeFile(ownerPath, JSON.stringify({
+                jobId: 'stalled-job',
+                pid: process.pid,
+                scope,
+              }), { flag: 'wx', mode: 0o444 })
+              await actual.chmod(ownerPath, 0o444)
+            }
+            return actual.writeFile(...args)
+          }),
+        }
+      })
+      const locks = await import('./runtimeLocks')
+
+      const lock = await locks.acquireRuntimeLock(root, scope, 'replacement-job')
+
+      expect(lock).toBeNull()
+      await expect(locks.readRuntimeLockOwner(lockDirectory)).resolves.toMatchObject({
+        jobId: 'stalled-job',
+      })
+      await lock?.release()
+    } finally {
+      vi.doUnmock('node:fs/promises')
+      vi.resetModules()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('does not trust a replacement directory after creating a lock directory', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const scope = '/work/demo'
+    const lockDirectory = path.join(root, `${runtimeLockName(scope)}.lock`)
+    const ownerPath = path.join(lockDirectory, 'owner.json')
+    const replacementOwner = {
+      jobId: 'replacement-job',
+      pid: process.pid,
+      scope,
+    }
+
+    try {
+      let simulatedRace = false
+      vi.resetModules()
+      vi.doMock('node:fs/promises', async () => {
+        const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+        return {
+          ...actual,
+          mkdir: vi.fn(async (...args: Parameters<typeof actual.mkdir>) => {
+            const [target] = args
+            const result = await actual.mkdir(...args)
+            if (target === lockDirectory && !simulatedRace) {
+              simulatedRace = true
+              await actual.rm(lockDirectory, { force: true, recursive: true })
+              await actual.mkdir(lockDirectory, { recursive: true })
+              await actual.writeFile(ownerPath, JSON.stringify(replacementOwner), { mode: 0o444 })
+              await actual.chmod(ownerPath, 0o444)
+            }
+            return result
+          }),
+        }
+      })
+      const locks = await import('./runtimeLocks')
+
+      await expect(locks.acquireRuntimeLock(root, scope, 'stalled-job')).resolves.toBeNull()
+      await expect(locks.readRuntimeLockOwner(lockDirectory)).resolves.toEqual(replacementOwner)
+    } finally {
+      vi.doUnmock('node:fs/promises')
+      vi.resetModules()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('surfaces lock directory creation permission failures', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const scope = '/work/demo'
+    const lockDirectory = path.join(root, `${runtimeLockName(scope)}.lock`)
+    let lockDirectoryAttempts = 0
+
+    try {
+      vi.resetModules()
+      vi.doMock('node:fs/promises', async () => {
+        const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+        return {
+          ...actual,
+          mkdir: vi.fn(async (...args: Parameters<typeof actual.mkdir>) => {
+            const [target] = args
+            if (target === lockDirectory || String(target).endsWith('.reclaim.lock')) {
+              lockDirectoryAttempts += 1
+              const error = new Error(
+                lockDirectoryAttempts === 1
+                  ? 'permission denied'
+                  : 'recurred after permission failure',
+              ) as NodeJS.ErrnoException
+              error.code = lockDirectoryAttempts === 1 ? 'EACCES' : 'ELOOP'
+              throw error
+            }
+            return actual.mkdir(...args)
+          }),
+        }
+      })
+      const locks = await import('./runtimeLocks')
+
+      await expect(locks.acquireRuntimeLock(root, scope, 'job-1')).rejects.toThrow(
+        'permission denied',
+      )
+      expect(lockDirectoryAttempts).toBe(1)
+    } finally {
+      vi.doUnmock('node:fs/promises')
+      vi.resetModules()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('surfaces owner-file permission failures in the created lock directory', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const scope = '/work/demo'
+    const lockDirectory = path.join(root, `${runtimeLockName(scope)}.lock`)
+    const ownerPath = path.join(lockDirectory, 'owner.json')
+    let ownerWriteAttempts = 0
+
+    try {
+      vi.resetModules()
+      vi.doMock('node:fs/promises', async () => {
+        const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+        return {
+          ...actual,
+          writeFile: vi.fn(async (...args: Parameters<typeof actual.writeFile>) => {
+            const [target] = args
+            if (target === ownerPath) {
+              ownerWriteAttempts += 1
+              const error = new Error(
+                ownerWriteAttempts === 1
+                  ? 'permission denied'
+                  : 'permission failure retried',
+              ) as NodeJS.ErrnoException
+              error.code = ownerWriteAttempts === 1 ? 'EACCES' : 'ELOOP'
+              throw error
+            }
+            return actual.writeFile(...args)
+          }),
+        }
+      })
+      const locks = await import('./runtimeLocks')
+
+      await expect(locks.acquireRuntimeLock(root, scope, 'job-1')).rejects.toThrow(
+        'permission denied',
+      )
+      expect(ownerWriteAttempts).toBe(1)
+      await expect(stat(lockDirectory)).rejects.toThrow()
+    } finally {
+      vi.doUnmock('node:fs/promises')
+      vi.resetModules()
       await rm(root, { force: true, recursive: true })
     }
   })

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
@@ -80,4 +80,17 @@ describe('runtimeLocks', () => {
       await rm(root, { force: true, recursive: true })
     }
   })
+
+  it('does not delete locks that are still being initialized', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+
+      await expect(acquireRuntimeLock(root, '/work/demo', 'job-1')).resolves.toBeNull()
+      await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(true)
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
 })

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
@@ -111,4 +111,29 @@ describe('runtimeLocks', () => {
       await rm(root, { force: true, recursive: true })
     }
   })
+
+  it('prevents reclaimed directory initializers from overwriting the new owner', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      const staleTime = new Date(Date.now() - runtimeLockInitializationGraceMs - 1_000)
+      await utimes(lockDirectory, staleTime, staleTime)
+
+      const lock = await acquireRuntimeLock(root, '/work/demo', 'job-1')
+      expect(lock).not.toBeNull()
+
+      await expect(writeFile(path.join(lockDirectory, 'owner.json'), JSON.stringify({
+        jobId: 'stalled-job',
+        pid: process.pid,
+        scope: '/work/demo',
+      }))).rejects.toThrow()
+      await expect(readRuntimeLockOwner(lockDirectory)).resolves.toMatchObject({
+        jobId: 'job-1',
+      })
+      await lock?.release()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
 })

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
@@ -1,0 +1,83 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import {
+  acquireRuntimeLock,
+  isProcessAlive,
+  isRuntimeScopeActive,
+  readRuntimeLockOwner,
+  runtimeLockName,
+} from './runtimeLocks'
+
+describe('runtimeLocks', () => {
+  it('uses stable filesystem-safe lock names', () => {
+    expect(runtimeLockName('/work/demo')).toMatch(/^[a-f0-9]{24}$/)
+    expect(runtimeLockName('/work/demo')).toBe(runtimeLockName('/work/demo'))
+    expect(runtimeLockName('/work/other')).not.toBe(runtimeLockName('/work/demo'))
+  })
+
+  it('tracks active scopes through lock acquisition and release', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    try {
+      const first = await acquireRuntimeLock(root, '/work/demo', 'job-1')
+      expect(first).not.toBeNull()
+      await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(true)
+
+      await expect(acquireRuntimeLock(root, '/work/demo', 'job-2')).resolves.toBeNull()
+
+      await first?.release()
+      await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(false)
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('reads valid lock owners and ignores malformed owner files', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      await writeFile(path.join(lockDirectory, 'owner.json'), JSON.stringify({
+        jobId: 'job-1',
+        pid: process.pid,
+        scope: '/work/demo',
+      }))
+      await expect(readRuntimeLockOwner(lockDirectory)).resolves.toEqual({
+        jobId: 'job-1',
+        pid: process.pid,
+        scope: '/work/demo',
+      })
+
+      await writeFile(path.join(lockDirectory, 'owner.json'), JSON.stringify({
+        jobId: 'job-1',
+      }))
+      await expect(readRuntimeLockOwner(lockDirectory)).resolves.toBeNull()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('cleans stale lock owners before acquiring a scope', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      await writeFile(path.join(lockDirectory, 'owner.json'), JSON.stringify({
+        jobId: 'stale-job',
+        pid: -1,
+        scope: '/work/demo',
+      }))
+
+      expect(isProcessAlive(-1)).toBe(false)
+      await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(false)
+
+      const lock = await acquireRuntimeLock(root, '/work/demo', 'job-1')
+      expect(lock).not.toBeNull()
+      await lock?.release()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
@@ -197,6 +197,16 @@ describe('runtimeLocks', () => {
     }
   })
 
+  it('does not create reclaim locks when checking a missing scope', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    try {
+      await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(false)
+      await expect(stat(root)).rejects.toThrow()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it('reclaims ownerless locks after initialization stalls', async () => {
     const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
     const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
@@ -8,6 +8,7 @@ import {
   isProcessAlive,
   isRuntimeScopeActive,
   readRuntimeLockOwner,
+  runtimeLockInitializationGraceMs,
   runtimeLockName,
 } from './runtimeLocks'
 
@@ -89,6 +90,23 @@ describe('runtimeLocks', () => {
 
       await expect(acquireRuntimeLock(root, '/work/demo', 'job-1')).resolves.toBeNull()
       await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(true)
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('reclaims ownerless locks after initialization stalls', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      const staleTime = new Date(Date.now() - runtimeLockInitializationGraceMs - 1_000)
+      await utimes(lockDirectory, staleTime, staleTime)
+
+      await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(false)
+      const lock = await acquireRuntimeLock(root, '/work/demo', 'job-1')
+      expect(lock).not.toBeNull()
+      await lock?.release()
     } finally {
       await rm(root, { force: true, recursive: true })
     }

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.test.ts
@@ -82,6 +82,90 @@ describe('runtimeLocks', () => {
     }
   })
 
+  it('allows only one concurrent stale lock reclaimer to acquire the scope', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      await writeFile(path.join(lockDirectory, 'owner.json'), JSON.stringify({
+        jobId: 'stale-job',
+        pid: -1,
+        scope: '/work/demo',
+      }))
+
+      const attempts = await Promise.all(
+        Array.from({ length: 8 }, (_value, index) =>
+          acquireRuntimeLock(root, '/work/demo', `job-${index}`),
+        ),
+      )
+      const locks = attempts.filter((lock): lock is NonNullable<typeof lock> => lock !== null)
+
+      expect(locks).toHaveLength(1)
+      await expect(isRuntimeScopeActive(root, '/work/demo')).resolves.toBe(true)
+      await locks[0]?.release()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('retries after clearing a stale reclaim lock', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    const reclaimLock = path.join(root, `${runtimeLockName('/work/demo:reclaim')}.reclaim.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      await writeFile(path.join(lockDirectory, 'owner.json'), JSON.stringify({
+        jobId: 'stale-job',
+        pid: -1,
+        scope: '/work/demo',
+      }))
+      await writeFile(reclaimLock, JSON.stringify({
+        jobId: 'stale-reclaimer:reclaim',
+        pid: -1,
+        scope: '/work/demo:reclaim',
+      }))
+
+      const lock = await acquireRuntimeLock(root, '/work/demo', 'job-1')
+
+      expect(lock).not.toBeNull()
+      await lock?.release()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('waits for observer reclaim contention before reporting lock acquisition blocked', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    const reclaimLock = path.join(root, `${runtimeLockName('/work/demo:reclaim')}.reclaim.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      await writeFile(path.join(lockDirectory, 'owner.json'), JSON.stringify({
+        jobId: 'stale-job',
+        pid: -1,
+        scope: '/work/demo',
+      }))
+      await writeFile(reclaimLock, JSON.stringify({
+        jobId: `observer-${process.pid}:reclaim`,
+        pid: process.pid,
+        scope: '/work/demo:reclaim',
+      }))
+      const observerRelease = new Promise<void>((resolve, reject) => {
+        setTimeout(() => {
+          rm(reclaimLock, { force: true, recursive: true }).then(resolve, reject)
+        }, 5)
+      })
+
+      const lock = await acquireRuntimeLock(root, '/work/demo', 'job-1')
+      await observerRelease
+
+      expect(lock).not.toBeNull()
+      await lock?.release()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it('does not delete locks that are still being initialized', async () => {
     const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
     const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 export interface RuntimeLockHandle {
@@ -64,7 +64,7 @@ export async function acquireRuntimeLock(
     if (code !== 'EEXIST') throw error
 
     const owner = await readRuntimeLockOwner(lockDirectory)
-    if (!owner || owner.scope !== scope || !isProcessAlive(owner.pid)) {
+    if (owner && owner.scope === scope && !isProcessAlive(owner.pid)) {
       await rm(lockDirectory, { force: true, recursive: true })
       return acquireRuntimeLock(rootDirectory, scope, jobId)
     }
@@ -94,7 +94,15 @@ export async function isRuntimeScopeActive(
 ): Promise<boolean> {
   const lockDirectory = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
   const owner = await readRuntimeLockOwner(lockDirectory)
-  if (!owner || owner.scope !== scope || !isProcessAlive(owner.pid)) {
+  if (!owner) {
+    try {
+      await stat(lockDirectory)
+      return true
+    } catch {
+      return false
+    }
+  }
+  if (owner && owner.scope === scope && !isProcessAlive(owner.pid)) {
     await rm(lockDirectory, { force: true, recursive: true })
     return false
   }

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
@@ -61,7 +61,15 @@ async function readLockOwnerText(lockPath: string): Promise<string | null> {
     return await readFile(lockPath, 'utf8')
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code
-    if (code !== 'EISDIR') return null
+    if (code !== 'EISDIR') {
+      if (code !== 'EPERM') return null
+      try {
+        const stats = await stat(lockPath)
+        if (!stats.isDirectory()) return null
+      } catch {
+        return null
+      }
+    }
   }
 
   try {

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
@@ -208,21 +208,22 @@ export async function isRuntimeScopeActive(
 ): Promise<boolean> {
   const lockPath = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
   const active = await isRuntimeLockPathActive(lockPath, scope)
-  if (!active) {
-    const reclaimLock = await acquireRuntimeReclaimLock(rootDirectory, scope, `observer-${process.pid}`)
-    if (!reclaimLock) {
-      return isRuntimeLockPathActive(lockPath, scope)
-    }
-    try {
-      if (await isRuntimeLockPathActive(lockPath, scope)) {
-        return true
-      }
-      await rm(lockPath, { force: true, recursive: true })
-    } finally {
-      await reclaimLock.release()
-    }
+  if (active) return true
+  if (!await runtimeLockPathExists(lockPath)) return false
+
+  const reclaimLock = await acquireRuntimeReclaimLock(rootDirectory, scope, `observer-${process.pid}`)
+  if (!reclaimLock) {
+    return isRuntimeLockPathActive(lockPath, scope)
   }
-  return active
+  try {
+    if (await isRuntimeLockPathActive(lockPath, scope)) {
+      return true
+    }
+    await rm(lockPath, { force: true, recursive: true })
+  } finally {
+    await reclaimLock.release()
+  }
+  return false
 }
 
 async function isRuntimeLockPathActive(
@@ -242,6 +243,15 @@ async function isRuntimeLockPathActive(
     return false
   }
   return true
+}
+
+async function runtimeLockPathExists(lockPath: string): Promise<boolean> {
+  try {
+    await stat(lockPath)
+    return true
+  } catch {
+    return false
+  }
 }
 
 function isSameRuntimeLockOwner(

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto'
-import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, open, readFile, rm, stat } from 'node:fs/promises'
+import type { Stats } from 'node:fs'
+import type { FileHandle } from 'node:fs/promises'
 import path from 'node:path'
 
 export interface RuntimeLockHandle {
@@ -32,7 +34,8 @@ export function isProcessAlive(pid: number): boolean {
 
 export async function readRuntimeLockOwner(lockDirectory: string): Promise<RuntimeLockOwner | null> {
   try {
-    const raw = await readFile(path.join(lockDirectory, 'owner.json'), 'utf8')
+    const raw = await readLockOwnerText(lockDirectory)
+    if (!raw) return null
     const parsed = JSON.parse(raw) as Partial<RuntimeLockOwner>
     if (
       typeof parsed.jobId === 'string'
@@ -51,41 +54,73 @@ export async function readRuntimeLockOwner(lockDirectory: string): Promise<Runti
   return null
 }
 
+async function readLockOwnerText(lockPath: string): Promise<string | null> {
+  try {
+    return await readFile(lockPath, 'utf8')
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code !== 'EISDIR') return null
+  }
+
+  try {
+    return await readFile(path.join(lockPath, 'owner.json'), 'utf8')
+  } catch {
+    return null
+  }
+}
+
 export async function acquireRuntimeLock(
   rootDirectory: string,
   scope: string,
   jobId: string,
 ): Promise<RuntimeLockHandle | null> {
   await mkdir(rootDirectory, { recursive: true })
-  const lockDirectory = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
+  const lockPath = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
+  let lockFile: FileHandle
 
   try {
-    await mkdir(lockDirectory)
+    lockFile = await open(lockPath, 'wx')
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code
     if (code !== 'EEXIST') throw error
 
-    const active = await isRuntimeLockDirectoryActive(lockDirectory, scope)
+    const active = await isRuntimeLockPathActive(lockPath, scope)
     if (!active) {
-      await rm(lockDirectory, { force: true, recursive: true })
+      await rm(lockPath, { force: true, recursive: true })
       return acquireRuntimeLock(rootDirectory, scope, jobId)
     }
     return null
   }
 
-  await writeFile(
-    path.join(lockDirectory, 'owner.json'),
-    JSON.stringify({
-      jobId,
-      pid: process.pid,
-      scope,
-    }, null, 2),
-  )
+  const owner: RuntimeLockOwner = {
+    jobId,
+    pid: process.pid,
+    scope,
+  }
+  let removeFailedLock = false
+  try {
+    await lockFile.writeFile(JSON.stringify(owner, null, 2))
+    const currentOwner = await readRuntimeLockOwner(lockPath)
+    if (!isSameRuntimeLockOwner(currentOwner, owner)) {
+      return null
+    }
+  } catch (error) {
+    removeFailedLock = await isSameFile(lockPath, lockFile)
+    throw error
+  } finally {
+    await lockFile.close()
+    if (removeFailedLock) {
+      await rm(lockPath, { force: true, recursive: true })
+    }
+  }
 
   return {
-    directory: lockDirectory,
+    directory: lockPath,
     release: async () => {
-      await rm(lockDirectory, { force: true, recursive: true })
+      const currentOwner = await readRuntimeLockOwner(lockPath)
+      if (isSameRuntimeLockOwner(currentOwner, owner)) {
+        await rm(lockPath, { force: true, recursive: true })
+      }
     },
   }
 }
@@ -94,22 +129,22 @@ export async function isRuntimeScopeActive(
   rootDirectory: string,
   scope: string,
 ): Promise<boolean> {
-  const lockDirectory = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
-  const active = await isRuntimeLockDirectoryActive(lockDirectory, scope)
+  const lockPath = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
+  const active = await isRuntimeLockPathActive(lockPath, scope)
   if (!active) {
-    await rm(lockDirectory, { force: true, recursive: true })
+    await rm(lockPath, { force: true, recursive: true })
   }
   return active
 }
 
-async function isRuntimeLockDirectoryActive(
-  lockDirectory: string,
+async function isRuntimeLockPathActive(
+  lockPath: string,
   scope: string,
 ): Promise<boolean> {
-  const owner = await readRuntimeLockOwner(lockDirectory)
+  const owner = await readRuntimeLockOwner(lockPath)
   if (!owner) {
     try {
-      const stats = await stat(lockDirectory)
+      const stats = await stat(lockPath)
       return Date.now() - stats.mtimeMs < runtimeLockInitializationGraceMs
     } catch {
       return false
@@ -119,4 +154,29 @@ async function isRuntimeLockDirectoryActive(
     return false
   }
   return true
+}
+
+function isSameRuntimeLockOwner(
+  actual: RuntimeLockOwner | null,
+  expected: RuntimeLockOwner,
+): boolean {
+  return actual?.jobId === expected.jobId
+    && actual.pid === expected.pid
+    && actual.scope === expected.scope
+}
+
+async function isSameFile(lockPath: string, lockFile: FileHandle): Promise<boolean> {
+  try {
+    const [pathStats, fileStats] = await Promise.all([
+      stat(lockPath),
+      lockFile.stat(),
+    ])
+    return isSameStatsFile(pathStats, fileStats)
+  } catch {
+    return false
+  }
+}
+
+function isSameStatsFile(first: Stats, second: Stats): boolean {
+  return first.dev === second.dev && first.ino === second.ino
 }

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
@@ -1,0 +1,102 @@
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export interface RuntimeLockHandle {
+  directory: string
+  release(): Promise<void>
+}
+
+export interface RuntimeLockOwner {
+  jobId: string
+  pid: number
+  scope: string
+}
+
+export function runtimeLockName(scope: string): string {
+  return createHash('sha256').update(scope).digest('hex').slice(0, 24)
+}
+
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    return code === 'EPERM'
+  }
+}
+
+export async function readRuntimeLockOwner(lockDirectory: string): Promise<RuntimeLockOwner | null> {
+  try {
+    const raw = await readFile(path.join(lockDirectory, 'owner.json'), 'utf8')
+    const parsed = JSON.parse(raw) as Partial<RuntimeLockOwner>
+    if (
+      typeof parsed.jobId === 'string'
+      && typeof parsed.pid === 'number'
+      && typeof parsed.scope === 'string'
+    ) {
+      return {
+        jobId: parsed.jobId,
+        pid: parsed.pid,
+        scope: parsed.scope,
+      }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+export async function acquireRuntimeLock(
+  rootDirectory: string,
+  scope: string,
+  jobId: string,
+): Promise<RuntimeLockHandle | null> {
+  await mkdir(rootDirectory, { recursive: true })
+  const lockDirectory = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
+
+  try {
+    await mkdir(lockDirectory)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code !== 'EEXIST') throw error
+
+    const owner = await readRuntimeLockOwner(lockDirectory)
+    if (!owner || owner.scope !== scope || !isProcessAlive(owner.pid)) {
+      await rm(lockDirectory, { force: true, recursive: true })
+      return acquireRuntimeLock(rootDirectory, scope, jobId)
+    }
+    return null
+  }
+
+  await writeFile(
+    path.join(lockDirectory, 'owner.json'),
+    JSON.stringify({
+      jobId,
+      pid: process.pid,
+      scope,
+    }, null, 2),
+  )
+
+  return {
+    directory: lockDirectory,
+    release: async () => {
+      await rm(lockDirectory, { force: true, recursive: true })
+    },
+  }
+}
+
+export async function isRuntimeScopeActive(
+  rootDirectory: string,
+  scope: string,
+): Promise<boolean> {
+  const lockDirectory = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
+  const owner = await readRuntimeLockOwner(lockDirectory)
+  if (!owner || owner.scope !== scope || !isProcessAlive(owner.pid)) {
+    await rm(lockDirectory, { force: true, recursive: true })
+    return false
+  }
+  return true
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
@@ -13,6 +13,8 @@ export interface RuntimeLockOwner {
   scope: string
 }
 
+export const runtimeLockInitializationGraceMs = 5_000
+
 export function runtimeLockName(scope: string): string {
   return createHash('sha256').update(scope).digest('hex').slice(0, 24)
 }
@@ -63,8 +65,8 @@ export async function acquireRuntimeLock(
     const code = (error as NodeJS.ErrnoException).code
     if (code !== 'EEXIST') throw error
 
-    const owner = await readRuntimeLockOwner(lockDirectory)
-    if (owner && owner.scope === scope && !isProcessAlive(owner.pid)) {
+    const active = await isRuntimeLockDirectoryActive(lockDirectory, scope)
+    if (!active) {
       await rm(lockDirectory, { force: true, recursive: true })
       return acquireRuntimeLock(rootDirectory, scope, jobId)
     }
@@ -93,17 +95,27 @@ export async function isRuntimeScopeActive(
   scope: string,
 ): Promise<boolean> {
   const lockDirectory = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
+  const active = await isRuntimeLockDirectoryActive(lockDirectory, scope)
+  if (!active) {
+    await rm(lockDirectory, { force: true, recursive: true })
+  }
+  return active
+}
+
+async function isRuntimeLockDirectoryActive(
+  lockDirectory: string,
+  scope: string,
+): Promise<boolean> {
   const owner = await readRuntimeLockOwner(lockDirectory)
   if (!owner) {
     try {
-      await stat(lockDirectory)
-      return true
+      const stats = await stat(lockDirectory)
+      return Date.now() - stats.mtimeMs < runtimeLockInitializationGraceMs
     } catch {
       return false
     }
   }
   if (owner && owner.scope === scope && !isProcessAlive(owner.pid)) {
-    await rm(lockDirectory, { force: true, recursive: true })
     return false
   }
   return true

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
@@ -1,7 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, open, readFile, rm, stat } from 'node:fs/promises'
-import type { Stats } from 'node:fs'
-import type { FileHandle } from 'node:fs/promises'
+import { chmod, mkdir, readFile, rm, rmdir, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 export interface RuntimeLockHandle {
@@ -105,7 +103,7 @@ async function acquireRuntimeLockWithReclaimRetry(
     pid: process.pid,
     scope,
   }
-  const lock = await acquireOwnerFileLock(lockPath, owner)
+  const lock = await acquireOwnerDirectoryLock(lockPath, owner)
   if (lock) return lock
 
   const active = await isRuntimeLockPathActive(lockPath, scope)
@@ -152,7 +150,7 @@ async function acquireRuntimeReclaimLock(
     pid: process.pid,
     scope: reclaimScope,
   }
-  const lock = await acquireOwnerFileLock(reclaimPath, owner)
+  const lock = await acquireOwnerDirectoryLock(reclaimPath, owner)
   if (lock) return lock
 
   if (await isRuntimeLockPathActive(reclaimPath, reclaimScope)) {
@@ -163,35 +161,34 @@ async function acquireRuntimeReclaimLock(
   return acquireRuntimeReclaimLock(rootDirectory, scope, jobId)
 }
 
-async function acquireOwnerFileLock(
+async function acquireOwnerDirectoryLock(
   lockPath: string,
   owner: RuntimeLockOwner,
 ): Promise<RuntimeLockHandle | null> {
-  let lockFile: FileHandle
-
+  let lockDirectoryCreated = false
   try {
-    lockFile = await open(lockPath, 'wx')
+    await mkdir(lockPath)
+    lockDirectoryCreated = true
+    if (!await writeRuntimeLockOwnerFile(lockPath, owner)) return null
   } catch (error) {
+    if (lockDirectoryCreated) {
+      await removeFailedRuntimeLockDirectory(lockPath, owner)
+    }
     const code = (error as NodeJS.ErrnoException).code
-    if (code === 'EEXIST' || code === 'EISDIR') return null
+    if (
+      code === 'EEXIST'
+      || code === 'EISDIR'
+      || code === 'ENOTDIR'
+      || code === 'ENOTEMPTY'
+    ) {
+      return null
+    }
     throw error
   }
 
-  let removeFailedLock = false
-  try {
-    await lockFile.writeFile(JSON.stringify(owner, null, 2))
-    const currentOwner = await readRuntimeLockOwner(lockPath)
-    if (!isSameRuntimeLockOwner(currentOwner, owner)) {
-      return null
-    }
-  } catch (error) {
-    removeFailedLock = await isSameFile(lockPath, lockFile)
-    throw error
-  } finally {
-    await lockFile.close()
-    if (removeFailedLock) {
-      await rm(lockPath, { force: true, recursive: true })
-    }
+  const currentOwner = await readRuntimeLockOwner(lockPath)
+  if (!isSameRuntimeLockOwner(currentOwner, owner)) {
+    return null
   }
 
   return {
@@ -256,20 +253,62 @@ function isSameRuntimeLockOwner(
     && actual.scope === expected.scope
 }
 
-async function isSameFile(lockPath: string, lockFile: FileHandle): Promise<boolean> {
+async function writeRuntimeLockOwnerFile(
+  lockPath: string,
+  owner: RuntimeLockOwner,
+): Promise<boolean> {
+  const ownerPath = path.join(lockPath, 'owner.json')
+  let ownerWritten = false
   try {
-    const [pathStats, fileStats] = await Promise.all([
-      stat(lockPath),
-      lockFile.stat(),
-    ])
-    return isSameStatsFile(pathStats, fileStats)
-  } catch {
-    return false
+    await writeFile(ownerPath, JSON.stringify(owner, null, 2), { flag: 'wx', mode: 0o444 })
+    ownerWritten = true
+    await chmod(ownerPath, 0o444)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (ownerWritten) {
+      await removeRuntimeLockOwnerFileIfOwnerMatches(lockPath, owner)
+      throw error
+    }
+    if (code === 'EEXIST') return false
+    if (
+      (code === 'EACCES' || code === 'EPERM')
+      && await readRuntimeLockOwner(lockPath) !== null
+    ) {
+      return false
+    }
+    throw error
   }
 }
 
-function isSameStatsFile(first: Stats, second: Stats): boolean {
-  return first.dev === second.dev && first.ino === second.ino
+async function removeRuntimeLockOwnerFileIfOwnerMatches(
+  lockPath: string,
+  owner: RuntimeLockOwner,
+): Promise<void> {
+  try {
+    const currentOwner = await readRuntimeLockOwner(lockPath)
+    if (isSameRuntimeLockOwner(currentOwner, owner)) {
+      await rm(path.join(lockPath, 'owner.json'), { force: true })
+    }
+  } catch {
+    // Losing a race should not turn into a runtime failure.
+  }
+}
+
+async function removeFailedRuntimeLockDirectory(
+  lockPath: string,
+  owner: RuntimeLockOwner,
+): Promise<void> {
+  try {
+    const currentOwner = await readRuntimeLockOwner(lockPath)
+    if (currentOwner && !isSameRuntimeLockOwner(currentOwner, owner)) return
+    if (currentOwner) {
+      await rm(path.join(lockPath, 'owner.json'), { force: true })
+    }
+    await rmdir(lockPath)
+  } catch {
+    // Cleanup is best-effort; the original acquisition error is more useful.
+  }
 }
 
 async function waitForRuntimeLockReclaimRetry(): Promise<void> {

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.ts
@@ -16,6 +16,8 @@ export interface RuntimeLockOwner {
 }
 
 export const runtimeLockInitializationGraceMs = 5_000
+const runtimeLockReclaimRetryAttempts = 50
+const runtimeLockReclaimRetryDelayMs = 10
 
 export function runtimeLockName(scope: string): string {
   return createHash('sha256').update(scope).digest('hex').slice(0, 24)
@@ -74,29 +76,99 @@ export async function acquireRuntimeLock(
   scope: string,
   jobId: string,
 ): Promise<RuntimeLockHandle | null> {
+  return acquireRuntimeLockWithReclaimRetry(
+    rootDirectory,
+    scope,
+    jobId,
+    runtimeLockReclaimRetryAttempts,
+  )
+}
+
+async function acquireRuntimeLockWithReclaimRetry(
+  rootDirectory: string,
+  scope: string,
+  jobId: string,
+  remainingReclaimRetries: number,
+): Promise<RuntimeLockHandle | null> {
   await mkdir(rootDirectory, { recursive: true })
   const lockPath = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
+  const owner: RuntimeLockOwner = {
+    jobId,
+    pid: process.pid,
+    scope,
+  }
+  const lock = await acquireOwnerFileLock(lockPath, owner)
+  if (lock) return lock
+
+  const active = await isRuntimeLockPathActive(lockPath, scope)
+  if (active) return null
+
+  const reclaimLock = await acquireRuntimeReclaimLock(rootDirectory, scope, jobId)
+  if (!reclaimLock) {
+    if (await isRuntimeLockPathActive(lockPath, scope)) return null
+    if (remainingReclaimRetries <= 0) return null
+    await waitForRuntimeLockReclaimRetry()
+    return acquireRuntimeLockWithReclaimRetry(
+      rootDirectory,
+      scope,
+      jobId,
+      remainingReclaimRetries - 1,
+    )
+  }
+  try {
+    if (await isRuntimeLockPathActive(lockPath, scope)) {
+      return null
+    }
+    await rm(lockPath, { force: true, recursive: true })
+  } finally {
+    await reclaimLock.release()
+  }
+  return acquireRuntimeLockWithReclaimRetry(
+    rootDirectory,
+    scope,
+    jobId,
+    runtimeLockReclaimRetryAttempts,
+  )
+}
+
+async function acquireRuntimeReclaimLock(
+  rootDirectory: string,
+  scope: string,
+  jobId: string,
+): Promise<RuntimeLockHandle | null> {
+  await mkdir(rootDirectory, { recursive: true })
+  const reclaimScope = `${scope}:reclaim`
+  const reclaimPath = path.join(rootDirectory, `${runtimeLockName(reclaimScope)}.reclaim.lock`)
+  const owner: RuntimeLockOwner = {
+    jobId: `${jobId}:reclaim`,
+    pid: process.pid,
+    scope: reclaimScope,
+  }
+  const lock = await acquireOwnerFileLock(reclaimPath, owner)
+  if (lock) return lock
+
+  if (await isRuntimeLockPathActive(reclaimPath, reclaimScope)) {
+    return null
+  }
+
+  await rm(reclaimPath, { force: true, recursive: true })
+  return acquireRuntimeReclaimLock(rootDirectory, scope, jobId)
+}
+
+async function acquireOwnerFileLock(
+  lockPath: string,
+  owner: RuntimeLockOwner,
+): Promise<RuntimeLockHandle | null> {
   let lockFile: FileHandle
 
   try {
     lockFile = await open(lockPath, 'wx')
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code
-    if (code !== 'EEXIST') throw error
-
-    const active = await isRuntimeLockPathActive(lockPath, scope)
-    if (!active) {
-      await rm(lockPath, { force: true, recursive: true })
-      return acquireRuntimeLock(rootDirectory, scope, jobId)
-    }
-    return null
+    if (code === 'EEXIST' || code === 'EISDIR') return null
+    throw error
   }
 
-  const owner: RuntimeLockOwner = {
-    jobId,
-    pid: process.pid,
-    scope,
-  }
   let removeFailedLock = false
   try {
     await lockFile.writeFile(JSON.stringify(owner, null, 2))
@@ -132,7 +204,18 @@ export async function isRuntimeScopeActive(
   const lockPath = path.join(rootDirectory, `${runtimeLockName(scope)}.lock`)
   const active = await isRuntimeLockPathActive(lockPath, scope)
   if (!active) {
-    await rm(lockPath, { force: true, recursive: true })
+    const reclaimLock = await acquireRuntimeReclaimLock(rootDirectory, scope, `observer-${process.pid}`)
+    if (!reclaimLock) {
+      return isRuntimeLockPathActive(lockPath, scope)
+    }
+    try {
+      if (await isRuntimeLockPathActive(lockPath, scope)) {
+        return true
+      }
+      await rm(lockPath, { force: true, recursive: true })
+    } finally {
+      await reclaimLock.release()
+    }
   }
   return active
 }
@@ -179,4 +262,8 @@ async function isSameFile(lockPath: string, lockFile: FileHandle): Promise<boole
 
 function isSameStatsFile(first: Stats, second: Stats): boolean {
   return first.dev === second.dev && first.ino === second.ino
+}
+
+async function waitForRuntimeLockReclaimRetry(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, runtimeLockReclaimRetryDelayMs))
 }

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.windows.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeLocks.windows.test.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+const epermDirectoryReadPaths = vi.hoisted(() => new Set<string>())
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    readFile: vi.fn((file: unknown, options?: unknown) => {
+      const filePath = typeof file === 'string'
+        ? file
+        : file instanceof URL
+          ? file.pathname
+          : ''
+      if (epermDirectoryReadPaths.has(filePath)) {
+        const error = new Error('operation not permitted') as NodeJS.ErrnoException
+        error.code = 'EPERM'
+        throw error
+      }
+      return actual.readFile(file as never, options as never)
+    }),
+  }
+})
+
+import {
+  readRuntimeLockOwner,
+  runtimeLockName,
+} from './runtimeLocks'
+
+describe('runtimeLocks Windows directory compatibility', () => {
+  it('reads directory lock owners when directory reads report EPERM', async () => {
+    const root = path.join(tmpdir(), `ecos-runtime-lock-test-${randomUUID()}`)
+    const lockDirectory = path.join(root, `${runtimeLockName('/work/demo')}.lock`)
+    try {
+      await mkdir(lockDirectory, { recursive: true })
+      await writeFile(path.join(lockDirectory, 'owner.json'), JSON.stringify({
+        jobId: 'job-1',
+        pid: process.pid,
+        scope: '/work/demo',
+      }))
+      epermDirectoryReadPaths.add(lockDirectory)
+
+      await expect(readRuntimeLockOwner(lockDirectory)).resolves.toEqual({
+        jobId: 'job-1',
+        pid: process.pid,
+        scope: '/work/demo',
+      })
+    } finally {
+      epermDirectoryReadPaths.delete(lockDirectory)
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeScopes.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeScopes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  globalRuntimeScope,
+  globalRuntimeScopeRecord,
+  normalizeDirectoryScope,
+  workspaceRuntimeScope,
+} from './runtimeScopes'
+
+describe('runtimeScopes', () => {
+  it('normalizes workspace directory scopes', () => {
+    expect(normalizeDirectoryScope(' /work/demo/ ')).toBe('/work/demo')
+    expect(normalizeDirectoryScope('C:\\work\\demo\\')).toBe('C:/work/demo')
+    expect(normalizeDirectoryScope('/')).toBe('/')
+  })
+
+  it('creates workspace runtime scope records', () => {
+    expect(workspaceRuntimeScope(' /work/demo/ ')).toEqual({
+      directory: '/work/demo',
+      id: '/work/demo',
+      workspaceId: '/work/demo',
+    })
+  })
+
+  it('creates a global runtime scope for empty directories', () => {
+    expect(workspaceRuntimeScope('   ')).toEqual({
+      id: globalRuntimeScope,
+    })
+    expect(globalRuntimeScopeRecord()).toEqual({
+      id: globalRuntimeScope,
+    })
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeScopes.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/runtimeScopes.ts
@@ -1,0 +1,30 @@
+export interface RuntimeScope {
+  directory?: string
+  id: string
+  workspaceId?: string
+}
+
+export const globalRuntimeScope = '__global__'
+
+export function normalizeDirectoryScope(directory: string): string {
+  const normalized = directory.trim().replace(/\\/g, '/')
+  return normalized.length > 1 && normalized.endsWith('/')
+    ? normalized.slice(0, -1)
+    : normalized
+}
+
+export function workspaceRuntimeScope(directory: string): RuntimeScope {
+  const normalized = normalizeDirectoryScope(directory)
+  if (!normalized) return globalRuntimeScopeRecord()
+  return {
+    directory: normalized,
+    id: normalized,
+    workspaceId: normalized,
+  }
+}
+
+export function globalRuntimeScopeRecord(): RuntimeScope {
+  return {
+    id: globalRuntimeScope,
+  }
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.test.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+import {
+  SharedRuntimeManager,
+  type SharedRuntimeAdapter,
+  type SharedRuntimeAdapterContext,
+} from './sharedRuntimeManager'
+import { workspaceRuntimeScope } from './runtimeScopes'
+
+interface RuntimeRequest {
+  label: string
+  longRunning?: boolean
+  scopeDirectory?: string
+}
+
+interface RuntimeResult {
+  messages: string[]
+  ok: boolean
+}
+
+interface RuntimeEvent {
+  jobId?: string
+  label: string
+  result?: RuntimeResult
+  scopeId?: string
+  text: string
+  type: 'queued' | 'started' | 'progress' | 'completed' | 'failed'
+}
+
+interface RuntimeAdapterContext extends SharedRuntimeAdapterContext<RuntimeEvent> {
+  providerId: string
+}
+
+function createManager(adapter: SharedRuntimeAdapter<RuntimeRequest, RuntimeResult, RuntimeEvent>) {
+  return new SharedRuntimeManager<RuntimeRequest, RuntimeResult, RuntimeEvent>({
+    adapter,
+    createFailedResult: (_request, message) => ({
+      messages: [message],
+      ok: false,
+    }),
+    getRequestLabel: (request) => request.label,
+    isLongRunning: (request) => request.longRunning === true,
+    resolveScope: (request) => workspaceRuntimeScope(request.scopeDirectory ?? ''),
+    runtimeLockRoot: path.join(tmpdir(), `ecos-shared-runtime-lock-test-${randomUUID()}`),
+    toCompletedEvent: (request, jobId, scope, result) => ({
+      jobId,
+      label: request.label,
+      result,
+      scopeId: scope.id,
+      text: result.messages.join('\n'),
+      type: 'completed',
+    }),
+    toFailedEvent: (request, jobId, scope, result) => ({
+      jobId,
+      label: request.label,
+      result,
+      scopeId: scope.id,
+      text: result.messages.join('\n'),
+      type: 'failed',
+    }),
+    toQueuedEvent: (request, jobId, scope) => ({
+      jobId,
+      label: request.label,
+      scopeId: scope.id,
+      text: `Queued ${request.label}`,
+      type: 'queued',
+    }),
+    toStartedEvent: (request, jobId, scope) => ({
+      jobId,
+      label: request.label,
+      scopeId: scope.id,
+      text: `Started ${request.label}`,
+      type: 'started',
+    }),
+    withJobMetadata: (event, _request, jobId, scope) => ({
+      ...event,
+      jobId,
+      scopeId: scope.id,
+    }),
+  })
+}
+
+describe('SharedRuntimeManager', () => {
+  it('keeps request, result, event, and adapter context types connected', () => {
+    expectTypeOf<Parameters<SharedRuntimeAdapter<RuntimeRequest, RuntimeResult, RuntimeEvent>['execute']>[0]>()
+      .toEqualTypeOf<RuntimeRequest>()
+    expectTypeOf<Parameters<SharedRuntimeAdapter<RuntimeRequest, RuntimeResult, RuntimeEvent>['execute']>[1]>()
+      .toEqualTypeOf<SharedRuntimeAdapterContext<RuntimeEvent>>()
+    expectTypeOf<Parameters<SharedRuntimeAdapter<
+      RuntimeRequest,
+      RuntimeResult,
+      RuntimeEvent,
+      RuntimeAdapterContext
+    >['execute']>[1]>().toEqualTypeOf<RuntimeAdapterContext>()
+  })
+
+  it('fans out queued, adapter, and completed events with the same job metadata', async () => {
+    const registeredListener = vi.fn()
+    const directListener = vi.fn()
+    const manager = createManager({
+      execute: vi.fn(async (_request, context) => {
+        context.emit({
+          label: 'build',
+          text: 'halfway',
+          type: 'progress',
+        })
+        return {
+          messages: ['done'],
+          ok: true,
+        }
+      }),
+    })
+
+    manager.onEvent(registeredListener)
+    await expect(manager.execute({
+      label: 'build',
+      scopeDirectory: '/work/demo',
+    }, directListener)).resolves.toEqual({
+      messages: ['done'],
+      ok: true,
+    })
+
+    expect(directListener).toHaveBeenCalledTimes(4)
+    expect(registeredListener).toHaveBeenCalledTimes(4)
+    expect(directListener).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      label: 'build',
+      scopeId: '/work/demo',
+      type: 'queued',
+    }))
+    expect(directListener).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      label: 'build',
+      scopeId: '/work/demo',
+      type: 'started',
+    }))
+    expect(directListener).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      jobId: expect.any(String),
+      scopeId: '/work/demo',
+      text: 'halfway',
+      type: 'progress',
+    }))
+    expect(directListener).toHaveBeenNthCalledWith(4, expect.objectContaining({
+      result: { messages: ['done'], ok: true },
+      type: 'completed',
+    }))
+
+    const jobIds = directListener.mock.calls.map(([event]) => event.jobId)
+    expect(new Set(jobIds).size).toBe(1)
+  })
+
+  it('tracks active long-running scopes and clears them after execution', async () => {
+    let release!: () => void
+    const manager = createManager({
+      execute: vi.fn(() => new Promise<RuntimeResult>((resolve) => {
+        release = () => resolve({
+          messages: ['done'],
+          ok: true,
+        })
+      })),
+    })
+
+    const pending = manager.execute({
+      label: 'flow',
+      longRunning: true,
+      scopeDirectory: '/work/demo',
+    })
+
+    await vi.waitFor(async () => {
+      await expect(manager.isScopeActive('/work/demo')).resolves.toBe(true)
+    })
+
+    release()
+    await expect(pending).resolves.toEqual({
+      messages: ['done'],
+      ok: true,
+    })
+    await expect(manager.isScopeActive('/work/demo')).resolves.toBe(false)
+  })
+
+  it('fails overlapping long-running requests for the same scope', async () => {
+    let release!: () => void
+    const adapterExecute = vi.fn(() => new Promise<RuntimeResult>((resolve) => {
+      release = () => resolve({
+        messages: ['done'],
+        ok: true,
+      })
+    }))
+    const listener = vi.fn()
+    const manager = createManager({
+      execute: adapterExecute,
+    })
+
+    const first = manager.execute({
+      label: 'flow',
+      longRunning: true,
+      scopeDirectory: '/work/demo',
+    })
+    await vi.waitFor(() => {
+      expect(adapterExecute).toHaveBeenCalledTimes(1)
+    })
+
+    await expect(manager.execute({
+      label: 'flow',
+      longRunning: true,
+      scopeDirectory: '/work/demo',
+    }, listener)).resolves.toEqual({
+      messages: ['Another flow is already running for /work/demo. Wait for it to finish before starting a new one.'],
+      ok: false,
+    })
+    expect(adapterExecute).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+      result: expect.objectContaining({ ok: false }),
+      type: 'failed',
+    }))
+
+    release()
+    await first
+  })
+
+  it('maps adapter errors to failed results and clears active scopes', async () => {
+    const manager = createManager({
+      execute: vi.fn(async () => {
+        throw new Error('adapter unavailable')
+      }),
+    })
+
+    await expect(manager.execute({
+      label: 'flow',
+      longRunning: true,
+      scopeDirectory: '/work/demo',
+    })).resolves.toEqual({
+      messages: ['adapter unavailable'],
+      ok: false,
+    })
+    await expect(manager.isScopeActive('/work/demo')).resolves.toBe(false)
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.test.ts
@@ -151,13 +151,14 @@ describe('SharedRuntimeManager', () => {
 
   it('tracks active long-running scopes and clears them after execution', async () => {
     let release!: () => void
+    const adapterExecute = vi.fn(() => new Promise<RuntimeResult>((resolve) => {
+      release = () => resolve({
+        messages: ['done'],
+        ok: true,
+      })
+    }))
     const manager = createManager({
-      execute: vi.fn(() => new Promise<RuntimeResult>((resolve) => {
-        release = () => resolve({
-          messages: ['done'],
-          ok: true,
-        })
-      })),
+      execute: adapterExecute,
     })
 
     const pending = manager.execute({
@@ -167,6 +168,7 @@ describe('SharedRuntimeManager', () => {
     })
 
     await vi.waitFor(async () => {
+      expect(adapterExecute).toHaveBeenCalledTimes(1)
       await expect(manager.isScopeActive('/work/demo')).resolves.toBe(true)
     })
 
@@ -233,6 +235,33 @@ describe('SharedRuntimeManager', () => {
       messages: ['adapter unavailable'],
       ok: false,
     })
+    await expect(manager.isScopeActive('/work/demo')).resolves.toBe(false)
+  })
+
+  it('clears active long-running scopes when started event delivery fails', async () => {
+    const adapterExecute = vi.fn(async () => ({
+      messages: ['done'],
+      ok: true,
+    }))
+    const listener = vi.fn((event: RuntimeEvent) => {
+      if (event.type === 'started') {
+        throw new Error('listener unavailable')
+      }
+    })
+    const manager = createManager({
+      execute: adapterExecute,
+    })
+
+    await expect(manager.execute({
+      label: 'flow',
+      longRunning: true,
+      scopeDirectory: '/work/demo',
+    }, listener)).resolves.toEqual({
+      messages: ['listener unavailable'],
+      ok: false,
+    })
+
+    expect(adapterExecute).not.toHaveBeenCalled()
     await expect(manager.isScopeActive('/work/demo')).resolves.toBe(false)
   })
 })

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.ts
@@ -26,7 +26,7 @@ export interface SharedRuntimeAdapter<
   TRequest,
   TResult,
   TEvent,
-  TContext extends SharedRuntimeAdapterContext<TEvent> = SharedRuntimeAdapterContext<TEvent>,
+  TContext = SharedRuntimeAdapterContext<TEvent>,
 > {
   execute(
     request: TRequest,
@@ -38,7 +38,7 @@ export interface SharedRuntimeManagerOptions<
   TRequest,
   TResult,
   TEvent,
-  TContext extends SharedRuntimeAdapterContext<TEvent> = SharedRuntimeAdapterContext<TEvent>,
+  TContext = SharedRuntimeAdapterContext<TEvent>,
 > {
   adapter: SharedRuntimeAdapter<TRequest, TResult, TEvent, TContext>
   createAdapterContext?: (
@@ -47,6 +47,7 @@ export interface SharedRuntimeManagerOptions<
     jobId: string,
     scope: RuntimeScope,
   ) => TContext
+  createBlockedResult?(request: TRequest, message: string): TResult
   createFailedResult(request: TRequest, message: string): TResult
   getRequestLabel(request: TRequest): string
   isFailedResult?: (result: TResult) => boolean
@@ -69,7 +70,7 @@ export class SharedRuntimeManager<
   TRequest,
   TResult,
   TEvent,
-  TContext extends SharedRuntimeAdapterContext<TEvent> = SharedRuntimeAdapterContext<TEvent>,
+  TContext = SharedRuntimeAdapterContext<TEvent>,
 > {
   private readonly activeLongRunningJobsByScope = new Map<string, string>()
   private readonly eventFanout = new RuntimeEventFanout<TEvent>()
@@ -100,6 +101,7 @@ export class SharedRuntimeManager<
     const scope = this.options.resolveScope(request)
     const longRunning = this.options.isLongRunning(request)
     let runtimeLock: RuntimeLockHandle | null = null
+    let trackedActiveScope = false
 
     this.emit(this.options.toQueuedEvent(request, jobId, scope), listener)
 
@@ -108,11 +110,18 @@ export class SharedRuntimeManager<
     }
 
     if (longRunning) {
-      runtimeLock = await acquireRuntimeLock(this.runtimeLockRoot, scope.id, jobId)
+      this.activeLongRunningJobsByScope.set(scope.id, jobId)
+      trackedActiveScope = true
+      try {
+        runtimeLock = await acquireRuntimeLock(this.runtimeLockRoot, scope.id, jobId)
+      } catch (error) {
+        this.clearActiveScope(scope.id, jobId)
+        throw error
+      }
       if (!runtimeLock) {
+        this.clearActiveScope(scope.id, jobId)
         return this.failBlockedRequest(request, jobId, scope, listener)
       }
-      this.activeLongRunningJobsByScope.set(scope.id, jobId)
     }
 
     try {
@@ -140,8 +149,8 @@ export class SharedRuntimeManager<
       this.emit(this.options.toFailedEvent(request, jobId, scope, result), listener)
       return result
     } finally {
-      if (longRunning && this.activeLongRunningJobsByScope.get(scope.id) === jobId) {
-        this.activeLongRunningJobsByScope.delete(scope.id)
+      if (trackedActiveScope) {
+        this.clearActiveScope(scope.id, jobId)
       }
       await runtimeLock?.release()
     }
@@ -160,9 +169,16 @@ export class SharedRuntimeManager<
     const message = scope.directory
       ? `Another ${this.options.getRequestLabel(request)} is already running for ${scope.directory}. Wait for it to finish before starting a new one.`
       : `Another ${this.options.getRequestLabel(request)} is already running. Wait for it to finish before starting a new one.`
-    const result = this.options.createFailedResult(request, message)
+    const result = this.options.createBlockedResult?.(request, message)
+      ?? this.options.createFailedResult(request, message)
     this.emit(this.options.toFailedEvent(request, jobId, scope, result), listener)
     return result
+  }
+
+  private clearActiveScope(scopeId: string, jobId: string): void {
+    if (this.activeLongRunningJobsByScope.get(scopeId) === jobId) {
+      this.activeLongRunningJobsByScope.delete(scopeId)
+    }
   }
 
   private scopeIdForString(scope: string): string {

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.ts
@@ -115,17 +115,17 @@ export class SharedRuntimeManager<
       this.activeLongRunningJobsByScope.set(scope.id, jobId)
     }
 
-    this.emit(this.options.toStartedEvent(request, jobId, scope), listener)
-
-    const context: SharedRuntimeAdapterContext<TEvent> = {
-      emit: (event) => {
-        this.emit(this.options.withJobMetadata(event, request, jobId, scope), listener)
-      },
-    }
-    const adapterContext = this.options.createAdapterContext?.(context, request, jobId, scope)
-      ?? (context as TContext)
-
     try {
+      this.emit(this.options.toStartedEvent(request, jobId, scope), listener)
+
+      const context: SharedRuntimeAdapterContext<TEvent> = {
+        emit: (event) => {
+          this.emit(this.options.withJobMetadata(event, request, jobId, scope), listener)
+        },
+      }
+      const adapterContext = this.options.createAdapterContext?.(context, request, jobId, scope)
+        ?? (context as TContext)
+
       const result = await this.options.adapter.execute(request, adapterContext)
       const event = this.options.isFailedResult?.(result) === true
         ? this.options.toFailedEvent(request, jobId, scope, result)

--- a/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/runtime/sharedRuntimeManager.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from 'node:crypto'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  acquireRuntimeLock,
+  isRuntimeScopeActive,
+  type RuntimeLockHandle,
+} from './runtimeLocks'
+import {
+  globalRuntimeScope,
+  type RuntimeScope,
+  workspaceRuntimeScope,
+} from './runtimeScopes'
+import {
+  RuntimeEventFanout,
+  type RuntimeEventListener,
+} from './runtimeEvents'
+
+export type { RuntimeScope } from './runtimeScopes'
+
+export interface SharedRuntimeAdapterContext<TEvent> {
+  emit(event: TEvent): void
+}
+
+export interface SharedRuntimeAdapter<
+  TRequest,
+  TResult,
+  TEvent,
+  TContext extends SharedRuntimeAdapterContext<TEvent> = SharedRuntimeAdapterContext<TEvent>,
+> {
+  execute(
+    request: TRequest,
+    context: TContext,
+  ): Promise<TResult>
+}
+
+export interface SharedRuntimeManagerOptions<
+  TRequest,
+  TResult,
+  TEvent,
+  TContext extends SharedRuntimeAdapterContext<TEvent> = SharedRuntimeAdapterContext<TEvent>,
+> {
+  adapter: SharedRuntimeAdapter<TRequest, TResult, TEvent, TContext>
+  createAdapterContext?: (
+    context: SharedRuntimeAdapterContext<TEvent>,
+    request: TRequest,
+    jobId: string,
+    scope: RuntimeScope,
+  ) => TContext
+  createFailedResult(request: TRequest, message: string): TResult
+  getRequestLabel(request: TRequest): string
+  isFailedResult?: (result: TResult) => boolean
+  isLongRunning(request: TRequest): boolean
+  resolveScope(request: TRequest): RuntimeScope
+  runtimeLockRoot?: string
+  toQueuedEvent(request: TRequest, jobId: string, scope: RuntimeScope): TEvent
+  toStartedEvent(request: TRequest, jobId: string, scope: RuntimeScope): TEvent
+  toCompletedEvent(
+    request: TRequest,
+    jobId: string,
+    scope: RuntimeScope,
+    result: TResult,
+  ): TEvent
+  toFailedEvent(request: TRequest, jobId: string, scope: RuntimeScope, result: TResult): TEvent
+  withJobMetadata(event: TEvent, request: TRequest, jobId: string, scope: RuntimeScope): TEvent
+}
+
+export class SharedRuntimeManager<
+  TRequest,
+  TResult,
+  TEvent,
+  TContext extends SharedRuntimeAdapterContext<TEvent> = SharedRuntimeAdapterContext<TEvent>,
+> {
+  private readonly activeLongRunningJobsByScope = new Map<string, string>()
+  private readonly eventFanout = new RuntimeEventFanout<TEvent>()
+  private readonly options: SharedRuntimeManagerOptions<TRequest, TResult, TEvent, TContext>
+  private readonly runtimeLockRoot: string
+
+  constructor(options: SharedRuntimeManagerOptions<TRequest, TResult, TEvent, TContext>) {
+    this.options = options
+    this.runtimeLockRoot = options.runtimeLockRoot
+      ?? path.join(os.tmpdir(), 'ecos-studio-runtime-locks')
+  }
+
+  onEvent(listener: RuntimeEventListener<TEvent>): () => void {
+    return this.eventFanout.onEvent(listener)
+  }
+
+  async isScopeActive(scope: RuntimeScope | string): Promise<boolean> {
+    const scopeId = typeof scope === 'string' ? this.scopeIdForString(scope) : scope.id
+    if (this.activeLongRunningJobsByScope.has(scopeId)) return true
+    return isRuntimeScopeActive(this.runtimeLockRoot, scopeId)
+  }
+
+  async execute(
+    request: TRequest,
+    listener?: RuntimeEventListener<TEvent>,
+  ): Promise<TResult> {
+    const jobId = randomUUID()
+    const scope = this.options.resolveScope(request)
+    const longRunning = this.options.isLongRunning(request)
+    let runtimeLock: RuntimeLockHandle | null = null
+
+    this.emit(this.options.toQueuedEvent(request, jobId, scope), listener)
+
+    if (longRunning && this.activeLongRunningJobsByScope.has(scope.id)) {
+      return this.failBlockedRequest(request, jobId, scope, listener)
+    }
+
+    if (longRunning) {
+      runtimeLock = await acquireRuntimeLock(this.runtimeLockRoot, scope.id, jobId)
+      if (!runtimeLock) {
+        return this.failBlockedRequest(request, jobId, scope, listener)
+      }
+      this.activeLongRunningJobsByScope.set(scope.id, jobId)
+    }
+
+    this.emit(this.options.toStartedEvent(request, jobId, scope), listener)
+
+    const context: SharedRuntimeAdapterContext<TEvent> = {
+      emit: (event) => {
+        this.emit(this.options.withJobMetadata(event, request, jobId, scope), listener)
+      },
+    }
+    const adapterContext = this.options.createAdapterContext?.(context, request, jobId, scope)
+      ?? (context as TContext)
+
+    try {
+      const result = await this.options.adapter.execute(request, adapterContext)
+      const event = this.options.isFailedResult?.(result) === true
+        ? this.options.toFailedEvent(request, jobId, scope, result)
+        : this.options.toCompletedEvent(request, jobId, scope, result)
+      this.emit(event, listener)
+      return result
+    } catch (error) {
+      const result = this.options.createFailedResult(
+        request,
+        error instanceof Error ? error.message : String(error),
+      )
+      this.emit(this.options.toFailedEvent(request, jobId, scope, result), listener)
+      return result
+    } finally {
+      if (longRunning && this.activeLongRunningJobsByScope.get(scope.id) === jobId) {
+        this.activeLongRunningJobsByScope.delete(scope.id)
+      }
+      await runtimeLock?.release()
+    }
+  }
+
+  private emit(event: TEvent, listener?: RuntimeEventListener<TEvent>): void {
+    this.eventFanout.emit(event, listener)
+  }
+
+  private failBlockedRequest(
+    request: TRequest,
+    jobId: string,
+    scope: RuntimeScope,
+    listener?: RuntimeEventListener<TEvent>,
+  ): TResult {
+    const message = scope.directory
+      ? `Another ${this.options.getRequestLabel(request)} is already running for ${scope.directory}. Wait for it to finish before starting a new one.`
+      : `Another ${this.options.getRequestLabel(request)} is already running. Wait for it to finish before starting a new one.`
+    const result = this.options.createFailedResult(request, message)
+    this.emit(this.options.toFailedEvent(request, jobId, scope, result), listener)
+    return result
+  }
+
+  private scopeIdForString(scope: string): string {
+    if (scope === globalRuntimeScope) return scope
+    return workspaceRuntimeScope(scope).id
+  }
+}

--- a/ecos/gui/packages/shared/src/contracts/desktopAgent.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopAgent.ts
@@ -1,0 +1,81 @@
+export type DesktopAgentStatusState = 'stopped' | 'starting' | 'ready' | 'running' | 'error'
+
+export interface DesktopAgentProviderRequest {
+  providerId?: string
+}
+
+export interface DesktopAgentStartRequest extends DesktopAgentProviderRequest {
+  directory?: string
+}
+
+export interface DesktopAgentStartSessionRequest extends DesktopAgentProviderRequest {
+  directory?: string
+  sessionId?: string
+  workspaceId?: string
+}
+
+export interface DesktopAgentStartSessionResponse {
+  sessionId: string
+}
+
+export interface DesktopAgentSendMessageRequest extends DesktopAgentProviderRequest {
+  message: string
+  sessionId: string
+}
+
+export interface DesktopAgentSendMessageResponse {
+  messageId?: string
+  sessionId: string
+  text?: string
+  turnId?: string
+}
+
+export interface DesktopAgentStatus {
+  activeSessionId?: string
+  message?: string
+  providerId: string
+  state: DesktopAgentStatusState
+}
+
+export interface DesktopAgentSetModeRequest extends DesktopAgentProviderRequest {
+  mode: string
+}
+
+export interface DesktopAgentSessionSummary {
+  directory?: string
+  sessionId: string
+  title?: string
+  updatedAt?: string
+  workspaceId?: string
+}
+
+export interface DesktopAgentListSessionsRequest extends DesktopAgentProviderRequest {
+  directory?: string
+  workspaceId?: string
+}
+
+export interface DesktopAgentListSessionsResponse {
+  sessions: DesktopAgentSessionSummary[]
+}
+
+export interface DesktopAgentResumeSessionRequest extends DesktopAgentProviderRequest {
+  sessionId: string
+}
+
+export interface DesktopAgentResumeSessionResponse {
+  sessionId: string
+}
+
+export type DesktopAgentEventType =
+  | 'status'
+  | 'session'
+  | 'message'
+  | 'tool'
+  | 'error'
+
+export interface DesktopAgentEvent {
+  providerId?: string
+  sessionId?: string
+  text?: string
+  type: DesktopAgentEventType
+}

--- a/ecos/gui/packages/shared/src/index.ts
+++ b/ecos/gui/packages/shared/src/index.ts
@@ -51,6 +51,24 @@ export type {
   DesktopShellSession,
   DesktopShellSessionOptions,
 } from './contracts/desktopShell.ts';
+export type {
+  DesktopAgentEvent,
+  DesktopAgentEventType,
+  DesktopAgentListSessionsRequest,
+  DesktopAgentListSessionsResponse,
+  DesktopAgentProviderRequest,
+  DesktopAgentResumeSessionRequest,
+  DesktopAgentResumeSessionResponse,
+  DesktopAgentSendMessageRequest,
+  DesktopAgentSendMessageResponse,
+  DesktopAgentSessionSummary,
+  DesktopAgentSetModeRequest,
+  DesktopAgentStartRequest,
+  DesktopAgentStartSessionRequest,
+  DesktopAgentStartSessionResponse,
+  DesktopAgentStatus,
+  DesktopAgentStatusState,
+} from './contracts/desktopAgent.ts';
 export {
   appMenuActionIds,
   desktopMenuEventIds,


### PR DESCRIPTION
## Summary

- Add shared runtime manager for DesktopRuntimeManager and AgentManager

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [x] `cd ecos/gui && pnpm run build`
- [x] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [x] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [x] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
