### PR TITLE
fix(gui): improve resource manager responsive layout

### DIFF
--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -2,6 +2,50 @@ import { describe, expect, it } from 'vitest'
 import pluginToolsViewSource from './PluginToolsView.vue?raw'
 
 describe('PluginToolsView resource table layout', () => {
+  it('bounds the dialog inside the available app viewport', () => {
+    expect(pluginToolsViewSource).toMatch(
+      /\.manager-dialog\s*\{[\s\S]*height:\s*min\(760px,\s*calc\(100% - var\(--dialog-block-gutter\)\)\);[\s\S]*min-height:\s*min\(560px,\s*calc\(100% - var\(--dialog-block-gutter\)\)\);[\s\S]*overflow:\s*hidden;/,
+    )
+    expect(pluginToolsViewSource).not.toContain('min-height: 620px;')
+    expect(pluginToolsViewSource).not.toContain('overflow: visible;')
+  })
+
+  it('keeps the compact resource manager layout scrollable instead of clipped', () => {
+    expect(pluginToolsViewSource).toMatch(
+      /@media \(max-width: 1240px\)\s*\{[\s\S]*\.manager-grid\s*\{[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;[\s\S]*overflow-y:\s*auto;/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /@media \(max-width: 1240px\)\s*\{[\s\S]*\.manager-table-panel\s*\{[\s\S]*flex:\s*0 0 clamp\(280px,\s*42vh,\s*420px\);/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /@media \(max-width: 1240px\)\s*\{[\s\S]*\.selected-panel\s*\{[\s\S]*min-height:\s*220px;/,
+    )
+  })
+
+  it('keeps compact category navigation as short buttons instead of stretched cards', () => {
+    expect(pluginToolsViewSource).toMatch(
+      /@media \(max-width: 1240px\)\s*\{[\s\S]*\.resource-nav\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /@media \(max-width: 1240px\)\s*\{[\s\S]*\.resource-nav-item\s*\{[\s\S]*width:\s*auto;[\s\S]*min-height:\s*40px;/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /@media \(max-width: 1240px\)\s*\{[\s\S]*\.manager-help\s*\{[\s\S]*grid-template-columns:\s*24px minmax\(0,\s*1fr\) auto;/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /@media \(max-width: 767px\)\s*\{[\s\S]*\.resource-nav\s*\{[\s\S]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);/,
+    )
+  })
+
+  it('lets the selected resources list shrink so footer actions remain visible', () => {
+    expect(pluginToolsViewSource).toMatch(
+      /\.selected-list\s*\{[\s\S]*flex:\s*1 1 0;[\s\S]*min-height:\s*0;/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /\.selected-actions\s*\{[\s\S]*flex:\s*0 0 auto;/,
+    )
+  })
+
   it('keeps the resource table from showing a horizontal scrollbar', () => {
     expect(pluginToolsViewSource).toMatch(
       /\.resource-table-scroll\s*\{[\s\S]*overflow-x:\s*hidden;[\s\S]*overflow-y:\s*auto;/,

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -612,6 +612,8 @@ async function openDocs(): Promise<void> {
   --warn-bg: color-mix(in srgb, var(--warn-color) 14%, transparent);
   --danger-color: #d85d5d;
   --danger-bg: color-mix(in srgb, var(--danger-color) 14%, transparent);
+  --dialog-inline-gutter: clamp(24px, 6vw, 96px);
+  --dialog-block-gutter: clamp(28px, 7vh, 64px);
   position: relative;
   display: flex;
   align-items: center;
@@ -714,12 +716,12 @@ async function openDocs(): Promise<void> {
   z-index: 2;
   display: flex;
   flex-direction: column;
-  width: min(1280px, calc(100% - 96px));
-  max-height: calc(100% - 64px);
-  min-height: 620px;
+  width: min(1280px, calc(100% - var(--dialog-inline-gutter)));
+  height: min(760px, calc(100% - var(--dialog-block-gutter)));
+  min-height: min(560px, calc(100% - var(--dialog-block-gutter)));
   margin: 0 auto;
-  padding: 36px 38px 38px;
-  overflow: auto;
+  padding: clamp(24px, 3.2vh, 36px) clamp(24px, 3vw, 38px) clamp(24px, 3.4vh, 38px);
+  overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--border-color) 92%, transparent);
   border-radius: 16px;
   background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
@@ -751,7 +753,7 @@ async function openDocs(): Promise<void> {
 .manager-header {
   flex: 0 0 auto;
   padding-right: 42px;
-  margin-bottom: 28px;
+  margin-bottom: clamp(18px, 3vh, 28px);
 }
 
 .manager-header h1 {
@@ -771,9 +773,10 @@ async function openDocs(): Promise<void> {
 /* ---- Grid ---- */
 .manager-grid {
   display: grid;
-  grid-template-columns: 200px minmax(0, 1fr) 240px;
+  grid-template-columns: minmax(170px, 200px) minmax(420px, 1fr) minmax(220px, 240px);
   gap: 12px;
   min-height: 0;
+  overflow: hidden;
   flex: 1 1 auto;
 }
 
@@ -895,16 +898,17 @@ async function openDocs(): Promise<void> {
 .manager-table-panel {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   padding: 16px;
   overflow: hidden;
 }
 
 .manager-toolbar {
   display: grid;
-  grid-template-columns: minmax(120px, 160px) auto;
+  grid-template-columns: minmax(120px, 180px) minmax(0, auto);
   align-items: center;
   gap: 12px;
-  margin-bottom: 24px;
+  margin-bottom: clamp(14px, 2.5vh, 24px);
 }
 
 .resource-search {
@@ -942,11 +946,18 @@ async function openDocs(): Promise<void> {
   justify-self: end;
   display: flex;
   align-items: center;
+  max-width: 100%;
   min-height: 36px;
   padding: 3px;
+  overflow-x: auto;
   border: 1px solid var(--border-color);
   border-radius: 999px;
   background: color-mix(in srgb, var(--bg-primary) 80%, transparent);
+  scrollbar-width: none;
+}
+
+.resource-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .resource-tabs button {
@@ -1056,7 +1067,7 @@ async function openDocs(): Promise<void> {
 .resource-table-head,
 .resource-row {
   display: grid;
-  grid-template-columns: 32px minmax(180px, 2fr) 72px 68px 110px 90px;
+  grid-template-columns: 32px minmax(150px, 2fr) minmax(68px, 0.6fr) minmax(58px, 0.5fr) minmax(88px, 0.7fr) minmax(70px, auto);
   align-items: center;
   gap: 0;
 }
@@ -1160,7 +1171,7 @@ async function openDocs(): Promise<void> {
 .resource-copy small {
   display: block;
   overflow: hidden;
-  max-width: 260px;
+  max-width: min(260px, 100%);
   margin-top: 2px;
   color: var(--text-secondary);
   font-size: 11px;
@@ -1464,9 +1475,9 @@ async function openDocs(): Promise<void> {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  flex: 1;
+  flex: 1 1 0;
   overflow: auto;
-  min-height: 160px;
+  min-height: 0;
 }
 
 .selected-empty {
@@ -1611,6 +1622,7 @@ async function openDocs(): Promise<void> {
 .selected-actions {
   display: grid;
   gap: 10px;
+  flex: 0 0 auto;
   margin-top: auto;
 }
 
@@ -1716,37 +1728,66 @@ async function openDocs(): Promise<void> {
 }
 
 /* ---- Responsive ---- */
-@media (max-width: 1120px) {
+@media (max-width: 1240px) {
   .manager-dialog {
-    width: min(980px, calc(100% - 40px));
-    height: auto;
-    min-height: calc(100vh - 96px);
-    margin: 48px auto;
-    overflow: visible;
+    --dialog-inline-gutter: 40px;
+    --dialog-block-gutter: 40px;
+    width: min(980px, calc(100% - var(--dialog-inline-gutter)));
+    height: calc(100% - var(--dialog-block-gutter));
+    min-height: 0;
   }
 
   .manager-grid {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    padding-right: 2px;
   }
 
   .manager-sidebar {
-    flex-direction: row;
-    gap: 16px;
+    flex: 0 0 auto;
+    flex-direction: column;
+    gap: 12px;
   }
 
   .resource-nav {
-    flex: 1;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .resource-nav-item {
+    min-height: 42px;
+    padding: 0 12px;
   }
 
   .manager-help {
-    width: 220px;
-    flex-shrink: 0;
+    width: auto;
+    grid-template-columns: 24px minmax(0, 1fr) auto;
+    align-items: center;
+    padding: 12px 14px;
+  }
+
+  .manager-help p {
+    margin: 2px 0 0;
+  }
+
+  .manager-help button {
+    grid-column: auto;
+    justify-self: end;
+    margin-left: 12px;
+    white-space: nowrap;
+  }
+
+  .manager-table-panel {
+    flex: 0 0 clamp(280px, 42vh, 420px);
+    min-height: 280px;
   }
 
   .selected-panel {
-    max-height: 320px;
+    flex: 0 0 auto;
+    min-height: 220px;
+    max-height: none;
   }
 
   .selected-list {
@@ -1755,11 +1796,15 @@ async function openDocs(): Promise<void> {
 }
 
 @media (max-width: 767px) {
+  .resource-manager-view {
+    --dialog-inline-gutter: 24px;
+    --dialog-block-gutter: 24px;
+  }
+
   .manager-dialog {
     width: calc(100% - 24px);
+    height: calc(100% - var(--dialog-block-gutter));
     padding: 24px 18px;
-    margin: 24px auto;
-    min-height: calc(100vh - 48px);
   }
 
   .manager-sidebar {
@@ -1770,17 +1815,39 @@ async function openDocs(): Promise<void> {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .resource-nav-item {
+    min-height: 40px;
+  }
+
   .manager-help {
     width: auto;
   }
 
   .manager-toolbar {
     grid-template-columns: 1fr;
+    margin-bottom: 16px;
   }
 
   .resource-tabs {
     justify-self: stretch;
-    overflow-x: auto;
+  }
+
+  .manager-table-meta {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .resource-table-head,
+  .resource-row {
+    grid-template-columns: 28px minmax(130px, 1fr) minmax(74px, auto) minmax(68px, auto);
+  }
+
+  .resource-table-head span:nth-child(3),
+  .resource-row > .resource-muted:nth-child(3),
+  .resource-table-head span:nth-child(4),
+  .resource-row > .resource-muted:nth-child(4) {
+    display: none;
   }
 
   .manager-close {


### PR DESCRIPTION
## Summary

Improve the Resource Manager (`PluginToolsView`) responsive layout so the dialog, toolbar, category navigation, and selected-resources panel adapt cleanly on narrower viewports without clipping footer actions or overflowing the app viewport.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## What Changed

- Constrain the manager dialog to the available viewport using responsive gutters and `min()` height rules instead of a fixed `620px` minimum.
- Rework the compact layout breakpoint (`max-width: 1240px`) so the grid stacks vertically with internal scrolling, category nav uses a 2-column button grid, and the table/selected panels keep usable minimum heights.
- Make toolbar tabs horizontally scrollable on overflow, tighten table column sizing, and hide low-priority columns on very narrow screens (`max-width: 767px`).
- Let the selected-resources list shrink (`flex: 1 1 0; min-height: 0`) so footer install/remove actions stay visible.
- Add layout regression tests in `PluginToolsView.layout.test.ts` for the responsive CSS contracts above.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `pnpm --filter @ecos-studio/renderer exec vitest run src/views/PluginToolsView.layout.test.ts`
- [ ] `cd ecos/gui && pnpm run test` — N/A; only renderer layout tests were added/run for this change.
- [ ] `cd ecos/gui && pnpm run build` — not run; CSS-only renderer change with no build pipeline impact expected.
- [ ] `make build` — N/A
- [ ] `make demo-gcd` — N/A
- [ ] `make demo-retrosoc` — N/A
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev` — recommended before merge to visually confirm narrow-width behavior.

Skipped checks and reason:

- Full GUI test suite and production build were not run; change is scoped to responsive CSS and source-level layout regression tests. Residual risk is limited to visual polish at intermediate breakpoints.

## Screenshots or Recordings

Required for visible GUI changes.

- TODO: add before/after screenshots at ~1240px and ~767px widths showing dialog fit, stacked layout, and visible footer actions.

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Renderer-only CSS/layout change; no dependency, packaging, or submodule updates.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed. — N/A; no user-facing copy changed.
- [x] I included lockfile changes for dependency updates. — N/A; no dependency changes.
- [x] I documented intentional submodule updates. — N/A; no submodule changes.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
