### PR TITLE
feat(gui): add checklist gallery table

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/designFilelist.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/designFilelist.ts
@@ -1,0 +1,121 @@
+import { isAbsoluteLocalPath, joinLocalPath, normalizeLocalPath } from '@ecos-studio/shared'
+
+export type FilelistLine =
+  | { kind: 'file'; raw: string; path: string }
+  | { kind: 'other'; raw: string }
+
+const HDL_EXTENSIONS = new Set(['v', 'sv', 'vhd', 'vhdl'])
+
+export function isHdlFilePath(path: string): boolean {
+  const basename = path.split(/[\\/]/).pop() ?? path
+  const extension = basename.includes('.') ? basename.split('.').pop()?.toLowerCase() : ''
+  return Boolean(extension && HDL_EXTENSIONS.has(extension))
+}
+
+export function parseFilelistContent(content: string): FilelistLine[] {
+  const lines: FilelistLine[] = []
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const trimmed = rawLine.trim()
+    if (!trimmed) {
+      lines.push({ kind: 'other', raw: rawLine })
+      continue
+    }
+
+    if (
+      trimmed.startsWith('#')
+      || trimmed.startsWith('//')
+      || trimmed.startsWith('`')
+    ) {
+      lines.push({ kind: 'other', raw: rawLine })
+      continue
+    }
+
+    if (trimmed.startsWith('+incdir+')) {
+      lines.push({ kind: 'other', raw: rawLine })
+      continue
+    }
+
+    if (trimmed.startsWith('+') || trimmed.startsWith('-')) {
+      lines.push({ kind: 'other', raw: rawLine })
+      continue
+    }
+
+    const path = extractPathValue(trimmed)
+    if (!path) {
+      lines.push({ kind: 'other', raw: rawLine })
+      continue
+    }
+
+    lines.push({ kind: 'file', raw: rawLine, path })
+  }
+
+  return lines
+}
+
+export function serializeFilelistLines(lines: FilelistLine[]): string {
+  const serialized = lines.map((line) => line.raw)
+  const trailingNewline = serialized.length > 0 && serialized[serialized.length - 1] !== ''
+    ? '\n'
+    : ''
+  return `${serialized.join('\n')}${trailingNewline}`
+}
+
+export function resolveFilelistPath(entryPath: string, filelistDir: string): string {
+  const trimmed = entryPath.trim()
+  if (isAbsoluteLocalPath(trimmed)) {
+    return normalizeLocalPath(trimmed)
+  }
+  return joinLocalPath(filelistDir, trimmed)
+}
+
+export function formatFilelistEntry(relativePath: string): string {
+  if (/\s/.test(relativePath)) {
+    return `"${relativePath}"`
+  }
+  return relativePath
+}
+
+export function appendFilelistEntry(lines: FilelistLine[], relativePath: string): FilelistLine[] {
+  const entry = formatFilelistEntry(relativePath)
+  const next = [...lines]
+  if (next.length > 0 && next[next.length - 1]?.raw !== '') {
+    next.push({ kind: 'other', raw: '' })
+  }
+  next.push({ kind: 'file', raw: entry, path: relativePath })
+  return next
+}
+
+export function removeFilelistEntry(lines: FilelistLine[], filelistEntry: string): FilelistLine[] {
+  return lines.filter((line) => !(line.kind === 'file' && line.raw === filelistEntry))
+}
+
+function extractPathValue(line: string): string {
+  const withoutComment = stripInlineComment(line).trim()
+  if (!withoutComment) return ''
+
+  const quote = withoutComment[0]
+  if (quote === '"' || quote === '\'') {
+    const closingIndex = withoutComment.indexOf(quote, 1)
+    if (closingIndex > 1) {
+      return withoutComment.slice(1, closingIndex)
+    }
+    return withoutComment.slice(1)
+  }
+
+  return withoutComment.split(/\s+/)[0] ?? ''
+}
+
+function stripInlineComment(line: string): string {
+  const hashIndex = line.indexOf('#')
+  const slashIndex = line.indexOf('//')
+  let cutIndex = -1
+
+  if (hashIndex >= 0) cutIndex = hashIndex
+  if (slashIndex >= 0 && (cutIndex < 0 || slashIndex < cutIndex)) {
+    cutIndex = slashIndex
+  }
+
+  if (cutIndex < 0) return line
+  return line.slice(0, cutIndex)
+}

--- a/ecos/gui/apps/renderer/src/components/ChecklistTable.vue
+++ b/ecos/gui/apps/renderer/src/components/ChecklistTable.vue
@@ -1,0 +1,240 @@
+<template>
+  <div class="checklist-table-root">
+    <div v-if="items.length === 0" class="checklist-empty">
+      <i class="ri-list-check-2"></i>
+      <p>{{ emptyTitle }}</p>
+      <span>{{ emptyHint }}</span>
+    </div>
+
+    <div v-else class="checklist-scroll">
+      <div v-if="showSummary" class="checklist-summary">
+        {{ passedCount }}/{{ items.length }} passed
+      </div>
+      <table class="checklist-table">
+        <thead>
+          <tr>
+            <th>Step</th>
+            <th>Type</th>
+            <th>Item</th>
+            <th>State</th>
+            <th v-if="hasInfo">Info</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="(item, idx) in items"
+            :key="idx"
+            :class="checklistStateClass(item.state)"
+          >
+            <td class="col-step">{{ item.step }}</td>
+            <td class="col-type">{{ item.type }}</td>
+            <td class="col-item">{{ item.item }}</td>
+            <td class="col-state">
+              <span class="state-tag" :class="checklistStateClass(item.state)">
+                <i :class="checklistStateIcon(item.state)" class="state-icon"></i>
+                {{ item.state }}
+              </span>
+            </td>
+            <td v-if="hasInfo" class="col-info">{{ item.info || '—' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ChecklistItem } from '@/composables/useHomeData'
+import {
+  checklistStateClass,
+  checklistStateIcon,
+  isChecklistPassed,
+} from '@/utils/checklistState'
+
+const props = withDefaults(defineProps<{
+  items: ChecklistItem[]
+  showSummary?: boolean
+  emptyTitle?: string
+  emptyHint?: string
+}>(), {
+  showSummary: true,
+  emptyTitle: 'No checklist items',
+  emptyHint: 'Run this step to populate the checklist.',
+})
+
+const hasInfo = computed(() => props.items.some(item => Boolean(item.info?.trim())))
+const passedCount = computed(() => props.items.filter(item => isChecklistPassed(item.state)).length)
+</script>
+
+<style scoped>
+.checklist-table-root {
+  height: 100%;
+  min-height: 0;
+}
+
+.checklist-scroll {
+  height: 100%;
+  overflow: auto;
+}
+
+.checklist-summary {
+  margin-bottom: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.checklist-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 10px;
+}
+
+.checklist-table thead th:nth-child(1) { width: 16%; }
+.checklist-table thead th:nth-child(2) { width: 14%; }
+.checklist-table thead th:nth-child(3) { width: auto; }
+.checklist-table thead th:nth-child(4) { width: 14%; }
+.checklist-table thead th:nth-child(5) { width: 22%; }
+
+.checklist-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-primary);
+  padding: 6px 8px;
+  text-align: left;
+  font-weight: 700;
+  font-size: 9px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--border-color);
+  white-space: nowrap;
+}
+
+.checklist-table tbody td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+.checklist-table tbody tr {
+  transition: background 0.1s ease;
+}
+
+.checklist-table tbody tr:hover {
+  background: rgba(var(--accent-rgb, 59, 130, 246), 0.04);
+}
+
+.col-step {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.col-type,
+.col-item,
+.col-info {
+  color: var(--text-secondary);
+}
+
+.col-info {
+  font-size: 9px;
+}
+
+.state-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  font-size: 9px;
+  font-weight: 600;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.state-icon {
+  font-size: 11px;
+}
+
+.state-tag.state-success {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+}
+
+.state-tag.state-failed {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.state-tag.state-warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+}
+
+.state-tag.state-ongoing {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+}
+
+.state-tag.state-pending {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+}
+
+.state-tag.state-unstart {
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.checklist-empty {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 20px;
+  border: 2px dashed var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  text-align: center;
+}
+
+.checklist-empty i {
+  font-size: 28px;
+  color: var(--text-secondary);
+  opacity: 0.3;
+}
+
+.checklist-empty p {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.checklist-empty span {
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+:deep(.spin) {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+:global(.window-resizing) .checklist-table td {
+  overflow-wrap: normal !important;
+  word-break: keep-all !important;
+}
+</style>

--- a/ecos/gui/apps/renderer/src/components/ThumbnailGallery.vue
+++ b/ecos/gui/apps/renderer/src/components/ThumbnailGallery.vue
@@ -83,6 +83,11 @@
         <div v-else-if="activeTab === InfoEnum.maps" class="w-full">
           <MapsGallery :maps-data="currentTabInfo as Record<string, MapInfoType>" @select="handleMapSelect" />
         </div>
+
+        <!-- Checklist 表格 -->
+        <div v-else-if="activeTab === InfoEnum.checklist" class="w-full h-full min-h-0">
+          <ChecklistTable :items="currentChecklistItems" />
+        </div>
       </div>
 
       <!-- 错误提示 -->
@@ -107,6 +112,8 @@ import { requestProjectPathAccess } from '@/utils/projectFs'
 import { readProjectTextFile } from '@/utils/projectFiles'
 import { convertRemoteToLocalPath } from '@/utils/projectPaths'
 import MapsGallery from './MapsGallery.vue'
+import ChecklistTable from './ChecklistTable.vue'
+import type { ChecklistItem } from '@/composables/useHomeData'
 import type { MapInfo as MapInfoType } from '../types'
 import { clearStepTabCache } from './thumbnailGalleryCache'
 
@@ -187,6 +194,9 @@ function getAnalysisIcon(key: string): string {
 // 存储每个 tab 的 info 数据（值可能是字符串路径或对象）
 const tabInfoCache = ref<Record<string, Record<string, unknown>>>({})
 
+// 存储每个 step 解析后的 checklist 条目
+const checklistItemsCache = ref<Record<string, ChecklistItem[]>>({})
+
 // 存储每个 tab 的错误信息
 const tabErrorCache = ref<Record<string, string | null>>({})
 
@@ -222,6 +232,11 @@ const currentTabInfo = computed(() => {
   if (!currentStep.value) return {}
   const cacheKey = `${currentStep.value}_${activeTab.value}`
   return tabInfoCache.value[cacheKey] || {}
+})
+
+const currentChecklistItems = computed(() => {
+  if (!currentStep.value) return []
+  return checklistItemsCache.value[`${currentStep.value}_checklist_items`] ?? []
 })
 
 // 定义带有 path 和 info 的对象类型
@@ -275,6 +290,49 @@ function convertToLocalPath(remotePath: string): string {
   return convertRemoteToLocalPath(remotePath, currentProject.value?.path ?? '')
 }
 
+function getChecklistPathFromTabInfo(info: Record<string, unknown>): string | null {
+  const path = info.path
+  return typeof path === 'string' && path.length > 0 ? path : null
+}
+
+async function loadChecklistItems(force = false): Promise<void> {
+  if (!currentStep.value) return
+
+  const itemsCacheKey = `${currentStep.value}_checklist_items`
+  if (!force && itemsCacheKey in checklistItemsCache.value) return
+
+  const tabCacheKey = `${currentStep.value}_${InfoEnum.checklist}`
+  const checklistPath = getChecklistPathFromTabInfo(tabInfoCache.value[tabCacheKey] ?? {})
+  if (!checklistPath) {
+    checklistItemsCache.value[itemsCacheKey] = []
+    return
+  }
+
+  if (!isDesktopRuntimeAvailable) {
+    checklistItemsCache.value[itemsCacheKey] = []
+    setTabError('Checklist is readable only in the ECOS Studio desktop runtime')
+    return
+  }
+
+  try {
+    const localPath = convertToLocalPath(checklistPath)
+    if (!(await requestProjectPathAccess(localPath))) {
+      checklistItemsCache.value[itemsCacheKey] = []
+      setTabError('No file-system access in current workspace scope')
+      return
+    }
+
+    const fileContent = await readProjectTextFile(localPath)
+    const data = JSON.parse(fileContent) as { checklist?: ChecklistItem[] }
+    checklistItemsCache.value[itemsCacheKey] = Array.isArray(data.checklist) ? data.checklist : []
+    setTabError(null)
+  } catch (err) {
+    console.error('loadChecklistItems error:', err)
+    checklistItemsCache.value[itemsCacheKey] = []
+    setTabError(err instanceof Error ? err.message : 'Failed to load checklist')
+  }
+}
+
 // 获取 Tab 数据
 async function fetchTabInfo(tabId: InfoEnum) {
   if (!currentStep.value) return
@@ -282,7 +340,12 @@ async function fetchTabInfo(tabId: InfoEnum) {
   const cacheKey = `${currentStep.value}_${tabId}`
 
   // 如果已有缓存，不重新请求
-  if (tabInfoCache.value[cacheKey]) return
+  if (tabInfoCache.value[cacheKey]) {
+    if (tabId === InfoEnum.checklist) {
+      await loadChecklistItems()
+    }
+    return
+  }
 
   isLoadingTab.value = true
   setTabError(null)
@@ -303,6 +366,10 @@ async function fetchTabInfo(tabId: InfoEnum) {
     const infoObj = response.info
     if (infoObj && typeof infoObj === 'object') {
       tabInfoCache.value[cacheKey] = infoObj as Record<string, unknown>
+    }
+
+    if (tabId === InfoEnum.checklist) {
+      await loadChecklistItems(true)
     }
   } catch (err) {
     console.error('fetchTabInfo error:', err)
@@ -434,6 +501,7 @@ watch(currentStep, async (newStep) => {
     // 清除缓存
     tabInfoCache.value = {}
     tabErrorCache.value = {}
+    checklistItemsCache.value = {}
     // 获取当前 tab 的数据
     await fetchTabInfo(activeTab.value)
   }
@@ -448,7 +516,12 @@ watch(
   ],
   async () => {
     if (!currentStep.value) return
-    clearStepTabCache(tabInfoCache.value, tabErrorCache.value, currentStep.value)
+    clearStepTabCache(
+      tabInfoCache.value,
+      tabErrorCache.value,
+      currentStep.value,
+      checklistItemsCache.value,
+    )
     await fetchTabInfo(activeTab.value)
   },
 )

--- a/ecos/gui/apps/renderer/src/components/thumbnailGalleryCache.test.ts
+++ b/ecos/gui/apps/renderer/src/components/thumbnailGalleryCache.test.ts
@@ -14,14 +14,21 @@ describe('thumbnailGalleryCache', () => {
       Floorplan_sta: 'old sta error',
       place_maps: 'keep me',
     }
+    const checklistItemsCache = {
+      Floorplan_checklist_items: [{ step: 'route', type: 'Route', item: 'x', state: 'Passed' }],
+      place_checklist_items: [{ step: 'place', type: 'Density', item: 'y', state: 'Passed' }],
+    }
 
-    clearStepTabCache(tabInfoCache, tabErrorCache, 'Floorplan')
+    clearStepTabCache(tabInfoCache, tabErrorCache, 'Floorplan', checklistItemsCache)
 
     expect(tabInfoCache).toEqual({
       place_maps: { density: 'other-step' },
     })
     expect(tabErrorCache).toEqual({
       place_maps: 'keep me',
+    })
+    expect(checklistItemsCache).toEqual({
+      place_checklist_items: [{ step: 'place', type: 'Density', item: 'y', state: 'Passed' }],
     })
   })
 

--- a/ecos/gui/apps/renderer/src/components/thumbnailGalleryCache.ts
+++ b/ecos/gui/apps/renderer/src/components/thumbnailGalleryCache.ts
@@ -2,6 +2,7 @@ export function clearStepTabCache(
   tabInfoCache: Record<string, Record<string, unknown>>,
   tabErrorCache: Record<string, string | null>,
   step: string | undefined,
+  checklistItemsCache?: Record<string, unknown[]>,
 ): void {
   if (!step) return
 
@@ -11,5 +12,11 @@ export function clearStepTabCache(
 
   for (const key of Object.keys(tabErrorCache).filter(k => k.startsWith(`${step}_`))) {
     delete tabErrorCache[key]
+  }
+
+  if (checklistItemsCache) {
+    for (const key of Object.keys(checklistItemsCache).filter(k => k.startsWith(`${step}_`))) {
+      delete checklistItemsCache[key]
+    }
   }
 }

--- a/ecos/gui/apps/renderer/src/composables/useHomeData.ts
+++ b/ecos/gui/apps/renderer/src/composables/useHomeData.ts
@@ -54,6 +54,7 @@ export interface ChecklistItem {
   type: string
   item: string
   state: string
+  info?: string
 }
 
 /** checklist.json 数据结构 */

--- a/ecos/gui/apps/renderer/src/utils/checklistState.test.ts
+++ b/ecos/gui/apps/renderer/src/utils/checklistState.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  checklistStateClass,
+  checklistStateIcon,
+  isChecklistPassed,
+  normalizeChecklistState,
+} from './checklistState'
+
+describe('checklistState', () => {
+  it('maps new and legacy states to visual kinds', () => {
+    expect(normalizeChecklistState('Passed')).toBe('success')
+    expect(normalizeChecklistState('Success')).toBe('success')
+    expect(normalizeChecklistState('Failed')).toBe('failed')
+    expect(normalizeChecklistState('Warning')).toBe('warning')
+    expect(normalizeChecklistState('Unstart')).toBe('unstart')
+  })
+
+  it('treats passed-like states as completed', () => {
+    expect(isChecklistPassed('Passed')).toBe(true)
+    expect(isChecklistPassed('Success')).toBe(true)
+    expect(isChecklistPassed('Failed')).toBe(false)
+  })
+
+  it('returns css class and icon helpers', () => {
+    expect(checklistStateClass('Passed')).toBe('state-success')
+    expect(checklistStateIcon('Failed')).toBe('ri-close-circle-fill')
+  })
+})

--- a/ecos/gui/apps/renderer/src/utils/checklistState.ts
+++ b/ecos/gui/apps/renderer/src/utils/checklistState.ts
@@ -1,0 +1,48 @@
+export type ChecklistStateKind = 'success' | 'failed' | 'warning' | 'ongoing' | 'pending' | 'unstart'
+
+export function normalizeChecklistState(state: string): ChecklistStateKind {
+  switch (state) {
+    case 'Passed':
+    case 'Success':
+    case 'Accepted':
+      return 'success'
+    case 'Failed':
+    case 'Imcomplete':
+      return 'failed'
+    case 'Warning':
+      return 'warning'
+    case 'Ongoing':
+      return 'ongoing'
+    case 'Pending':
+      return 'pending'
+    case 'Unstart':
+      return 'unstart'
+    default:
+      return 'unstart'
+  }
+}
+
+export function checklistStateClass(state: string): string {
+  return `state-${normalizeChecklistState(state)}`
+}
+
+export function checklistStateIcon(state: string): string {
+  switch (normalizeChecklistState(state)) {
+    case 'success':
+      return 'ri-checkbox-circle-fill'
+    case 'failed':
+      return 'ri-close-circle-fill'
+    case 'warning':
+      return 'ri-error-warning-fill'
+    case 'ongoing':
+      return 'ri-loader-4-line spin'
+    case 'pending':
+      return 'ri-time-line'
+    default:
+      return 'ri-checkbox-blank-circle-line'
+  }
+}
+
+export function isChecklistPassed(state: string): boolean {
+  return normalizeChecklistState(state) === 'success'
+}

--- a/ecos/gui/apps/renderer/src/views/HomeView.vue
+++ b/ecos/gui/apps/renderer/src/views/HomeView.vue
@@ -296,43 +296,11 @@
           <span class="header-count">{{ checklistCompletedCount }}/{{ checklistItems.length }}</span>
         </div>
         <div class="checklist-content">
-          <!-- Table format -->
-          <div class="checklist-table-wrap" v-if="checklistItems.length > 0">
-            <table class="checklist-table">
-              <thead>
-                <tr>
-                  <th>Step/Stage</th>
-                  <th>Validation Type</th>
-                  <th>Acceptance Criteria</th>
-                  <th>Acceptance Result</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="(item, idx) in checklistItems" :key="idx" :class="stateClass(item.state)">
-                  <td>
-                    <div class="table-step-name">
-                      <i class="ri-checkbox-blank-circle-line table-step-icon"></i>
-                      {{ item.step }}
-                    </div>
-                  </td>
-                  <td class="table-tool">{{ item.type }}</td>
-                  <td class="table-criteria">{{ item.item }}</td>
-                  <td>
-                    <span class="table-state-tag" :class="stateClass(item.state)">
-                      <i :class="stateIcon(item.state)" class="table-state-icon"></i>
-                      {{ item.state }}
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <!-- Empty state -->
-          <div class="checklist-placeholder" v-else>
-            <i class="ri-list-check-2"></i>
-            <p>No checklist items</p>
-            <span>After running the flow, the checklist will be displayed.</span>
-          </div>
+          <ChecklistTable
+            :items="checklistItems"
+            :show-summary="false"
+            empty-hint="After running the flow, the checklist will be displayed."
+          />
         </div>
       </section>
           </SplitterPanel>
@@ -555,8 +523,10 @@ import Splitter from 'primevue/splitter'
 import SplitterPanel from 'primevue/splitterpanel'
 import FlowLogCodeViewer from '@/components/FlowLogCodeViewer.vue'
 import FlowLogStepChooser from '@/components/FlowLogStepChooser.vue'
+import ChecklistTable from '@/components/ChecklistTable.vue'
 import { useParameters } from '@/composables/useParameters'
 import { useHomeData, type AnalysisChartItem, type FlowLogSegment } from '@/composables/useHomeData'
+import { isChecklistPassed } from '@/utils/checklistState'
 import { isWindowResizing } from '@/composables/useWindowResizeState'
 import {
   flowLogStepKey,
@@ -751,7 +721,7 @@ watch(
 
 // checklist 完成计数
 const checklistCompletedCount = computed(() =>
-  checklistItems.value.filter(c => c.state === 'Success').length
+  checklistItems.value.filter(item => isChecklistPassed(item.state)).length
 )
 
 // ============ Layout 全屏 & 缩放平移 ============
@@ -1285,42 +1255,6 @@ function onAnalysisChartClick(chart: AnalysisChartItem) {
 
 function closeChartPreview() {
   chartPreview.value.visible = false
-}
-
-// ============ 辅助函数 ============
-
-/** 根据步骤状态返回图标类名 */
-function stateIcon(state: string): string {
-  switch (state) {
-    case 'Success':
-      return 'ri-checkbox-circle-fill'
-    case 'Ongoing':
-      return 'ri-loader-4-line spin'
-    case 'Imcomplete':
-      return 'ri-close-circle-fill'
-    case 'Pending':
-      return 'ri-time-line'
-    case 'Unstart':
-    default:
-      return 'ri-checkbox-blank-circle-line'
-  }
-}
-
-/** 根据步骤状态返回 CSS 类名 */
-function stateClass(state: string): string {
-  switch (state) {
-    case 'Success':
-      return 'state-success'
-    case 'Ongoing':
-      return 'state-ongoing'
-    case 'Imcomplete':
-      return 'state-failed'
-    case 'Pending':
-      return 'state-pending'
-    case 'Unstart':
-    default:
-      return 'state-unstart'
-  }
 }
 
 </script>
@@ -2429,162 +2363,7 @@ html.dark .chart-card:hover {
   flex: 1;
   padding: 8px;
   overflow: auto;
-}
-
-.checklist-table-wrap {
-  height: 100%;
-  overflow: auto;
-  /*
-   * 隔离表格内部重排：窗口宽度变化时 section-card 已经 contain: layout，
-   * 再给滚动容器加一层 contain 能阻止表格列宽重算反向影响卡片自身。
-   */
   contain: content;
-}
-
-.checklist-table {
-  width: 100%;
-  /*
-   * table-layout: fixed —— 列宽仅按首行 <th> 的声明分配，不再逐格测量
-   * 内容。默认的 auto 布局在窗口缩放时会对所有行单元格做 min/max-content
-   * 计算，行数越多越慢。这里配合下面的 th 宽度声明直接锁死列比例。
-   */
-  table-layout: fixed;
-  border-collapse: separate;
-  border-spacing: 0;
-  font-size: 10px;
-}
-
-.checklist-table thead th:nth-child(1) { width: 22%; }
-.checklist-table thead th:nth-child(2) { width: 18%; }
-.checklist-table thead th:nth-child(3) { width: auto; }
-.checklist-table thead th:nth-child(4) { width: 16%; }
-
-.checklist-table td {
-  /* fixed 布局下超长单元格不会再撑开列宽，统一允许在词内换行避免溢出 */
-  overflow-wrap: anywhere;
-}
-
-.checklist-table thead th {
-  position: sticky;
-  top: 0;
-  background: var(--bg-sidebar);
-  padding: 6px 8px;
-  text-align: left;
-  font-weight: 700;
-  font-size: 9px;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  border-bottom: 1px solid var(--border-color);
-  white-space: nowrap;
-}
-
-.checklist-table tbody td {
-  padding: 5px 8px;
-  border-bottom: 1px solid var(--border-color);
-  color: var(--text-primary);
-  vertical-align: middle;
-}
-
-.checklist-table tbody tr {
-  transition: background 0.1s ease;
-}
-
-.checklist-table tbody tr:hover {
-  background: rgba(var(--accent-rgb, 59, 130, 246), 0.04);
-}
-
-.table-step-name {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.table-step-icon {
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
-.table-tool,
-.table-criteria {
-  color: var(--text-secondary);
-  font-size: 10px;
-}
-
-.table-state-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 6px;
-  font-size: 9px;
-  font-weight: 600;
-  border-radius: 3px;
-  white-space: nowrap;
-}
-
-.table-state-icon {
-  font-size: 11px;
-}
-
-.table-state-tag.state-success {
-  background: rgba(16, 185, 129, 0.15);
-  color: #10b981;
-}
-
-.table-state-tag.state-ongoing {
-  background: rgba(59, 130, 246, 0.15);
-  color: #3b82f6;
-}
-
-.table-state-tag.state-failed {
-  background: rgba(239, 68, 68, 0.15);
-  color: #ef4444;
-}
-
-.table-state-tag.state-pending {
-  background: rgba(245, 158, 11, 0.15);
-  color: #f59e0b;
-}
-
-.table-state-tag.state-unstart {
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  opacity: 0.6;
-}
-
-/* Empty state */
-.checklist-placeholder {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 20px;
-  border: 2px dashed var(--border-color);
-  border-radius: 8px;
-  background: var(--bg-primary);
-}
-
-.checklist-placeholder i {
-  font-size: 28px;
-  color: var(--text-secondary);
-  opacity: 0.3;
-}
-
-.checklist-placeholder p {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  margin: 0;
-}
-
-.checklist-placeholder span {
-  font-size: 10px;
-  color: var(--text-secondary);
-  opacity: 0.6;
 }
 
 /* ==================== 通用动画 ==================== */
@@ -2600,14 +2379,6 @@ html.dark .chart-card:hover {
 
 .spin {
   animation: spin 1s linear infinite;
-}
-
-/* Checklist 单元格内容在 resize 期间切回 normal（非 anywhere）——
- * anywhere 允许的 "任意位置断词" 需要测量每一个字符，缩放帧上代价偏高。
- */
-.window-resizing .checklist-table td {
-  overflow-wrap: normal !important;
-  word-break: keep-all !important;
 }
 
 /* ==================== 响应式 ==================== */

--- a/ecos/gui/packages/shared/src/types/designFiles.ts
+++ b/ecos/gui/packages/shared/src/types/designFiles.ts
@@ -1,0 +1,19 @@
+export interface WorkspaceDesignFileEntry {
+  /** Path as written in the workspace filelist. */
+  filelistEntry: string
+  basename: string
+  resolvedPath: string
+  exists: boolean
+  /** True when the RTL file lives under workspace/origin/. */
+  managedInWorkspace: boolean
+}
+
+export interface WorkspaceDesignFileSkip {
+  path: string
+  reason: string
+}
+
+export interface WorkspaceDesignFileAddResult {
+  added: WorkspaceDesignFileEntry[]
+  skipped: WorkspaceDesignFileSkip[]
+}


### PR DESCRIPTION
## Summary

- Add a reusable checklist table for GUI checklist results.
- Render checklist data in `ThumbnailGallery` and reuse the same table in `HomeView`.
- Add checklist state normalization helpers and focused tests.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## What Changed

- Introduced `ChecklistTable.vue` for shared checklist rendering, empty states, status styling, and optional summary display.
- Added checklist loading support to `ThumbnailGallery`, including per-step cache invalidation.
- Moved checklist state mapping into `checklistState.ts` and updated completion counting to support both legacy and new states.
- Added filelist/design-file helper types and service utilities for future workspace design file handling.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other:
  - `cd ecos/gui && pnpm --filter @ecos-studio/renderer exec vitest run src/components/thumbnailGalleryCache.test.ts src/utils/checklistState.test.ts`
  - `cd ecos/gui && pnpm --filter @ecos-studio/renderer run typecheck`
  - `cd ecos/gui && pnpm --filter @ecos-studio/desktop-electron run typecheck`
  - `git diff --check`

Skipped checks and reason:

- Full GUI test suite, production build, and manual GUI smoke were not run; validation was limited to the renderer tests and package typechecks that cover this scoped change.
- `make build`, `make demo-gcd`, and `make demo-retrosoc` are N/A because this PR does not change release packaging or ECC demo flows.

## Screenshots or Recordings

Required for visible GUI changes.

<img width="1800" height="1200" alt="image" src="https://github.com/user-attachments/assets/64da5be3-239e-4046-9509-4ed437da45e8" />

<img width="1800" height="1200" alt="image" src="https://github.com/user-attachments/assets/9323c184-2f00-4a8d-803a-6cb04ccbc117" />


## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- No dependency or lockfile changes.
- No submodule gitlink changes are included in commit `8be7b50`.
- Local working tree still shows modified content inside `ecc`, but it is not part of this PR commit.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.