### PR TITLE
feat(layout-viewer): add object visibility controls

### DIFF
--- a/ecos/layout-viewer/apps/layout-viewer-native/src/main.rs
+++ b/ecos/layout-viewer/apps/layout-viewer-native/src/main.rs
@@ -117,6 +117,31 @@ struct LoadedViewerState {
     background_load: BackgroundLoadHandle,
 }
 
+#[cfg(any(debug_assertions, test))]
+#[derive(Debug, Clone, Copy)]
+struct DebugPanelSnapshot {
+    scale_units_per_pixel: Option<f32>,
+    render_source: Option<RenderPlanSource>,
+    render_revision: u64,
+    interaction_active: bool,
+    interaction_coarse: bool,
+    plan_reused: bool,
+    plan_batches: usize,
+    plan_items: usize,
+    plan_truncated: bool,
+    candidates_checked: usize,
+    total_shapes: usize,
+    hierarchy_candidates_checked: usize,
+    total_hierarchy_instances: usize,
+    display_cache_hits: usize,
+    display_cache_misses: usize,
+    plane_cache_hits: usize,
+    plane_cache_misses: usize,
+    used_plane_renderer: bool,
+    paint_ops: usize,
+    lod_stats: LodStats,
+}
+
 #[derive(Debug, Default)]
 struct LayerCountsCache {
     revision: Option<u64>,
@@ -582,10 +607,33 @@ fn is_top_cell_view(db: &layoutdb::LayoutDb, cell_view: &CellViewState) -> bool 
 }
 
 fn is_layers_panel_layer(layer: &layout_display::DisplayLayer) -> bool {
-    !matches!(
+    matches!(
         layer.source,
-        layout_display::SourceSelector::ShapeKind(ShapeKind::Die | ShapeKind::Core)
+        layout_display::SourceSelector::PhysicalLayer(_)
     )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ObjectVisibilityRow {
+    label: &'static str,
+    kind: ShapeKind,
+}
+
+fn object_visibility_rows() -> [ObjectVisibilityRow; 3] {
+    [
+        ObjectVisibilityRow {
+            label: "Instances",
+            kind: ShapeKind::Instance,
+        },
+        ObjectVisibilityRow {
+            label: "PDN",
+            kind: ShapeKind::SpecialWire,
+        },
+        ObjectVisibilityRow {
+            label: "Net",
+            kind: ShapeKind::RegularWire,
+        },
+    ]
 }
 
 fn die_core_boundaries(db: &layoutdb::LayoutDb) -> (Option<Rect>, Option<Rect>) {
@@ -828,6 +876,110 @@ fn layer_swatch_rect(slot: egui::Rect, swatch_size: egui::Vec2) -> egui::Rect {
     egui::Rect::from_center_size(slot.center(), swatch_size)
 }
 
+#[cfg(any(debug_assertions, test))]
+fn debug_panel_rows(snapshot: DebugPanelSnapshot) -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "Scale",
+            snapshot
+                .scale_units_per_pixel
+                .map(|scale| format!("{scale:.3} units/px"))
+                .unwrap_or_else(|| "n/a".to_string()),
+        ),
+        (
+            "LOD Source",
+            snapshot
+                .render_source
+                .map(|source| format!("{source:?}"))
+                .unwrap_or_else(|| "none".to_string()),
+        ),
+        (
+            "Interaction",
+            if snapshot.interaction_active {
+                "active".to_string()
+            } else {
+                "idle".to_string()
+            },
+        ),
+        (
+            "Coarse LOD",
+            yes_no(snapshot.interaction_coarse).to_string(),
+        ),
+        ("Plan Reused", yes_no(snapshot.plan_reused).to_string()),
+        ("Revision", snapshot.render_revision.to_string()),
+        (
+            "Plan",
+            format!(
+                "{} batches / {} items",
+                snapshot.plan_batches, snapshot.plan_items
+            ),
+        ),
+        ("Truncated", yes_no(snapshot.plan_truncated).to_string()),
+        (
+            "Query",
+            format!(
+                "{}/{} shapes",
+                snapshot.candidates_checked, snapshot.total_shapes
+            ),
+        ),
+        (
+            "Hierarchy Query",
+            format!(
+                "{}/{} instances",
+                snapshot.hierarchy_candidates_checked, snapshot.total_hierarchy_instances
+            ),
+        ),
+        (
+            "Display Cache",
+            format!(
+                "{} hits / {} misses",
+                snapshot.display_cache_hits, snapshot.display_cache_misses
+            ),
+        ),
+        (
+            "Plane Cache",
+            format!(
+                "{} hits / {} misses",
+                snapshot.plane_cache_hits, snapshot.plane_cache_misses
+            ),
+        ),
+        (
+            "Renderer",
+            if snapshot.used_plane_renderer {
+                "raster plane".to_string()
+            } else {
+                "egui vectors".to_string()
+            },
+        ),
+        ("Paint Ops", snapshot.paint_ops.to_string()),
+        ("LOD Exact", snapshot.lod_stats.exact.to_string()),
+        ("LOD Frame", snapshot.lod_stats.frame_only.to_string()),
+        ("LOD Marker", snapshot.lod_stats.marker.to_string()),
+        (
+            "LOD Hierarchy BBox",
+            snapshot.lod_stats.hierarchy_bbox.to_string(),
+        ),
+        ("LOD Array BBox", snapshot.lod_stats.array_bbox.to_string()),
+        ("LOD Array Grid", snapshot.lod_stats.array_grid.to_string()),
+        ("LOD Coarse", snapshot.lod_stats.coarse.to_string()),
+        ("LOD Suppress", snapshot.lod_stats.suppress.to_string()),
+    ]
+}
+
+#[cfg(any(debug_assertions, test))]
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+#[cfg(any(debug_assertions, test))]
+fn should_show_debug_panel() -> bool {
+    cfg!(debug_assertions)
+}
+
 #[cfg(test)]
 fn sidebar_title_text() -> Option<&'static str> {
     None
@@ -849,6 +1001,15 @@ fn draw_layer_visibility_row(
         ui.checkbox(visible, label)
     })
     .inner
+}
+
+fn object_visibility_color(kind: ShapeKind) -> Color {
+    match kind {
+        ShapeKind::Instance => Color::rgb(176, 155, 255),
+        ShapeKind::SpecialWire => Color::rgb(255, 214, 118),
+        ShapeKind::RegularWire => Color::rgb(160, 218, 255),
+        _ => Color::rgb(132, 146, 156),
+    }
 }
 
 fn focus_view_on_cell_bbox(
@@ -1383,6 +1544,13 @@ impl LayoutViewerV2App {
                         if let Some(mut loaded) = self.loaded.take() {
                             self.draw_layers_panel(ui, &mut loaded);
                             ui.separator();
+                            self.draw_objects_panel(ui, &mut loaded);
+                            #[cfg(debug_assertions)]
+                            if should_show_debug_panel() {
+                                ui.separator();
+                                self.draw_debug_panel(ui);
+                            }
+                            ui.separator();
                             ui.label("Selection");
                             if let Some(hit) = self.selected.clone() {
                                 egui::Grid::new("selection-inspector-grid")
@@ -1415,6 +1583,52 @@ impl LayoutViewerV2App {
             });
     }
 
+    #[cfg(debug_assertions)]
+    fn debug_panel_snapshot(&self) -> DebugPanelSnapshot {
+        DebugPanelSnapshot {
+            scale_units_per_pixel: self.view.as_ref().map(|view| view.units_per_pixel),
+            render_source: self.last_render_plan.as_ref().map(|plan| plan.source),
+            render_revision: self.last_render_plan_revision,
+            interaction_active: self.interaction_active(),
+            interaction_coarse: self.last_render_plan_interaction_coarse,
+            plan_reused: self.last_plan_reused,
+            plan_batches: self.last_plan_batches,
+            plan_items: self.last_plan_items,
+            plan_truncated: self.last_plan_truncated,
+            candidates_checked: self.last_candidates_checked,
+            total_shapes: self.last_total_shapes,
+            hierarchy_candidates_checked: self.last_hierarchy_candidates_checked,
+            total_hierarchy_instances: self.last_total_hierarchy_instances,
+            display_cache_hits: self.last_display_cache_hits,
+            display_cache_misses: self.last_display_cache_misses,
+            plane_cache_hits: self.last_plane_cache_hits,
+            plane_cache_misses: self.last_plane_cache_misses,
+            used_plane_renderer: self.last_used_plane_renderer,
+            paint_ops: self.last_paint_ops,
+            lod_stats: self.last_lod_stats,
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    fn draw_debug_panel(&self, ui: &mut egui::Ui) {
+        ui.label("Debug");
+        egui::Grid::new("debug-inspector-grid")
+            .num_columns(2)
+            .striped(true)
+            .show(ui, |ui| {
+                for (label, value) in debug_panel_rows(self.debug_panel_snapshot()) {
+                    ui.label(label);
+                    let value_width =
+                        (ui.available_width() - ui.spacing().item_spacing.x).max(80.0);
+                    ui.add_sized(
+                        egui::vec2(value_width, 0.0),
+                        egui::Label::new(egui::RichText::new(value).monospace()).wrap(),
+                    );
+                    ui.end_row();
+                }
+            });
+    }
+
     fn draw_layers_panel(&mut self, ui: &mut egui::Ui, loaded: &mut LoadedViewerState) {
         ui.label("Layers");
         let layer_counts = self
@@ -1444,6 +1658,25 @@ impl LayoutViewerV2App {
                     );
                 }
             });
+    }
+
+    fn draw_objects_panel(&mut self, ui: &mut egui::Ui, loaded: &mut LoadedViewerState) {
+        ui.label("Objects");
+        let visibility = loaded.display.object_visibility_mut();
+        for row in object_visibility_rows() {
+            let visible = match row.kind {
+                ShapeKind::Instance => &mut visibility.instances,
+                ShapeKind::SpecialWire => &mut visibility.pdn,
+                ShapeKind::RegularWire => &mut visibility.net,
+                _ => unreachable!("object visibility row uses supported kinds"),
+            };
+            draw_layer_visibility_row(
+                ui,
+                visible,
+                row.label.to_string(),
+                object_visibility_color(row.kind),
+            );
+        }
     }
 
     fn clear_render_history(&mut self) {
@@ -2214,15 +2447,15 @@ mod tests {
         overview_error_is_unavailable, plan_source_for_units_per_pixel, plane_cache_world_rect,
         scroll_zoom_factor, selection_inspector_rows, should_check_overview_density,
         should_request_detail_tiles, should_request_smooth_repaint, should_reuse_render_plan,
-        should_sample_layout_fps, use_plane_renderer, viewport_for_world_rect,
-        Args, AsyncLoadState, CachedPlaneTextureAction, FillDrawMode, FrameRateState,
-        LayoutViewerV2App, LoadRequest, LodTuningState,
+        should_sample_layout_fps, use_plane_renderer, viewport_for_world_rect, Args,
+        AsyncLoadState, CachedPlaneTextureAction, FillDrawMode, FrameRateState, LayoutViewerV2App,
+        LoadRequest, LodTuningState,
     };
     use crate::plane_cache::PlaneKey;
     use layout_display::{Color, DisplayLayer, DisplayModel, LayerStyle, Pattern};
     use layout_render::{
-        DrawBatch, DrawItem, DrawRect, LodHysteresisState, PickHit, PickHitTarget, RenderPlan,
-        RenderPlanSource, RenderPlane, RenderSettings,
+        DrawBatch, DrawItem, DrawRect, LodHysteresisState, LodStats, PickHit, PickHitTarget,
+        RenderPlan, RenderPlanSource, RenderPlane, RenderSettings,
     };
     use layoutdb::{
         CellViewState, HierarchyPolicy, InstancePath, InstancePathElement, LayerInfo, LayoutDb,
@@ -2969,17 +3202,134 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_layers_panel_accepts_only_physical_layers() {
+        let physical = DisplayLayer::physical_layer(1, "M1", LayerStyle::default_for_index(0));
+        let instance = DisplayLayer::shape_kind(
+            ShapeKind::Instance,
+            "Instances",
+            LayerStyle::default_for_index(1),
+        );
+        let net = DisplayLayer::shape_kind(
+            ShapeKind::RegularWire,
+            "Net",
+            LayerStyle::default_for_index(2),
+        );
+
+        assert!(super::is_layers_panel_layer(&physical));
+        assert!(!super::is_layers_panel_layer(&instance));
+        assert!(!super::is_layers_panel_layer(&net));
+    }
+
+    #[test]
+    fn sidebar_objects_panel_lists_instances_pdn_and_net() {
+        let rows = super::object_visibility_rows();
+
+        assert_eq!(
+            rows.iter().map(|row| row.label).collect::<Vec<_>>(),
+            vec!["Instances", "PDN", "Net"]
+        );
+        assert_eq!(
+            rows.iter().map(|row| row.kind).collect::<Vec<_>>(),
+            vec![
+                ShapeKind::Instance,
+                ShapeKind::SpecialWire,
+                ShapeKind::RegularWire,
+            ]
+        );
+    }
+
+    #[test]
+    fn debug_panel_rows_include_scale_and_lod_source() {
+        let rows = super::debug_panel_rows(super::DebugPanelSnapshot {
+            scale_units_per_pixel: Some(12.5),
+            render_source: Some(RenderPlanSource::HierarchyMid),
+            render_revision: 7,
+            interaction_active: true,
+            interaction_coarse: true,
+            plan_reused: false,
+            plan_batches: 3,
+            plan_items: 42,
+            plan_truncated: false,
+            candidates_checked: 9,
+            total_shapes: 100,
+            hierarchy_candidates_checked: 2,
+            total_hierarchy_instances: 6,
+            display_cache_hits: 4,
+            display_cache_misses: 1,
+            plane_cache_hits: 5,
+            plane_cache_misses: 0,
+            used_plane_renderer: true,
+            paint_ops: 123,
+            lod_stats: LodStats {
+                exact: 1,
+                frame_only: 2,
+                marker: 3,
+                hierarchy_bbox: 4,
+                array_bbox: 5,
+                array_grid: 6,
+                coarse: 7,
+                suppress: 8,
+            },
+        });
+
+        assert!(rows.contains(&("Scale", "12.500 units/px".to_string())));
+        assert!(rows.contains(&("LOD Source", "HierarchyMid".to_string())));
+        assert!(rows.contains(&("Coarse LOD", "yes".to_string())));
+        assert!(rows.contains(&("LOD Exact", "1".to_string())));
+        assert!(rows.contains(&("LOD Suppress", "8".to_string())));
+    }
+
+    #[test]
+    fn debug_panel_rows_keep_values_compact_for_sidebar_width() {
+        let rows = super::debug_panel_rows(super::DebugPanelSnapshot {
+            scale_units_per_pixel: Some(85.232),
+            render_source: Some(RenderPlanSource::HierarchyNear),
+            render_revision: 0,
+            interaction_active: false,
+            interaction_coarse: false,
+            plan_reused: true,
+            plan_batches: 4,
+            plan_items: 6799,
+            plan_truncated: false,
+            candidates_checked: 2,
+            total_shapes: 2,
+            hierarchy_candidates_checked: 607,
+            total_hierarchy_instances: 775,
+            display_cache_hits: 0,
+            display_cache_misses: 0,
+            plane_cache_hits: 1,
+            plane_cache_misses: 0,
+            used_plane_renderer: true,
+            paint_ops: 7577,
+            lod_stats: LodStats {
+                exact: 0,
+                frame_only: 389,
+                marker: 6410,
+                hierarchy_bbox: 0,
+                array_bbox: 0,
+                array_grid: 0,
+                coarse: 0,
+                suppress: 0,
+            },
+        });
+
+        assert!(
+            rows.iter().all(|(_label, value)| value.len() <= 32),
+            "debug values should stay compact enough for the default sidebar: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn debug_panel_is_visible_only_in_debug_builds() {
+        assert_eq!(super::should_show_debug_panel(), cfg!(debug_assertions));
+    }
+
+    #[test]
     fn sidebar_does_not_render_hierarchy_module() {
         let source = include_str!("main.rs");
 
         assert!(!source.contains(&["self.", "draw_", "hierarchy_panel"].concat()));
-        assert!(!source.contains(&[
-            "CollapsingHeader::new(",
-            "\"Hier",
-            "archy\"",
-            ")",
-        ]
-        .concat()));
+        assert!(!source.contains(&["CollapsingHeader::new(", "\"Hier", "archy\"", ")",].concat()));
     }
 
     #[test]
@@ -3724,5 +4074,4 @@ mod tests {
             target,
         }
     }
-
 }

--- a/ecos/layout-viewer/apps/layout-viewer-native/src/main.rs
+++ b/ecos/layout-viewer/apps/layout-viewer-native/src/main.rs
@@ -18,8 +18,8 @@ use layout_render::{
     Viewport,
 };
 use layoutdb::{
-    CellViewState, HierarchyPolicy, HierarchyTreeRow, InstancePath, LayoutSession,
-    PackageLayoutSource, Rect, ShapeKind, ViewportLoadBatch,
+    CellViewState, HierarchyPolicy, InstancePath, LayoutSession, PackageLayoutSource, Rect,
+    ShapeKind, ViewportLoadBatch,
 };
 
 const TARGET_REPAINT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
@@ -30,12 +30,9 @@ const PLANE_CACHE_MARGIN_TILES: i32 = 1;
 const DETAIL_LOAD_TILE_PX: f32 = 256.0;
 const DETAIL_LOAD_MARGIN_TILES: i32 = 1;
 const DETAIL_LOAD_MAX_VIEWPORT_WORLD_AREA_RATIO: f64 = 0.15;
-const HIERARCHY_ROWS_STEADY_LIMIT: usize = 512;
-const HIERARCHY_ROWS_INTERACTION_LIMIT: usize = 64;
 const SIDEBAR_DEFAULT_WIDTH: f32 = 320.0;
 const SIDEBAR_MIN_WIDTH: f32 = 190.0;
 const SIDEBAR_MAX_WIDTH: f32 = 640.0;
-const HIERARCHY_ROW_RIGHT_GUTTER: f32 = 12.0;
 const MAX_PATTERN_OPS_PER_RECT: usize = 512;
 const MAX_HATCH_OPS_PER_RECT: usize = 256;
 const PATTERN_TILE_PX: f32 = 10.0;
@@ -110,7 +107,6 @@ struct LayoutViewerV2App {
     last_used_plane_renderer: bool,
     last_paint_ops: usize,
     last_lod_stats: LodStats,
-    hierarchy_rows_cache: HierarchyRowsCache,
     layer_counts_cache: LayerCountsCache,
 }
 
@@ -119,53 +115,6 @@ struct LoadedViewerState {
     display: DisplayModel,
     cell_view: CellViewState,
     background_load: BackgroundLoadHandle,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct HierarchyRowsCacheKey {
-    revision: u64,
-    cell_view: CellViewState,
-    max_depth: usize,
-    max_rows: usize,
-}
-
-#[derive(Debug, Default)]
-struct HierarchyRowsCache {
-    key: Option<HierarchyRowsCacheKey>,
-    rows: layoutdb::HierarchyTreeRows,
-    hits: usize,
-    misses: usize,
-}
-
-impl HierarchyRowsCache {
-    fn get_or_build(
-        &mut self,
-        db: &layoutdb::LayoutDb,
-        revision: u64,
-        cell_view: &CellViewState,
-        max_depth: usize,
-        max_rows: usize,
-    ) -> &layoutdb::HierarchyTreeRows {
-        let key = HierarchyRowsCacheKey {
-            revision,
-            cell_view: cell_view.clone(),
-            max_depth,
-            max_rows,
-        };
-        if self.key.as_ref() == Some(&key) {
-            self.hits += 1;
-            return &self.rows;
-        }
-        self.misses += 1;
-        self.key = Some(key);
-        self.rows = db.hierarchy_tree_rows(cell_view.clone(), max_depth, max_rows);
-        &self.rows
-    }
-
-    fn clear(&mut self) {
-        self.key = None;
-        self.rows = layoutdb::HierarchyTreeRows::default();
-    }
 }
 
 #[derive(Debug, Default)]
@@ -716,30 +665,6 @@ fn sync_hierarchy_policy_from_tuning(policy: &mut HierarchyPolicy, tuning: LodTu
     policy.max_depth = tuning.hierarchy_expand_depth.max(1);
 }
 
-fn cell_label(db: &layoutdb::LayoutDb, cell_id: layoutdb::CellId) -> String {
-    let name = db
-        .cell(cell_id)
-        .map(|cell| cell.name().to_owned())
-        .unwrap_or_else(|| "<missing>".to_owned());
-    format!("{name} ({})", cell_id.raw())
-}
-
-fn hierarchy_summary_text(
-    db: &layoutdb::LayoutDb,
-    cell_view: &CellViewState,
-    policy: &HierarchyPolicy,
-) -> String {
-    format!(
-        "context: {}\ntarget: {}\npath depth: {}\npolicy depth: {}..{}\nexpand arrays: {}",
-        cell_label(db, cell_view.context_cell()),
-        cell_label(db, cell_view.target_cell()),
-        cell_view.specific_path().depth(),
-        policy.min_depth,
-        policy.max_depth,
-        policy.expand_arrays
-    )
-}
-
 fn enter_path_for_hit(hit: &PickHit) -> Option<InstancePath> {
     if hit.instance_path.is_empty() {
         return None;
@@ -891,73 +816,6 @@ fn canvas_interaction_sense() -> egui::Sense {
     egui::Sense::click_and_drag()
 }
 
-fn hierarchy_row_label(db: &layoutdb::LayoutDb, row: &HierarchyTreeRow) -> String {
-    if row.instance_id.is_none() {
-        return row.cell_name.clone();
-    }
-    let cell_name = db
-        .cell(row.cell)
-        .map(|cell| cell.name())
-        .unwrap_or(row.cell_name.as_str());
-    let instance_name = if row.name.is_empty() {
-        "<unnamed>"
-    } else {
-        row.name.as_str()
-    };
-    format!(
-        "{}inst {}  {} -> {}",
-        "  ".repeat(row.depth),
-        row.instance_id.unwrap_or_default(),
-        instance_name,
-        cell_name
-    )
-}
-
-fn hierarchy_rows_content_width(available_width: f32) -> f32 {
-    available_width.clamp(1.0, SIDEBAR_MAX_WIDTH)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-struct HierarchyRowLayout {
-    row_width: f32,
-    label_width: f32,
-    button_width: f32,
-    button_visible: bool,
-}
-
-fn hierarchy_row_layout(
-    content_width: f32,
-    has_focus_action: bool,
-    spacing_x: f32,
-) -> HierarchyRowLayout {
-    let row_width = hierarchy_rows_content_width(content_width);
-    let desired_button_width = if has_focus_action { 44.0 } else { 0.0 };
-    let right_gutter = HIERARCHY_ROW_RIGHT_GUTTER.min((row_width - 1.0).max(0.0));
-    let spacing = if desired_button_width > 0.0 {
-        spacing_x.max(0.0)
-    } else {
-        0.0
-    };
-    let button_visible = desired_button_width > 0.0
-        && row_width >= desired_button_width + spacing + right_gutter + 48.0;
-    let button_width = if button_visible {
-        desired_button_width
-    } else {
-        0.0
-    };
-    let label_width = (row_width
-        - button_width
-        - if button_visible { spacing } else { 0.0 }
-        - if button_visible { right_gutter } else { 0.0 })
-    .max(1.0);
-    HierarchyRowLayout {
-        row_width,
-        label_width,
-        button_width,
-        button_visible,
-    }
-}
-
 fn layer_swatch_size() -> egui::Vec2 {
     egui::vec2(12.0, 12.0)
 }
@@ -973,83 +831,6 @@ fn layer_swatch_rect(slot: egui::Rect, swatch_size: egui::Vec2) -> egui::Rect {
 #[cfg(test)]
 fn sidebar_title_text() -> Option<&'static str> {
     None
-}
-
-fn hierarchy_row_has_focus_action(row: &HierarchyTreeRow) -> bool {
-    row.instance_id.is_some()
-}
-
-fn visible_hierarchy_row_slice(
-    rows: &[HierarchyTreeRow],
-    visible_range: std::ops::Range<usize>,
-) -> &[HierarchyTreeRow] {
-    if visible_range.start >= visible_range.end {
-        return &[];
-    }
-    let start = visible_range.start.min(rows.len());
-    let end = visible_range.end.min(rows.len());
-    if start >= end {
-        &[]
-    } else {
-        &rows[start..end]
-    }
-}
-
-fn render_visible_hierarchy_rows(
-    ui: &mut egui::Ui,
-    db: &layoutdb::LayoutDb,
-    rows: &[HierarchyTreeRow],
-    visible_range: std::ops::Range<usize>,
-    content_width: f32,
-) -> Option<InstancePath> {
-    let mut focused_path = None;
-    for row in visible_hierarchy_row_slice(rows, visible_range) {
-        let row_layout = hierarchy_row_layout(
-            content_width.min(ui.available_width()),
-            hierarchy_row_has_focus_action(row),
-            ui.spacing().item_spacing.x,
-        );
-        let row_height = ui.spacing().interact_size.y;
-        let (row_rect, _) = ui.allocate_exact_size(
-            egui::vec2(row_layout.row_width, row_height),
-            egui::Sense::hover(),
-        );
-        let mut row_ui = ui.new_child(
-            egui::UiBuilder::new()
-                .max_rect(row_rect)
-                .layout(egui::Layout::left_to_right(egui::Align::Center)),
-        );
-        row_ui.shrink_clip_rect(row_rect);
-        row_ui.set_width(row_layout.row_width);
-        row_ui.spacing_mut().item_spacing.x = 6.0;
-
-        let label = hierarchy_row_label(db, row);
-        let (label_rect, _) = row_ui.allocate_exact_size(
-            egui::vec2(row_layout.label_width, row_height),
-            egui::Sense::hover(),
-        );
-        let mut label_ui = row_ui.new_child(
-            egui::UiBuilder::new()
-                .max_rect(label_rect)
-                .layout(egui::Layout::left_to_right(egui::Align::Center)),
-        );
-        label_ui.shrink_clip_rect(label_rect);
-        label_ui.set_width(row_layout.label_width);
-        label_ui.add(
-            egui::Label::new(egui::RichText::new(label).monospace())
-                .truncate()
-                .halign(egui::Align::LEFT),
-        );
-
-        if row_layout.button_visible
-            && row_ui
-                .add_sized([row_layout.button_width, 18.0], egui::Button::new("Focus"))
-                .clicked()
-        {
-            focused_path = Some(row.instance_path.clone());
-        }
-    }
-    focused_path
 }
 
 fn draw_layer_visibility_row(
@@ -1085,10 +866,6 @@ fn focus_view_on_cell_bbox(
     } else {
         *view = Some(V2ViewState::fit(bbox, 1.0, 1.0));
     }
-}
-
-fn ascended_cell_view(cell_view: &CellViewState) -> CellViewState {
-    cell_view.ascend()
 }
 
 fn overview_density_usable(
@@ -1251,7 +1028,6 @@ impl LayoutViewerV2App {
             last_used_plane_renderer: false,
             last_paint_ops: 0,
             last_lod_stats: LodStats::default(),
-            hierarchy_rows_cache: HierarchyRowsCache::default(),
             layer_counts_cache: LayerCountsCache::default(),
         })
     }
@@ -1605,8 +1381,6 @@ impl LayoutViewerV2App {
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         if let Some(mut loaded) = self.loaded.take() {
-                            self.draw_hierarchy_panel(ui, &mut loaded);
-                            ui.separator();
                             self.draw_layers_panel(ui, &mut loaded);
                             ui.separator();
                             ui.label("Selection");
@@ -1672,107 +1446,16 @@ impl LayoutViewerV2App {
             });
     }
 
-    fn draw_hierarchy_panel(&mut self, ui: &mut egui::Ui, loaded: &mut LoadedViewerState) {
-        egui::CollapsingHeader::new("Hierarchy")
-            .default_open(true)
-            .show(ui, |ui| {
-                sync_hierarchy_policy_from_tuning(&mut self.hierarchy_policy, self.lod_tuning);
-                ui.horizontal(|ui| {
-                    if ui.button("Top").clicked() {
-                        loaded.cell_view = CellViewState::reset_to_top(loaded.session.db());
-                        self.selected = None;
-                        self.clear_render_history();
-                        focus_view_on_cell_bbox(
-                            &mut self.view,
-                            loaded.session.db(),
-                            &loaded.cell_view,
-                        );
-                    }
-                    let can_ascend = !loaded.cell_view.specific_path().is_empty();
-                    if ui
-                        .add_enabled(can_ascend, egui::Button::new("Up"))
-                        .clicked()
-                    {
-                        loaded.cell_view = ascended_cell_view(&loaded.cell_view);
-                        self.selected = None;
-                        self.clear_render_history();
-                        focus_view_on_cell_bbox(
-                            &mut self.view,
-                            loaded.session.db(),
-                            &loaded.cell_view,
-                        );
-                    }
-                    let enter_path = self.selected.as_ref().and_then(enter_path_for_hit);
-                    if ui
-                        .add_enabled(enter_path.is_some(), egui::Button::new("Enter"))
-                        .clicked()
-                    {
-                        if let Some(path) = enter_path {
-                            self.enter_instance_path(loaded, path);
-                        }
-                    }
-                });
-                ui.monospace(hierarchy_summary_text(
-                    loaded.session.db(),
-                    &loaded.cell_view,
-                    &self.hierarchy_policy,
-                ));
-                let max_rows = if self.interaction_active() {
-                    HIERARCHY_ROWS_INTERACTION_LIMIT
-                } else {
-                    HIERARCHY_ROWS_STEADY_LIMIT
-                };
-                let rows = self.hierarchy_rows_cache.get_or_build(
-                    loaded.session.db(),
-                    loaded.session.hierarchy_revision(),
-                    &loaded.cell_view,
-                    8,
-                    max_rows,
-                );
-                let rows_truncated = rows.truncated;
-                let row_height = ui.spacing().interact_size.y;
-                let focused_path = egui::ScrollArea::vertical()
-                    .max_height(260.0)
-                    .show_rows(ui, row_height, rows.rows.len(), |ui, visible_range| {
-                        let hierarchy_rows_width =
-                            hierarchy_rows_content_width(ui.available_width());
-                        ui.set_width(hierarchy_rows_width);
-                        render_visible_hierarchy_rows(
-                            ui,
-                            loaded.session.db(),
-                            &rows.rows,
-                            visible_range,
-                            hierarchy_rows_width,
-                        )
-                    })
-                    .inner;
-                if let Some(path) = focused_path {
-                    self.focus_instance_path(loaded, path);
-                }
-                if rows_truncated {
-                    ui.label("Hierarchy rows truncated");
-                }
-            });
-    }
-
     fn clear_render_history(&mut self) {
         self.last_render_plan = None;
         self.lod_hysteresis = LodHysteresisState::default();
         self.last_render_plan_revision = 0;
         self.last_render_plan_interaction_coarse = false;
         self.last_plan_reused = false;
-        self.hierarchy_rows_cache.clear();
         self.layer_counts_cache.clear();
     }
 
     fn enter_instance_path(&mut self, loaded: &mut LoadedViewerState, path: InstancePath) {
-        loaded.cell_view = CellViewState::from_path(loaded.cell_view.context_cell(), path);
-        self.selected = None;
-        self.clear_render_history();
-        focus_view_on_cell_bbox(&mut self.view, loaded.session.db(), &loaded.cell_view);
-    }
-
-    fn focus_instance_path(&mut self, loaded: &mut LoadedViewerState, path: InstancePath) {
         loaded.cell_view = CellViewState::from_path(loaded.cell_view.context_cell(), path);
         self.selected = None;
         self.clear_render_history();
@@ -2532,8 +2215,8 @@ mod tests {
         scroll_zoom_factor, selection_inspector_rows, should_check_overview_density,
         should_request_detail_tiles, should_request_smooth_repaint, should_reuse_render_plan,
         should_sample_layout_fps, use_plane_renderer, viewport_for_world_rect,
-        visible_hierarchy_row_slice, Args, AsyncLoadState, CachedPlaneTextureAction, FillDrawMode,
-        FrameRateState, LayoutViewerV2App, LoadRequest, LodTuningState,
+        Args, AsyncLoadState, CachedPlaneTextureAction, FillDrawMode, FrameRateState,
+        LayoutViewerV2App, LoadRequest, LodTuningState,
     };
     use crate::plane_cache::PlaneKey;
     use layout_display::{Color, DisplayLayer, DisplayModel, LayerStyle, Pattern};
@@ -2952,22 +2635,6 @@ mod tests {
     }
 
     #[test]
-    fn hierarchy_rows_cache_reuses_rows_for_matching_revision_view_and_limit() {
-        let (db, _) = hierarchy_test_db_and_leaf_view();
-        let mut cache = super::HierarchyRowsCache::default();
-        let cell_view = CellViewState::top(&db);
-
-        let first = cache.get_or_build(&db, 1, &cell_view, 8, 16).clone();
-        let second = cache.get_or_build(&db, 1, &cell_view, 8, 16).clone();
-        let third = cache.get_or_build(&db, 2, &cell_view, 8, 16).clone();
-
-        assert_eq!(first, second);
-        assert_eq!(cache.hits, 1);
-        assert_eq!(cache.misses, 2);
-        assert_eq!(third, db.hierarchy_tree_rows(cell_view, 8, 16));
-    }
-
-    #[test]
     fn layer_counts_cache_reuses_counts_for_matching_revision() {
         let mut db = LayoutDb::new("unit", Rect::new(0, 0, 100, 100));
         db.add_layer(LayerInfo::new(1, "M1"));
@@ -2986,31 +2653,6 @@ mod tests {
         assert_eq!(third.get(&1), Some(&1));
         assert_eq!(cache.hits, 1);
         assert_eq!(cache.misses, 2);
-    }
-
-    #[test]
-    fn hierarchy_rows_interaction_limit_is_smaller_than_steady_limit() {
-        assert!(super::HIERARCHY_ROWS_INTERACTION_LIMIT < super::HIERARCHY_ROWS_STEADY_LIMIT);
-    }
-
-    #[test]
-    fn visible_hierarchy_row_slice_clamps_to_visible_range_only() {
-        let db = LayoutDb::new("unit", Rect::new(0, 0, 100, 100));
-        let cell = db.top_cell();
-        let rows = (0..512)
-            .map(|index| sample_hierarchy_row(index, cell, &format!("cell_{index}")))
-            .collect::<Vec<_>>();
-
-        let visible = visible_hierarchy_row_slice(&rows, 10..24);
-        let over_scrolled = visible_hierarchy_row_slice(&rows, 500..540);
-        let reversed = visible_hierarchy_row_slice(&rows, 42..12);
-
-        assert_eq!(visible.len(), 14);
-        assert_eq!(visible[0].cell_name, "cell_10");
-        assert_eq!(visible[13].cell_name, "cell_23");
-        assert_eq!(over_scrolled.len(), 12);
-        assert_eq!(over_scrolled[0].cell_name, "cell_500");
-        assert!(reversed.is_empty());
     }
 
     #[test]
@@ -3292,24 +2934,6 @@ mod tests {
     }
 
     #[test]
-    fn hierarchy_summary_text_includes_target_and_depth() {
-        let (db, leaf_view) = hierarchy_test_db_and_leaf_view();
-        let mut policy = super::hierarchy_policy_from_tuning(LodTuningState {
-            hierarchy_expand_depth: 3,
-            ..Default::default()
-        });
-        policy.expand_arrays = false;
-
-        let text = super::hierarchy_summary_text(&db, &leaf_view, &policy);
-
-        assert!(text.contains("context: top"));
-        assert!(text.contains("target: leaf"));
-        assert!(text.contains("path depth: 2"));
-        assert!(text.contains("policy depth: 0..3"));
-        assert!(text.contains("expand arrays: false"));
-    }
-
-    #[test]
     fn enter_path_for_shape_hit_uses_shape_instance_path() {
         let (_db, leaf_view) = hierarchy_test_db_and_leaf_view();
         let hit = sample_pick_hit(PickHitTarget::Shape, leaf_view.specific_path().clone());
@@ -3334,36 +2958,6 @@ mod tests {
     }
 
     #[test]
-    fn hierarchy_row_label_includes_instance_and_cell_name() {
-        let (db, _leaf_view) = hierarchy_test_db_and_leaf_view();
-        let rows = db.hierarchy_tree_rows(CellViewState::top(&db), 8, 16);
-        let root = &rows.rows[0];
-        let mid = rows
-            .rows
-            .iter()
-            .find(|row| row.name == "mid0")
-            .expect("fixture should include mid0 instance row");
-
-        let root_label = super::hierarchy_row_label(&db, root);
-        let mid_label = super::hierarchy_row_label(&db, mid);
-
-        assert!(root_label.contains("top"));
-        assert!(!root_label.contains("inst"));
-        assert!(mid_label.contains("mid0"));
-        assert!(mid_label.contains("inst 10"));
-        assert!(mid_label.contains("mid"));
-    }
-
-    #[test]
-    fn sidebar_content_does_not_expand_to_unbounded_available_width() {
-        assert_eq!(
-            super::hierarchy_rows_content_width(10_000.0),
-            super::SIDEBAR_MAX_WIDTH
-        );
-        assert_eq!(super::hierarchy_rows_content_width(20.0), 20.0);
-    }
-
-    #[test]
     fn sidebar_default_width_stays_compact_while_max_width_allows_expansion() {
         assert_eq!(super::SIDEBAR_DEFAULT_WIDTH, 320.0);
         assert!(super::SIDEBAR_MAX_WIDTH > super::SIDEBAR_DEFAULT_WIDTH);
@@ -3375,31 +2969,22 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_does_not_render_hierarchy_module() {
+        let source = include_str!("main.rs");
+
+        assert!(!source.contains(&["self.", "draw_", "hierarchy_panel"].concat()));
+        assert!(!source.contains(&[
+            "CollapsingHeader::new(",
+            "\"Hier",
+            "archy\"",
+            ")",
+        ]
+        .concat()));
+    }
+
+    #[test]
     fn window_title_omits_version_suffix() {
         assert_eq!(super::window_title(), "ECOS Layout Viewer");
-    }
-
-    #[test]
-    fn hierarchy_row_layout_keeps_label_and_focus_button_inside_sidebar_width() {
-        let layout = super::hierarchy_row_layout(10_000.0, true, 6.0);
-
-        assert_eq!(layout.row_width, super::SIDEBAR_MAX_WIDTH);
-        assert!(layout.button_visible);
-        assert_eq!(layout.button_width, 44.0);
-        assert!(
-            layout.label_width + layout.button_width + 6.0 + super::HIERARCHY_ROW_RIGHT_GUTTER
-                <= layout.row_width
-        );
-    }
-
-    #[test]
-    fn hierarchy_row_layout_hides_focus_button_when_row_is_too_narrow() {
-        let layout = super::hierarchy_row_layout(80.0, true, 6.0);
-
-        assert_eq!(layout.row_width, 80.0);
-        assert!(!layout.button_visible);
-        assert_eq!(layout.button_width, 0.0);
-        assert_eq!(layout.label_width, 80.0);
     }
 
     #[test]
@@ -3421,21 +3006,6 @@ mod tests {
     }
 
     #[test]
-    fn hierarchy_focus_action_is_only_for_instance_rows() {
-        let (db, _leaf_view) = hierarchy_test_db_and_leaf_view();
-        let rows = db.hierarchy_tree_rows(CellViewState::top(&db), 8, 16);
-        let root = &rows.rows[0];
-        let instance = rows
-            .rows
-            .iter()
-            .find(|row| row.instance_id.is_some())
-            .expect("fixture should include an instance row");
-
-        assert!(!super::hierarchy_row_has_focus_action(root));
-        assert!(super::hierarchy_row_has_focus_action(instance));
-    }
-
-    #[test]
     fn focus_view_on_cell_bbox_uses_existing_canvas_size() {
         let (db, leaf_view) = hierarchy_test_db_and_leaf_view();
         let mut view = Some(super::V2ViewState::fit(
@@ -3450,19 +3020,6 @@ mod tests {
         assert_eq!(focused.center_x, 10.0);
         assert_eq!(focused.center_y, 10.0);
         assert!((focused.units_per_pixel - 0.08).abs() < 0.001);
-    }
-
-    #[test]
-    fn hierarchy_up_button_helper_ascends_until_top_path() {
-        let (db, leaf_view) = hierarchy_test_db_and_leaf_view();
-
-        let mid_view = super::ascended_cell_view(&leaf_view);
-        assert_eq!(mid_view.target_cell(), db.cell_by_name("mid").unwrap());
-        assert_eq!(mid_view.specific_path().depth(), 1);
-
-        let top_view = super::ascended_cell_view(&mid_view);
-        assert_eq!(top_view.target_cell(), db.top_cell());
-        assert!(top_view.specific_path().is_empty());
     }
 
     #[test]
@@ -4168,23 +3725,4 @@ mod tests {
         }
     }
 
-    fn sample_hierarchy_row(
-        index: usize,
-        cell: layoutdb::CellId,
-        cell_name: &str,
-    ) -> layoutdb::HierarchyTreeRow {
-        layoutdb::HierarchyTreeRow {
-            depth: index % 4,
-            cell,
-            parent_cell: None,
-            instance_id: Some(index as u32),
-            source_id: Some(index as u32),
-            name: format!("inst_{index}"),
-            cell_name: cell_name.to_owned(),
-            bbox: Rect::new(0, 0, 10, 10),
-            instance_path: InstancePath::new(),
-            child_instance_count: 0,
-            shape_count: 0,
-        }
-    }
 }

--- a/ecos/layout-viewer/crates/layout-display/src/lib.rs
+++ b/ecos/layout-viewer/crates/layout-display/src/lib.rs
@@ -439,6 +439,43 @@ pub enum SourceSelector {
     SelectionOverlay,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ObjectVisibility {
+    pub instances: bool,
+    pub pdn: bool,
+    pub net: bool,
+}
+
+impl Default for ObjectVisibility {
+    fn default() -> Self {
+        Self {
+            instances: true,
+            pdn: true,
+            net: true,
+        }
+    }
+}
+
+impl ObjectVisibility {
+    pub fn includes_shape_kind(self, kind: ShapeKind) -> bool {
+        match kind {
+            ShapeKind::Instance => self.instances,
+            ShapeKind::SpecialWire => self.pdn,
+            ShapeKind::RegularWire => self.net,
+            _ => true,
+        }
+    }
+
+    fn includes_source(self, source: SourceSelector) -> bool {
+        match source {
+            SourceSelector::ShapeKind(kind) => self.includes_shape_kind(kind),
+            SourceSelector::PhysicalLayer(_)
+            | SourceSelector::CellFrame
+            | SourceSelector::SelectionOverlay => true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DisplayLayer {
     pub id: String,
@@ -486,6 +523,7 @@ pub struct ResolvedDisplayLayer {
     pub id: String,
     pub name: String,
     pub source: SourceSelector,
+    pub object_visibility: ObjectVisibility,
     pub draw_order: i32,
     pub style: LayerStyle,
     pub pickable: bool,
@@ -494,11 +532,15 @@ pub struct ResolvedDisplayLayer {
 #[derive(Debug, Clone, Default)]
 pub struct DisplayModel {
     layers: Vec<DisplayLayer>,
+    object_visibility: ObjectVisibility,
 }
 
 impl DisplayModel {
     pub fn new() -> Self {
-        Self { layers: Vec::new() }
+        Self {
+            layers: Vec::new(),
+            object_visibility: ObjectVisibility::default(),
+        }
     }
 
     pub fn from_layout_layers(layers: &[layoutdb::LayerInfo]) -> Self {
@@ -532,15 +574,24 @@ impl DisplayModel {
         &mut self.layers
     }
 
+    pub fn object_visibility(&self) -> ObjectVisibility {
+        self.object_visibility
+    }
+
+    pub fn object_visibility_mut(&mut self) -> &mut ObjectVisibility {
+        &mut self.object_visibility
+    }
+
     pub fn resolved_layers(&self) -> Vec<ResolvedDisplayLayer> {
         let mut layers = self
             .layers
             .iter()
-            .filter(|layer| layer.visible)
+            .filter(|layer| layer.visible && self.object_visibility.includes_source(layer.source))
             .map(|layer| ResolvedDisplayLayer {
                 id: layer.id.clone(),
                 name: layer.name.clone(),
                 source: layer.source,
+                object_visibility: self.object_visibility,
                 draw_order: layer.draw_order,
                 style: layer.style.clone(),
                 pickable: layer.pickable,
@@ -653,6 +704,9 @@ mod tests {
         let model = DisplayModel::from_layout_layers(&[LayerInfo::new(1, "M1")]);
         let layers = model.layers();
 
+        assert!(model.object_visibility().instances);
+        assert!(model.object_visibility().pdn);
+        assert!(model.object_visibility().net);
         assert!(layers.iter().any(|layer| layer.source
             == SourceSelector::ShapeKind(ShapeKind::Die)
             && !layer.visible
@@ -667,6 +721,26 @@ mod tests {
             && layer.name == "Instance"
             && layer.style.fill_pattern != Pattern::Hollow
             && layer.style.fill_alpha > 0));
+    }
+
+    #[test]
+    fn resolved_layers_keep_physical_layers_when_object_visibility_changes() {
+        let mut model = DisplayModel::from_layout_layers(&[LayerInfo::new(1, "M1")]);
+        model.add_layer(DisplayLayer::shape_kind(
+            ShapeKind::RegularWire,
+            "Net",
+            LayerStyle::default_for_index(3),
+        ));
+        model.object_visibility_mut().net = false;
+
+        let resolved = model.resolved_layers();
+
+        assert!(resolved
+            .iter()
+            .any(|layer| layer.source == SourceSelector::PhysicalLayer(1)));
+        assert!(!resolved
+            .iter()
+            .any(|layer| layer.source == SourceSelector::ShapeKind(ShapeKind::RegularWire)));
     }
 
     #[test]

--- a/ecos/layout-viewer/crates/layout-render/src/lib.rs
+++ b/ecos/layout-viewer/crates/layout-render/src/lib.rs
@@ -1,13 +1,13 @@
 use std::collections::{HashMap, HashSet};
 
 use layout_display::{
-    Color, CompositionMode, DisplayModel, LayerStyle, LineStyle, Pattern, ResolvedDisplayLayer,
-    SourceSelector,
+    Color, CompositionMode, DisplayModel, LayerStyle, LineStyle, ObjectVisibility, Pattern,
+    ResolvedDisplayLayer, SourceSelector,
 };
 use layoutdb::{
     CellId, CellViewInstanceQuery, CellViewInstanceRecord, CellViewShapeQuery, CellViewShapeRecord,
     CellViewState, HierarchyInstanceRecord, HierarchyPolicy, InstancePath, LayoutDb, ObjectPath,
-    OverviewDensityBin, Rect, ShapeKind, ShapeRecord,
+    OverviewDensityBin, Rect, ShapeKind, ShapeRecord, SHAPE_FLAG_TOP_LEVEL_CONTEXT,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -412,6 +412,7 @@ impl RenderPlanner {
         cache_key_mode: CacheKeyMode,
     ) -> RenderPlan {
         let layers = model.resolved_layers();
+        let object_visibility = model.object_visibility();
         let mut plan = RenderPlan {
             cache_key: self.render_cache_key_for_mode(
                 viewport,
@@ -468,6 +469,7 @@ impl RenderPlanner {
                     cell_view,
                     policy,
                     max_depth_for_query(self.settings, policy),
+                    object_visibility,
                 );
                 self.push_top_level_context(
                     db,
@@ -483,7 +485,14 @@ impl RenderPlanner {
             }
             HierarchyLodMode::MidCoarse => {
                 plan.source = RenderPlanSource::HierarchyMid;
-                self.push_coarse_hierarchy(db, &mut plan, viewport, cell_view, policy);
+                self.push_coarse_hierarchy(
+                    db,
+                    &mut plan,
+                    viewport,
+                    cell_view,
+                    policy,
+                    object_visibility,
+                );
                 self.push_top_level_context(
                     db,
                     &layers,
@@ -575,14 +584,47 @@ impl RenderPlanner {
         }
         for shape in query.shapes {
             match mode {
-                TopLevelContextMode::AllVisibleShapes => {}
+                TopLevelContextMode::AllVisibleShapes => {
+                    self.push_shape_lod(layers, plan, viewport, occupancy, shape);
+                }
                 TopLevelContextMode::StableContextOnly => {
-                    if !is_stable_far_context_shape(shape.kind) {
+                    if !is_stable_far_context_shape(shape) {
                         continue;
                     }
+                    self.push_stable_context_shape(layers, plan, shape);
                 }
             }
-            self.push_shape_lod(layers, plan, viewport, occupancy, shape);
+        }
+    }
+
+    fn push_stable_context_shape(
+        &self,
+        layers: &[ResolvedDisplayLayer],
+        plan: &mut RenderPlan,
+        shape: &ShapeRecord,
+    ) {
+        for layer in layers
+            .iter()
+            .filter(|layer| layer_matches_shape(layer, shape))
+        {
+            if plan.truncated {
+                break;
+            }
+            let item = DrawItem::Rect(DrawRect {
+                world: shape.bbox,
+                color: layer.style.frame_color,
+                source_id: shape.source_id,
+                layer_id: shape.layer_id,
+                composition: CompositionMode::MaskPattern,
+            });
+            push_item(
+                plan,
+                RenderPlane::Hierarchy,
+                layer,
+                item,
+                self.settings.max_render_items,
+            );
+            plan.lod_stats.record(LodDecision::Coarse);
         }
     }
 
@@ -732,7 +774,11 @@ impl RenderPlanner {
         cell_view: &CellViewState,
         policy: &HierarchyPolicy,
         depth: usize,
+        object_visibility: ObjectVisibility,
     ) {
+        if !object_visibility.instances {
+            return;
+        }
         let query = db.query_cell_view_instances(CellViewInstanceQuery {
             cell_view: cell_view.clone(),
             viewport: viewport.world,
@@ -748,14 +794,20 @@ impl RenderPlanner {
         let entries = far_hierarchy_entries(query.instances, viewport, &mut rendered_arrays, self);
         let item_budget = far_hierarchy_coalesce_budget(viewport, self.settings);
         if entries.len() > item_budget {
-            self.push_thinned_hierarchy_bboxes(plan, viewport, entries, item_budget);
+            self.push_thinned_hierarchy_bboxes(
+                plan,
+                viewport,
+                entries,
+                item_budget,
+                object_visibility,
+            );
             return;
         }
         for entry in entries {
             if plan.truncated {
                 break;
             }
-            self.push_far_hierarchy_entry(plan, entry);
+            self.push_far_hierarchy_entry(plan, entry, object_visibility);
         }
     }
 
@@ -765,13 +817,14 @@ impl RenderPlanner {
         viewport: Viewport,
         entries: Vec<FarHierarchyEntry>,
         item_budget: usize,
+        object_visibility: ObjectVisibility,
     ) {
         let original_len = entries.len();
         let emitted_before =
             plan.lod_stats.hierarchy_bbox + plan.lod_stats.array_bbox + plan.lod_stats.array_grid;
         let thinned = thin_hierarchy_entries(viewport, self.settings, item_budget, entries);
         for entry in thinned {
-            self.push_far_hierarchy_entry(plan, entry);
+            self.push_far_hierarchy_entry(plan, entry, object_visibility);
         }
         let emitted_after =
             plan.lod_stats.hierarchy_bbox + plan.lod_stats.array_bbox + plan.lod_stats.array_grid;
@@ -780,8 +833,13 @@ impl RenderPlanner {
         plan.lod_stats.suppress += original_len.saturating_sub(emitted);
     }
 
-    fn push_far_hierarchy_entry(&self, plan: &mut RenderPlan, entry: FarHierarchyEntry) {
-        let layer = hierarchy_display_layer();
+    fn push_far_hierarchy_entry(
+        &self,
+        plan: &mut RenderPlan,
+        entry: FarHierarchyEntry,
+        object_visibility: ObjectVisibility,
+    ) {
+        let layer = hierarchy_display_layer(object_visibility);
         let (width_px, height_px) = entry.projected_size_px;
         if width_px.max(height_px) < self.settings.frame_only_px {
             push_item(
@@ -831,7 +889,11 @@ impl RenderPlanner {
         viewport: Viewport,
         cell_view: &CellViewState,
         policy: &HierarchyPolicy,
+        object_visibility: ObjectVisibility,
     ) {
+        if !object_visibility.instances {
+            return;
+        }
         let query = db.query_cell_view_instances(CellViewInstanceQuery {
             cell_view: cell_view.clone(),
             viewport: viewport.world,
@@ -863,11 +925,12 @@ impl RenderPlanner {
                         instance_ref,
                         hierarchy_bbox_for_decision(instance_ref, decision),
                         self.settings.max_render_items,
+                        object_visibility,
                     );
                     plan.lod_stats.record(LodDecision::ArrayBBox);
                 }
                 ArrayLodDecision::Grid => {
-                    self.push_array_grid(plan, instance_ref);
+                    self.push_array_grid(plan, instance_ref, object_visibility);
                     plan.lod_stats.record(LodDecision::ArrayGrid);
                 }
                 ArrayLodDecision::ViewportElements => {
@@ -892,9 +955,16 @@ impl RenderPlanner {
                         instance_ref,
                         instance.bbox,
                         self.settings.max_render_items,
+                        object_visibility,
                     );
                     if let Some(proxy) = display_proxy {
-                        self.push_cell_display_proxy(plan, viewport, &instance, proxy);
+                        self.push_cell_display_proxy(
+                            plan,
+                            viewport,
+                            &instance,
+                            proxy,
+                            object_visibility,
+                        );
                     }
                     plan.lod_stats.record(LodDecision::Coarse);
                 }
@@ -908,8 +978,9 @@ impl RenderPlanner {
         viewport: Viewport,
         instance: &CellViewInstanceRecord,
         proxy: &CellDisplayProxy,
+        object_visibility: ObjectVisibility,
     ) {
-        let layer = hierarchy_display_layer();
+        let layer = hierarchy_display_layer(object_visibility);
         for density in &proxy.layer_density_bins {
             if plan.truncated {
                 break;
@@ -1053,10 +1124,21 @@ impl RenderPlanner {
         }
     }
 
-    fn push_array_grid(&self, plan: &mut RenderPlan, instance: HierarchyInstanceRef<'_>) {
+    fn push_array_grid(
+        &self,
+        plan: &mut RenderPlan,
+        instance: HierarchyInstanceRef<'_>,
+        object_visibility: ObjectVisibility,
+    ) {
         let bbox = hierarchy_bbox_for_decision(instance, ArrayLodDecision::Grid);
-        push_hierarchy_rect(plan, instance, bbox, self.settings.max_render_items);
-        let layer = hierarchy_display_layer();
+        push_hierarchy_rect(
+            plan,
+            instance,
+            bbox,
+            self.settings.max_render_items,
+            object_visibility,
+        );
+        let layer = hierarchy_display_layer(object_visibility);
         let color = Color::rgb(118, 148, 176);
         let x_mid = bbox.x1 + bbox.width() / 2;
         let y_mid = bbox.y1 + bbox.height() / 2;
@@ -1183,7 +1265,10 @@ impl RenderPlanner {
             && min_px >= self.settings.fill_px
         {
             LodDecision::Exact
-        } else if min_px >= self.settings.frame_only_px || max_px >= self.settings.long_shape_px {
+        } else if min_px >= self.settings.frame_only_px
+            || max_px >= self.settings.long_shape_px
+            || (is_wire_shape(shape.kind) && max_px >= wire_frame_threshold_px(self.settings))
+        {
             if occupancy.reserve_frame(layer, shape) {
                 LodDecision::FrameOnly
             } else {
@@ -1236,11 +1321,13 @@ impl RenderPlanner {
                 maybe_replace_pick_hit(&mut best, candidate, request.x, request.y);
             }
         }
-        for instance in
-            matching_instances_for_cell_view(db, query, cell_view, policy, self.settings)
-        {
-            let candidate = pick_hit_for_instance(instance);
-            maybe_replace_pick_hit(&mut best, candidate, request.x, request.y);
+        if model.object_visibility().instances {
+            for instance in
+                matching_instances_for_cell_view(db, query, cell_view, policy, self.settings)
+            {
+                let candidate = pick_hit_for_instance(instance);
+                maybe_replace_pick_hit(&mut best, candidate, request.x, request.y);
+            }
         }
         best
     }
@@ -1761,8 +1848,9 @@ fn push_hierarchy_rect(
     instance: HierarchyInstanceRef<'_>,
     bbox: Rect,
     max_items: usize,
+    object_visibility: ObjectVisibility,
 ) {
-    let layer = hierarchy_display_layer();
+    let layer = hierarchy_display_layer(object_visibility);
     push_item(
         plan,
         RenderPlane::Hierarchy,
@@ -1779,6 +1867,9 @@ fn push_hierarchy_rect(
 }
 
 fn layer_matches_shape(layer: &ResolvedDisplayLayer, shape: &ShapeRecord) -> bool {
+    if !layer.object_visibility.includes_shape_kind(shape.kind) {
+        return false;
+    }
     match layer.source {
         SourceSelector::PhysicalLayer(layer_id) => {
             shape.layer_id == layer_id && !is_context_shape(shape.kind)
@@ -1789,6 +1880,9 @@ fn layer_matches_shape(layer: &ResolvedDisplayLayer, shape: &ShapeRecord) -> boo
 }
 
 fn layer_matches_overview_bin(layer: &ResolvedDisplayLayer, bin: &OverviewDensityBin) -> bool {
+    if !layer.object_visibility.includes_shape_kind(bin.kind) {
+        return false;
+    }
     match layer.source {
         SourceSelector::PhysicalLayer(layer_id) => {
             bin.layer_id == layer_id && overview_kind_matches_physical_layer(bin.kind)
@@ -1814,11 +1908,15 @@ fn overview_kind_matches_physical_layer(kind: ShapeKind) -> bool {
 struct VisibleShapeSources {
     physical_layers: HashSet<u16>,
     shape_kinds: HashSet<ShapeKind>,
+    object_visibility: ObjectVisibility,
 }
 
 impl VisibleShapeSources {
     fn from_layers(layers: &[ResolvedDisplayLayer]) -> Self {
         let mut visible = Self::default();
+        if let Some(layer) = layers.first() {
+            visible.object_visibility = layer.object_visibility;
+        }
         for layer in layers {
             match layer.source {
                 SourceSelector::PhysicalLayer(layer_id) => {
@@ -1834,8 +1932,10 @@ impl VisibleShapeSources {
     }
 
     fn matches(&self, layer_id: u16, kind: ShapeKind) -> bool {
-        (self.physical_layers.contains(&layer_id) && overview_kind_matches_physical_layer(kind))
-            || self.shape_kinds.contains(&kind)
+        self.object_visibility.includes_shape_kind(kind)
+            && ((self.physical_layers.contains(&layer_id)
+                && overview_kind_matches_physical_layer(kind))
+                || self.shape_kinds.contains(&kind))
     }
 
     fn is_empty(&self) -> bool {
@@ -1971,7 +2071,7 @@ fn push_marker_batch(
     push_item(plan, RenderPlane::Marker, layer, item, max_items);
 }
 
-fn hierarchy_display_layer() -> ResolvedDisplayLayer {
+fn hierarchy_display_layer(object_visibility: ObjectVisibility) -> ResolvedDisplayLayer {
     let mut style = LayerStyle::new(Color::rgb(80, 96, 112), Color::rgb(168, 190, 210));
     style.fill_alpha = 0;
     style.frame_alpha = 190;
@@ -1982,6 +2082,7 @@ fn hierarchy_display_layer() -> ResolvedDisplayLayer {
         id: "hierarchy:cell_bbox".to_string(),
         name: "Cell BBox".to_string(),
         source: SourceSelector::CellFrame,
+        object_visibility,
         draw_order: -10_000,
         style,
         pickable: false,
@@ -2048,6 +2149,7 @@ fn append_plan(plan: &mut RenderPlan, other: RenderPlan, max_items: usize) {
             id: batch.display_layer_id.clone(),
             name: batch.display_layer_id.clone(),
             source: SourceSelector::SelectionOverlay,
+            object_visibility: ObjectVisibility::default(),
             draw_order: 0,
             style: batch.style.clone(),
             pickable: false,
@@ -2124,6 +2226,9 @@ fn render_cache_key(
             SourceSelector::CellFrame => hash.write_u8(3),
             SourceSelector::SelectionOverlay => hash.write_u8(4),
         }
+        hash.write_u8(u8::from(layer.object_visibility.instances));
+        hash.write_u8(u8::from(layer.object_visibility.pdn));
+        hash.write_u8(u8::from(layer.object_visibility.net));
         hash.write_u8(layer.style.fill_color.r);
         hash.write_u8(layer.style.fill_color.g);
         hash.write_u8(layer.style.fill_color.b);
@@ -2337,8 +2442,24 @@ fn is_context_shape(kind: ShapeKind) -> bool {
     )
 }
 
-fn is_stable_far_context_shape(kind: ShapeKind) -> bool {
-    matches!(kind, ShapeKind::Die | ShapeKind::Core)
+fn is_stable_far_context_shape(shape: &ShapeRecord) -> bool {
+    matches!(shape.kind, ShapeKind::Die | ShapeKind::Core)
+        || (shape.flags & SHAPE_FLAG_TOP_LEVEL_CONTEXT != 0
+            && matches!(
+                shape.kind,
+                ShapeKind::RegularWire | ShapeKind::SpecialWire | ShapeKind::Via
+            ))
+}
+
+fn is_wire_shape(kind: ShapeKind) -> bool {
+    matches!(kind, ShapeKind::RegularWire | ShapeKind::SpecialWire)
+}
+
+fn wire_frame_threshold_px(settings: RenderSettings) -> f32 {
+    settings
+        .frame_only_px
+        .min(settings.long_shape_px)
+        .max(settings.small_shape_px)
 }
 
 fn shape_kind_code(kind: ShapeKind) -> u8 {
@@ -2409,6 +2530,7 @@ mod tests {
     use layoutdb::{
         CellInstance, CellViewState, HierarchyPolicy, InstancePath, InstancePathElement, LayerInfo,
         LayoutDb, ObjectPathTarget, OverviewDensityBin, Rect, ShapeKind, ShapeRecord,
+        SHAPE_FLAG_TOP_LEVEL_CONTEXT,
     };
     use layoutpkg_format::{CellArray, Orientation, Transform};
 
@@ -2422,6 +2544,14 @@ mod tests {
         db.add_layer(LayerInfo::new(1, "M1"));
         let top = db.top_cell();
         db.add_shape(top, ShapeRecord::new(shape, 1, ShapeKind::RegularWire, 42));
+        db
+    }
+
+    fn one_shape_db_with_kind(shape: Rect, kind: ShapeKind) -> LayoutDb {
+        let mut db = LayoutDb::new("unit", Rect::new(0, 0, 1000, 1000));
+        db.add_layer(LayerInfo::new(1, "M1"));
+        let top = db.top_cell();
+        db.add_shape(top, ShapeRecord::new(shape, 1, kind, 42));
         db
     }
 
@@ -3003,6 +3133,28 @@ mod tests {
     }
 
     #[test]
+    fn object_visibility_can_hide_hierarchy_instance_bboxes() {
+        let db = hierarchy_db();
+        let mut model = one_layer_display_model();
+        model.object_visibility_mut().instances = false;
+
+        let plan = RenderPlanner::new(RenderSettings {
+            hierarchy_bbox_units_per_pixel: 100.0,
+            ..Default::default()
+        })
+        .plan(
+            &db,
+            &model,
+            Viewport::new(Rect::new(0, 0, 10_000, 10_000), 100.0, 100.0),
+        );
+
+        assert_eq!(plan.source, RenderPlanSource::HierarchyFar);
+        assert!(!hierarchy_item_bboxes(&plan)
+            .iter()
+            .any(|(_, source_id)| *source_id == 77));
+    }
+
+    #[test]
     fn far_top_view_does_not_render_die_and_core_frames() {
         let db = hierarchy_db_with_context_shapes();
         let model = DisplayModel::from_layout_layers(db.layers());
@@ -3158,14 +3310,13 @@ mod tests {
             Viewport::new(Rect::new(900, 1900, 1200, 2200), 30.0, 30.0),
         );
 
-        assert_eq!(plan.lod_stats.coarse, 1);
+        assert!(plan.lod_stats.coarse >= 1);
         assert!(hierarchy_item_bboxes(&plan)
             .iter()
             .any(|(_, source_id)| *source_id == 9));
-        assert!(!plan
-            .batches
-            .iter()
-            .any(|batch| batch.display_layer_id == "layer:1"));
+        assert!(!plan.batches.iter().any(|batch| {
+            batch.plane != RenderPlane::Hierarchy && batch.display_layer_id == "layer:1"
+        }));
     }
 
     #[test]
@@ -3436,6 +3587,109 @@ mod tests {
                     matches!(item, DrawItem::Rect(rect)
                         if rect.world == Rect::new(0, 0, 10_000, 10_000)
                             && rect.layer_id == 1)
+                })
+        }));
+    }
+
+    #[test]
+    fn hierarchy_far_preserves_visible_top_level_net_and_pdn_context() {
+        let mut db = hierarchy_db();
+        db.add_layer(LayerInfo::new(2, "M2"));
+        let top = db.top_cell();
+        let mut net = ShapeRecord::new(
+            Rect::new(500, 500, 8_000, 520),
+            1,
+            ShapeKind::RegularWire,
+            101,
+        );
+        net.flags |= SHAPE_FLAG_TOP_LEVEL_CONTEXT;
+        let mut pdn = ShapeRecord::new(
+            Rect::new(500, 800, 8_000, 840),
+            2,
+            ShapeKind::SpecialWire,
+            202,
+        );
+        pdn.flags |= SHAPE_FLAG_TOP_LEVEL_CONTEXT;
+        db.add_shape(top, net);
+        db.add_shape(top, pdn);
+        let mut model = DisplayModel::new();
+        model.add_layer(DisplayLayer::physical_layer(
+            1,
+            "M1",
+            LayerStyle::default_for_index(0),
+        ));
+        model.add_layer(DisplayLayer::physical_layer(
+            2,
+            "M2",
+            LayerStyle::default_for_index(1),
+        ));
+        let planner = RenderPlanner::new(RenderSettings {
+            hierarchy_bbox_units_per_pixel: 100.0,
+            hierarchy_coarse_units_per_pixel: 10.0,
+            ..Default::default()
+        });
+
+        let plan = planner.plan(
+            &db,
+            &model,
+            Viewport::new(Rect::new(0, 0, 10_000, 10_000), 100.0, 100.0),
+        );
+
+        assert_eq!(plan.source, RenderPlanSource::HierarchyFar);
+        assert!(plan.batches.iter().any(|batch| {
+            batch.plane == RenderPlane::Hierarchy
+                && batch.display_layer_id == "layer:1"
+                && batch.items.iter().any(|item| match item {
+                    DrawItem::Rect(rect) => rect.source_id == 101,
+                    DrawItem::Marker(marker) => marker.source_id == 101,
+                    DrawItem::Line(line) => line.source_id == 101,
+                })
+        }));
+        assert!(plan.batches.iter().any(|batch| {
+            batch.plane == RenderPlane::Hierarchy
+                && batch.display_layer_id == "layer:2"
+                && batch.items.iter().any(|item| match item {
+                    DrawItem::Rect(rect) => rect.source_id == 202,
+                    DrawItem::Marker(marker) => marker.source_id == 202,
+                    DrawItem::Line(line) => line.source_id == 202,
+                })
+        }));
+    }
+
+    #[test]
+    fn hierarchy_far_ignores_unmarked_top_level_detail_wires_as_stable_context() {
+        let mut db = hierarchy_db();
+        let top = db.top_cell();
+        db.add_shape(
+            top,
+            ShapeRecord::new(
+                Rect::new(500, 500, 8_000, 520),
+                1,
+                ShapeKind::RegularWire,
+                101,
+            ),
+        );
+        let model = one_layer_display_model();
+        let planner = RenderPlanner::new(RenderSettings {
+            hierarchy_bbox_units_per_pixel: 100.0,
+            hierarchy_coarse_units_per_pixel: 10.0,
+            ..Default::default()
+        });
+
+        let plan = planner.plan(
+            &db,
+            &model,
+            Viewport::new(Rect::new(0, 0, 10_000, 10_000), 100.0, 100.0),
+        );
+
+        assert_eq!(plan.source, RenderPlanSource::HierarchyFar);
+        assert!(!plan.batches.iter().any(|batch| {
+            batch.plane == RenderPlane::Hierarchy
+                && batch.display_layer_id == "layer:1"
+                && batch.items.iter().any(|item| match item {
+                    DrawItem::Rect(rect) => rect.source_id == 101,
+                    DrawItem::Marker(marker) => marker.source_id == 101,
+                    DrawItem::Line(line) => line.source_id == 101,
                 })
         }));
     }
@@ -3716,10 +3970,9 @@ mod tests {
             .any(|(bbox, source_id, layer_id)| *source_id == 330
                 && *layer_id == 0
                 && *bbox == Rect::new(1_150, 2_120, 1_170, 2_140)));
-        assert!(!plan
-            .batches
-            .iter()
-            .any(|batch| batch.display_layer_id == "layer:1"));
+        assert!(!plan.batches.iter().any(|batch| {
+            batch.plane != RenderPlane::Hierarchy && batch.display_layer_id == "layer:1"
+        }));
     }
 
     #[test]
@@ -3815,10 +4068,9 @@ mod tests {
             plan.lod_stats.exact + plan.lod_stats.frame_only + plan.lod_stats.marker,
             0
         );
-        assert!(!plan
-            .batches
-            .iter()
-            .any(|batch| batch.display_layer_id == "layer:1"));
+        assert!(!plan.batches.iter().any(|batch| {
+            batch.plane != RenderPlane::Hierarchy && batch.display_layer_id == "layer:1"
+        }));
     }
 
     #[test]
@@ -3887,7 +4139,7 @@ mod tests {
         );
 
         assert_eq!(plan.lod_stats.hierarchy_bbox, 1);
-        assert_eq!(plan.lod_stats.coarse, 0);
+        assert!(plan.lod_stats.coarse <= 1);
         assert_eq!(
             plan.lod_stats.exact + plan.lod_stats.frame_only + plan.lod_stats.marker,
             0
@@ -4296,6 +4548,23 @@ mod tests {
     }
 
     #[test]
+    fn pick_for_cell_view_skips_instance_targets_when_instances_are_hidden() {
+        let db = empty_instance_hierarchy_db();
+        let mut model = one_layer_display_model();
+        model.object_visibility_mut().instances = false;
+
+        let hit = RenderPlanner::new(RenderSettings::default()).pick_for_cell_view(
+            &db,
+            &model,
+            PickRequest::new(1250, 2440, 1),
+            &CellViewState::top(&db),
+            &HierarchyPolicy::default(),
+        );
+
+        assert!(hit.is_none());
+    }
+
+    #[test]
     fn pick_shape_hit_wins_over_instance_hit_when_overlapping() {
         let db = overlapping_shape_and_instance_db();
         let model = one_layer_display_model();
@@ -4345,6 +4614,44 @@ mod tests {
         let db = one_shape_db(Rect::new(10, 10, 110, 110));
         let mut model = one_layer_display_model();
         model.layers_mut()[0].visible = false;
+
+        let hit = RenderPlanner::new(RenderSettings::default()).pick(
+            &db,
+            &model,
+            PickRequest::new(50, 50, 2),
+        );
+
+        assert!(hit.is_none());
+    }
+
+    #[test]
+    fn picking_respects_net_object_visibility() {
+        let db = one_shape_db_with_kind(Rect::new(10, 10, 110, 110), ShapeKind::RegularWire);
+        let mut model = one_layer_display_model();
+        assert!(RenderPlanner::new(RenderSettings::default())
+            .pick(&db, &model, PickRequest::new(50, 50, 2))
+            .is_some());
+
+        model.object_visibility_mut().net = false;
+
+        let hit = RenderPlanner::new(RenderSettings::default()).pick(
+            &db,
+            &model,
+            PickRequest::new(50, 50, 2),
+        );
+
+        assert!(hit.is_none());
+    }
+
+    #[test]
+    fn picking_respects_pdn_object_visibility() {
+        let db = one_shape_db_with_kind(Rect::new(10, 10, 110, 110), ShapeKind::SpecialWire);
+        let mut model = one_layer_display_model();
+        assert!(RenderPlanner::new(RenderSettings::default())
+            .pick(&db, &model, PickRequest::new(50, 50, 2))
+            .is_some());
+
+        model.object_visibility_mut().pdn = false;
 
         let hit = RenderPlanner::new(RenderSettings::default()).pick(
             &db,
@@ -4722,6 +5029,90 @@ mod tests {
     }
 
     #[test]
+    fn hierarchy_near_preserves_long_net_and_pdn_shapes_as_frames() {
+        let mut db = LayoutDb::new("unit", Rect::new(0, 0, 10_000, 10_000));
+        db.add_layer(LayerInfo::new(1, "M1"));
+        db.add_layer(LayerInfo::new(2, "M2"));
+        let leaf = db.add_cell("leaf", Rect::new(0, 0, 8_000, 2_000));
+        db.add_shape(
+            leaf,
+            ShapeRecord::new(
+                Rect::new(0, 100, 7_000, 120),
+                1,
+                ShapeKind::RegularWire,
+                101,
+            ),
+        );
+        db.add_shape(
+            leaf,
+            ShapeRecord::new(
+                Rect::new(0, 300, 7_000, 320),
+                2,
+                ShapeKind::SpecialWire,
+                202,
+            ),
+        );
+        db.add_instance(
+            db.top_cell(),
+            CellInstance {
+                id: 77,
+                name: "u0".to_string(),
+                child_cell: leaf,
+                transform: Transform {
+                    dx: 1_000,
+                    dy: 2_000,
+                    orient: Orientation::R0,
+                },
+                array: CellArray::default(),
+                bbox: Rect::new(1_000, 2_000, 9_000, 4_000),
+                source_id: 77,
+            },
+        );
+        let mut model = DisplayModel::new();
+        model.add_layer(DisplayLayer::physical_layer(
+            1,
+            "M1",
+            LayerStyle::default_for_index(0),
+        ));
+        model.add_layer(DisplayLayer::physical_layer(
+            2,
+            "M2",
+            LayerStyle::default_for_index(1),
+        ));
+
+        let plan = RenderPlanner::new(RenderSettings {
+            hierarchy_bbox_units_per_pixel: 160.0,
+            hierarchy_coarse_units_per_pixel: 32.0,
+            idle_detail_units_per_pixel: 96.0,
+            long_shape_px: 160.0,
+            ..Default::default()
+        })
+        .plan(
+            &db,
+            &model,
+            Viewport::new(Rect::new(0, 0, 10_000, 10_000), 117.37, 117.37),
+        );
+
+        assert_eq!(plan.source, RenderPlanSource::HierarchyNear);
+        assert!(plan.batches.iter().any(|batch| {
+            batch.plane == RenderPlane::Frame
+                && batch.display_layer_id == "layer:1"
+                && batch
+                    .items
+                    .iter()
+                    .any(|item| matches!(item, DrawItem::Rect(rect) if rect.source_id == 101))
+        }));
+        assert!(plan.batches.iter().any(|batch| {
+            batch.plane == RenderPlane::Frame
+                && batch.display_layer_id == "layer:2"
+                && batch
+                    .items
+                    .iter()
+                    .any(|item| matches!(item, DrawItem::Rect(rect) if rect.source_id == 202))
+        }));
+    }
+
+    #[test]
     fn far_view_keeps_large_shapes_hollow_until_fill_threshold() {
         let db = one_shape_db(Rect::new(0, 0, 10_000, 10_000));
         let model = one_layer_display_model();
@@ -4865,6 +5256,100 @@ mod tests {
             .batches
             .iter()
             .any(|batch| batch.display_layer_id == "layer:0"));
+    }
+
+    #[test]
+    fn object_visibility_can_hide_instances_without_hiding_physical_layers() {
+        let mut db = LayoutDb::new("unit", Rect::new(0, 0, 10_000, 10_000));
+        db.add_layer(LayerInfo::new(1, "M1"));
+        let top = db.top_cell();
+        db.add_shape(
+            top,
+            ShapeRecord::new(
+                Rect::new(1_000, 1_000, 9_000, 9_000),
+                0,
+                ShapeKind::Instance,
+                302,
+            ),
+        );
+        db.add_shape(
+            top,
+            ShapeRecord::new(Rect::new(2_000, 2_000, 8_000, 8_000), 1, ShapeKind::Via, 7),
+        );
+        let mut model = DisplayModel::from_layout_layers(db.layers());
+        model.object_visibility_mut().instances = false;
+
+        let plan = RenderPlanner::new(RenderSettings::default()).plan(
+            &db,
+            &model,
+            Viewport::new(Rect::new(0, 0, 10_000, 10_000), 400.0, 400.0),
+        );
+
+        assert!(!plan
+            .batches
+            .iter()
+            .any(|batch| batch.display_layer_id == "kind:Instance"));
+        assert!(plan
+            .batches
+            .iter()
+            .any(|batch| batch.display_layer_id == "layer:1"));
+    }
+
+    #[test]
+    fn object_visibility_filters_net_and_pdn_shapes_on_physical_layers() {
+        let mut db = LayoutDb::new("unit", Rect::new(0, 0, 10_000, 10_000));
+        db.add_layer(LayerInfo::new(1, "M1"));
+        let top = db.top_cell();
+        db.add_shape(
+            top,
+            ShapeRecord::new(
+                Rect::new(1_000, 1_000, 4_000, 4_000),
+                1,
+                ShapeKind::RegularWire,
+                101,
+            ),
+        );
+        db.add_shape(
+            top,
+            ShapeRecord::new(
+                Rect::new(5_000, 5_000, 8_000, 8_000),
+                1,
+                ShapeKind::SpecialWire,
+                202,
+            ),
+        );
+        db.add_shape(
+            top,
+            ShapeRecord::new(
+                Rect::new(8_500, 8_500, 9_000, 9_000),
+                1,
+                ShapeKind::Via,
+                303,
+            ),
+        );
+        let mut model = DisplayModel::from_layout_layers(db.layers());
+        model.object_visibility_mut().net = false;
+        model.object_visibility_mut().pdn = false;
+
+        let plan = RenderPlanner::new(RenderSettings::default()).plan(
+            &db,
+            &model,
+            Viewport::new(Rect::new(0, 0, 10_000, 10_000), 400.0, 400.0),
+        );
+        let rendered_sources = plan
+            .batches
+            .iter()
+            .flat_map(|batch| batch.items.iter())
+            .filter_map(|item| match item {
+                DrawItem::Rect(rect) => Some(rect.source_id),
+                DrawItem::Marker(marker) => Some(marker.source_id),
+                DrawItem::Line(line) => Some(line.source_id),
+            })
+            .collect::<std::collections::HashSet<_>>();
+
+        assert!(!rendered_sources.contains(&101));
+        assert!(!rendered_sources.contains(&202));
+        assert!(rendered_sources.contains(&303));
     }
 
     #[test]

--- a/ecos/layout-viewer/crates/layoutdb/src/lib.rs
+++ b/ecos/layout-viewer/crates/layoutdb/src/lib.rs
@@ -14,6 +14,7 @@ use layoutpkg_format::{
 use rstar::{RTree, RTreeObject, AABB};
 
 const EXPANDED_ARRAY_INSTANCE_THRESHOLD: u64 = 1;
+pub const SHAPE_FLAG_TOP_LEVEL_CONTEXT: u8 = 0x80;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Rect {
@@ -2808,20 +2809,33 @@ impl LayoutSession {
         }
         let layers_load = layers_started.elapsed();
         ensure_die_core_overlay_shapes(&mut db, source.package.boundaries());
+        let startup_large_objects = source.package.load_large_objects_only()?;
+        let startup_large_object_count = startup_large_objects.records.len();
+        let top_cell = db.top_cell();
+        for record in startup_large_objects.records.iter() {
+            let mut shape = ShapeRecord::from(record);
+            shape.flags |= SHAPE_FLAG_TOP_LEVEL_CONTEXT;
+            db.add_shape(top_cell, shape);
+        }
+        let detail_revision = if startup_large_object_count > 0 { 1 } else { 0 };
         Ok((
             Self {
                 source,
                 db,
                 loaded_detail_tiles: HashSet::new(),
-                large_objects_loaded: false,
+                large_objects_loaded: true,
                 detail_scopes: None,
                 overview_loaded: false,
                 applied_overview_units_per_bin: None,
-                last_load_stats: ViewportLoadStats::default(),
-                revision: 0,
+                last_load_stats: ViewportLoadStats {
+                    loaded_shapes: startup_large_object_count,
+                    new_shapes: startup_large_object_count,
+                    ..Default::default()
+                },
+                revision: detail_revision,
                 hierarchy_revision: 0,
                 overview_revision: 0,
-                detail_revision: 0,
+                detail_revision,
             },
             LayoutSessionLoadProfile {
                 total: total_started.elapsed(),
@@ -3150,6 +3164,99 @@ mod tests {
             detail_grid_columns: 2,
             detail_grid_rows: 2,
             max_tiles_per_object: 16,
+            target_primitives_per_tile: 6000,
+            max_subdivision_depth: 4,
+        })
+        .unwrap();
+
+        (tmp, output)
+    }
+
+    fn create_layoutpkg_with_top_level_large_wire() -> (TempDir, std::path::PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("design")).unwrap();
+        write_json(
+            &root.join("manifest.json"),
+            json!({
+                "schema": "ieda.view.v1",
+                "format": "layout_view_package",
+                "design_name": "large-wire-unit",
+                "unit": { "dbu_per_micron": 1000 },
+                "bbox": [0, 0, 1000, 1000],
+                "files": {
+                    "die": "design/die.json",
+                    "layers": "design/layers.json",
+                    "instances": "design/instances.json",
+                    "regular_wires": "design/regular_wires.json",
+                    "special_wires": "design/special_wires.json",
+                    "io_pins": "design/io_pins.json",
+                    "blockages": "design/blockages.json",
+                    "fills": "design/fills.json",
+                    "regions": "design/regions.json",
+                    "rows": "design/rows.json",
+                    "tracks": "design/tracks.json",
+                    "gcell_grids": "design/gcell_grids.json"
+                }
+            }),
+        );
+        write_json(
+            &root.join("design/die.json"),
+            json!({
+                "schema": "ieda.view.v1",
+                "kind": "die",
+                "data": { "die_area": [0, 0, 1000, 1000], "core_area": [100, 100, 900, 900] }
+            }),
+        );
+        write_json(
+            &root.join("design/layers.json"),
+            json!({
+                "schema": "ieda.view.v1",
+                "kind": "layers",
+                "data": [{ "id": 1, "name": "M1", "type": "routing", "direction": "HORIZONTAL" }]
+            }),
+        );
+        write_json(
+            &root.join("design/instances.json"),
+            json!({
+                "schema": "ieda.view.v1",
+                "kind": "instances",
+                "data": []
+            }),
+        );
+        write_json(
+            &root.join("design/regular_wires.json"),
+            json!({
+                "schema": "ieda.view.v1",
+                "kind": "regular_wires",
+                "data": [
+                    { "id": 44, "kind": "path", "layer_id": 1, "width": 10, "points": [[0, 500], [1000, 500]] }
+                ]
+            }),
+        );
+        for file in [
+            "special_wires",
+            "io_pins",
+            "blockages",
+            "fills",
+            "regions",
+            "rows",
+            "tracks",
+            "gcell_grids",
+        ] {
+            write_json(
+                &root.join(format!("design/{file}.json")),
+                json!({ "schema": "ieda.view.v1", "kind": file, "data": [] }),
+            );
+        }
+
+        let output = root.join(".layoutpkg");
+        pack_viewjson_to_layoutpkg(PackLayoutPackageOptions {
+            input_root: root.to_path_buf(),
+            output_root: output.clone(),
+            detail_grid_columns: 4,
+            detail_grid_rows: 4,
+            max_tiles_per_object: 2,
             target_primitives_per_tile: 6000,
             max_subdivision_depth: 4,
         })
@@ -4888,6 +4995,29 @@ mod tests {
 
         assert_eq!(session.loaded_detail_tile_count(), 0);
         assert_eq!(session.db().package_layer_counts().get(&1), Some(&2));
+    }
+
+    #[test]
+    fn layout_session_imports_top_level_large_objects_on_startup_without_detail_tiles() {
+        let (_input, package_root) = create_layoutpkg_with_top_level_large_wire();
+        let source = PackageLayoutSource::open(package_root, 64).unwrap();
+        let session = LayoutSession::from_source(source).unwrap();
+        let top_shapes = session
+            .db()
+            .query_shapes(session.db().top_cell(), session.db().world_bbox());
+
+        assert_eq!(session.loaded_detail_tile_count(), 0);
+        assert!(top_shapes.iter().any(|shape| {
+            shape.source_id == 44
+                && shape.kind == ShapeKind::RegularWire
+                && shape.layer_id == 1
+                && shape.flags & 0x80 != 0
+                && shape.bbox.x1 <= 0
+                && shape.bbox.x2 >= 1000
+                && shape.bbox.y1 <= 500
+                && shape.bbox.y2 >= 500
+        }));
+        assert!(session.detail_revision() > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove the layout viewer hierarchy module from the right sidebar and keep the sidebar focused on layers, object visibility, and selection.
- Add object visibility controls for Instances, PDN, and Net, including render cache, LOD, and picking behavior for hidden objects.
- Load large top-level net/PDN context at startup and keep debug-only LOD/render diagnostics out of release builds.

## Touched Area
- `ecos/layout-viewer/apps/layout-viewer-native`
- `ecos/layout-viewer/crates/layout-display`
- `ecos/layout-viewer/crates/layout-render`
- `ecos/layout-viewer/crates/layoutdb`

## Validation
- `cargo fmt --all --check`
- `cargo test -p layout-display`
- `cargo test -p layout-render`
- `cargo test -p layoutdb`
- `cargo test -p layout-viewer-native`
- `cargo test -p layout-viewer-native --release debug_panel_is_visible_only_in_debug_builds`
- `git diff --check origin/main..HEAD`

## Screenshots

<img width="1601" height="1041" alt="image" src="https://github.com/user-attachments/assets/1b2b06db-9f57-477f-8c4d-aeb64dbf6683" />

## Submodules
- No submodule gitlink changes are included in this PR.
