### PR TITLE
feat(gui): add fullscreen panels and cli logs

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.test.ts
@@ -1,9 +1,18 @@
 import { EventEmitter } from 'node:events'
 import type { spawn as spawnChild } from 'node:child_process'
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DesktopCliCommandRequest } from '@ecos-studio/shared'
 import { EccCliAdapter } from './eccCliAdapter'
 import { electronLogger } from './logger'
@@ -70,10 +79,16 @@ async function waitForSpawn(harness: ReturnType<typeof createSpawnHarness>, inde
 describe('EccCliAdapter', () => {
   const tempDirs: string[] = []
 
+  beforeEach(() => {
+    vi.spyOn(electronLogger, 'status').mockImplementation(() => undefined)
+  })
+
   afterEach(() => {
     for (const directory of tempDirs.splice(0)) {
       rmSync(directory, { force: true, recursive: true })
     }
+    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   function createTempDir(prefix = 'ecos-ecc-adapter-'): string {
@@ -464,6 +479,181 @@ describe('EccCliAdapter', () => {
       text: 'warning text\n',
       type: 'stderr',
     })
+  })
+
+  it('tees ECC CLI stdout and stderr to a workspace command log without disrupting JSON results', async () => {
+    const workspaceDir = createTempDir('ecos-ecc-workspace-')
+    const harness = createSpawnHarness()
+    const emit = vi.fn()
+    const adapter = new EccCliAdapter({ spawn: harness.spawn })
+    const promise = adapter.execute(request('run_step', {
+      directory: workspaceDir,
+      step: 'Place',
+    }), { emit })
+
+    harness.children[0].stdout.emit('data', 'preparing dreamplace\n')
+    harness.children[0].stderr.emit('data', 'CMake Error at cmake/TorchExtension.cmake:19\n')
+    complete(harness.children[0], {
+      cmd: 'run_step',
+      data: { state: 'Success', step: 'Place' },
+      message: ['done'],
+      response: 'success',
+    })
+
+    const result = await promise
+
+    expect(result).toMatchObject({
+      data: {
+        cli_log_file: expect.stringContaining(`${workspaceDir}/log/ecc-cli-`),
+        state: 'Success',
+        step: 'Place',
+      },
+      ok: true,
+      response: 'success',
+    })
+
+    const logFiles = readdirSync(join(workspaceDir, 'log'))
+      .filter((name) => /^ecc-cli-\d{8}-\d{6}-run_step-[a-z0-9-]+\.log$/.test(name))
+    expect(logFiles).toHaveLength(1)
+
+    const logText = readFileSync(join(workspaceDir, 'log', logFiles[0]), 'utf8')
+    expect(logText).toContain('[command] ecc workspace run-step')
+    expect(logText).toContain('[stdout] preparing dreamplace')
+    expect(logText).toContain('[stderr] CMake Error at cmake/TorchExtension.cmake:19')
+    expect(logText).toContain('[exit] code=0 signal=null')
+  })
+
+  it('does not create a target workspace directory just to store create_workspace logs', async () => {
+    const tempDir = createTempDir('ecos-ecc-temp-')
+    const workspaceDir = join(tempDir, 'new workspace')
+    const harness = createSpawnHarness()
+    const adapter = new EccCliAdapter({
+      spawn: harness.spawn,
+      tempDir,
+    })
+    const promise = adapter.execute(request('create_workspace', {
+      directory: workspaceDir,
+      pdk: 'ics55',
+      parameters: { Design: 'demo' },
+    }), { emit: vi.fn() })
+
+    expect(existsSync(workspaceDir)).toBe(false)
+
+    complete(harness.children[0], {
+      cmd: 'create_workspace',
+      data: { directory: workspaceDir },
+      message: ['created'],
+      response: 'success',
+    })
+
+    const result = await promise
+
+    expect(result.data.cli_log_file).toEqual(expect.stringContaining(`${tempDir}/ecos-ecc-cli-logs/ecc-cli-`))
+    expect(existsSync(workspaceDir)).toBe(false)
+  })
+
+  it('keeps separate command logs for same-command runs that start in the same second', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-29T10:00:00.000Z'))
+
+    const workspaceDir = createTempDir('ecos-ecc-workspace-')
+    const harness = createSpawnHarness()
+    const adapter = new EccCliAdapter({ spawn: harness.spawn })
+
+    const first = adapter.execute(request('run_step', {
+      directory: workspaceDir,
+      step: 'Place',
+    }), { emit: vi.fn() })
+    complete(harness.children[0], {
+      cmd: 'run_step',
+      data: { state: 'Success', step: 'Place' },
+      message: ['first'],
+      response: 'success',
+    })
+    await first
+
+    const second = adapter.execute(request('run_step', {
+      directory: workspaceDir,
+      step: 'Place',
+    }), { emit: vi.fn() })
+    complete(harness.children[1], {
+      cmd: 'run_step',
+      data: { state: 'Success', step: 'Place' },
+      message: ['second'],
+      response: 'success',
+    })
+    await second
+
+    const logFiles = readdirSync(join(workspaceDir, 'log'))
+      .filter((name) => /^ecc-cli-\d{8}-\d{6}-run_step-[a-z0-9-]+\.log$/.test(name))
+    expect(logFiles).toHaveLength(2)
+  })
+
+  it('quotes command log argv so paths with spaces can be copied back to a shell', async () => {
+    const rootDir = createTempDir('ecos-ecc-workspace-root-')
+    const workspaceDir = join(rootDir, "workspace with space's")
+    mkdirSync(workspaceDir, { recursive: true })
+    const harness = createSpawnHarness()
+    const adapter = new EccCliAdapter({ spawn: harness.spawn })
+    const promise = adapter.execute(request('run_step', {
+      directory: workspaceDir,
+      step: 'Place',
+    }), { emit: vi.fn() })
+
+    complete(harness.children[0], {
+      cmd: 'run_step',
+      data: { state: 'Success', step: 'Place' },
+      message: ['done'],
+      response: 'success',
+    })
+    const result = await promise
+
+    const logText = readFileSync(String(result.data.cli_log_file), 'utf8')
+    expect(logText).toContain(`--directory '${workspaceDir.replace(/'/g, "'\\''")}'`)
+  })
+
+  it('announces the ECC CLI command log path in terminal output and repeats it on failure', async () => {
+    const workspaceDir = createTempDir('ecos-ecc-workspace-')
+    const harness = createSpawnHarness()
+    const emit = vi.fn()
+    const adapter = new EccCliAdapter({ spawn: harness.spawn })
+    const promise = adapter.execute(request('run_step', {
+      directory: workspaceDir,
+      step: 'CTS',
+    }), { emit })
+
+    const startMessage = emit.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.stream === 'stdout'
+        && event.type === 'stdout'
+        && event.text?.includes('[ECC CLI log] Writing full command log to:'))
+    expect(startMessage?.text).toContain(`${workspaceDir}/log/ecc-cli-`)
+    expect(electronLogger.status).toHaveBeenCalledWith(
+      '[ECC CLI log] Writing full command log to: %s',
+      expect.stringContaining(`${workspaceDir}/log/ecc-cli-`),
+    )
+
+    harness.children[0].stderr.emit('data', 'tool failed\n')
+    harness.children[0].emit('close', 1, null)
+
+    await expect(promise).resolves.toMatchObject({
+      ok: false,
+      response: 'error',
+    })
+    expect(emit).toHaveBeenCalledWith({
+      stream: 'stderr',
+      text: expect.stringContaining('[ECC CLI log] Command failed. Full log:'),
+      type: 'stderr',
+    })
+    expect(emit).toHaveBeenCalledWith({
+      stream: 'stderr',
+      text: expect.stringContaining(`${workspaceDir}/log/ecc-cli-`),
+      type: 'stderr',
+    })
+    expect(electronLogger.status).toHaveBeenCalledWith(
+      '[ECC CLI log] Command failed. Full log: %s',
+      expect.stringContaining(`${workspaceDir}/log/ecc-cli-`),
+    )
   })
 
   it('preserves structured data from CLI lifecycle event records', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.ts
@@ -1,6 +1,7 @@
 import { spawn as spawnChild } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { appendFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import type {
@@ -219,6 +220,128 @@ function resolveEccWrapperFallback(): string | null {
   return existsSync(wrapperPath) ? wrapperPath : null
 }
 
+function timestampForFile(date = new Date()): string {
+  const pad = (value: number): string => String(value).padStart(2, '0')
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+  ].join('') + '-' + [
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds()),
+  ].join('')
+}
+
+function safeLogToken(value: string): string {
+  const normalized = value.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '')
+  return normalized || 'command'
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_/@%+=:,.-]+$/.test(value)) {
+    return value
+  }
+
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+function commandLine(command: string, args: string[]): string {
+  return [command, ...args].map(shellQuote).join(' ')
+}
+
+function withCliLogFile(
+  resultValue: DesktopCliCommandResult,
+  cliLogFile: string | null,
+): DesktopCliCommandResult {
+  if (!cliLogFile) return resultValue
+  return {
+    ...resultValue,
+    data: {
+      ...resultValue.data,
+      cli_log_file: cliLogFile,
+    },
+  }
+}
+
+function cliLogStartText(path: string): string {
+  return `[ECC CLI log] Writing full command log to:\n${path}\n`
+}
+
+function cliLogFailedText(path: string): string {
+  return `[ECC CLI log] Command failed. Full log:\n${path}\n`
+}
+
+class CliCommandLog {
+  readonly path: string | null
+  private pendingWrite = Promise.resolve()
+
+  constructor(
+    request: DesktopCliCommandRequest,
+    private readonly prepared: PreparedCommand,
+    private readonly command: string,
+    activeWorkspace: string | null,
+    tempDir: string,
+  ) {
+    const workspaceDirectory = directoryFromRequest(request, activeWorkspace)
+    const filename = `ecc-cli-${timestampForFile()}-${safeLogToken(request.cmd)}-${randomUUID().slice(0, 8)}.log`
+    const fallbackLogDir = join(tempDir, 'ecos-ecc-cli-logs')
+    const canUseWorkspaceLog = request.cmd !== 'create_workspace'
+      && Boolean(workspaceDirectory)
+      && existsSync(workspaceDirectory)
+    const logDirs = canUseWorkspaceLog
+      ? [join(workspaceDirectory, 'log'), fallbackLogDir]
+      : [fallbackLogDir]
+
+    let lastError: unknown = null
+    for (const logDir of logDirs) {
+      const logPath = join(logDir, filename)
+      try {
+        mkdirSync(logDir, { recursive: true })
+        writeFileSync(logPath, '', { encoding: 'utf8', flag: 'wx' })
+        this.path = logPath
+        this.append('command', commandLine(this.command, this.prepared.args))
+        return
+      } catch (error) {
+        lastError = error
+      }
+    }
+
+    this.path = null
+    electronLogger.warn(
+      '[ECC CLI] failed to create command log: %s',
+      lastError instanceof Error ? lastError.message : String(lastError),
+    )
+  }
+
+  append(section: string, text: string): void {
+    if (!this.path) return
+    const logPath = this.path
+    const lines = text.endsWith('\n') ? text : `${text}\n`
+    this.pendingWrite = this.pendingWrite
+      .then(() => appendFile(logPath, `[${section}] ${lines}`, 'utf8'))
+      .catch((error) => {
+        electronLogger.warn(
+          '[ECC CLI] failed to write command log at %s: %s',
+          logPath,
+          error instanceof Error ? error.message : String(error),
+        )
+      })
+  }
+
+  async flush(): Promise<void> {
+    try {
+      await this.pendingWrite
+    } catch (error) {
+      electronLogger.warn(
+        '[ECC CLI] failed to write command log at %s: %s',
+        this.path,
+        error instanceof Error ? error.message : String(error),
+      )
+    }
+  }
+}
+
 export class EccCliAdapter {
   private readonly command: string
   private readonly env: NodeJS.ProcessEnv
@@ -398,6 +521,7 @@ export class EccCliAdapter {
       let stdoutBuffer = ''
       let stderrText = ''
       let invalidJsonLine: string | null = null
+      let failureLogAnnounced = false
       const start = Date.now()
       const resolvedCommand = resolveCommandFromPath(this.command, env)
       const fallbackCommand = !this.isPackaged
@@ -406,6 +530,46 @@ export class EccCliAdapter {
         ? resolveEccWrapperFallback()
         : null
       const spawnCommand = fallbackCommand ?? this.command
+      const commandLog = new CliCommandLog(
+        request,
+        prepared,
+        spawnCommand,
+        this.activeWorkspace,
+        this.tempDir,
+      )
+
+      const emitText = (stream: 'stdout' | 'stderr', text: string): void => {
+        context.emit({
+          stream,
+          text,
+          type: stream,
+        })
+      }
+
+      const announceCliLogStart = (): void => {
+        if (!commandLog.path) return
+        emitText('stdout', cliLogStartText(commandLog.path))
+        electronLogger.status(
+          '[ECC CLI log] Writing full command log to: %s',
+          commandLog.path,
+        )
+      }
+
+      const announceCliLogFailure = (): void => {
+        if (!commandLog.path || failureLogAnnounced) return
+        failureLogAnnounced = true
+        emitText('stderr', cliLogFailedText(commandLog.path))
+        electronLogger.status(
+          '[ECC CLI log] Command failed. Full log: %s',
+          commandLog.path,
+        )
+      }
+
+      const resolveAfterLogFlush = (resultValue: DesktopCliCommandResult): void => {
+        void commandLog.flush().finally(() => {
+          resolve(resultValue)
+        })
+      }
 
       electronLogger.debug(
         '[ECC CLI] spawn command=%s resolved=%s args=%s pathHead=%s',
@@ -420,13 +584,7 @@ export class EccCliAdapter {
         stdio: ['ignore', 'pipe', 'pipe'],
       })
 
-      const emitText = (stream: 'stdout' | 'stderr', text: string): void => {
-        context.emit({
-          stream,
-          text,
-          type: stream,
-        })
-      }
+      announceCliLogStart()
 
       const handleCliJson = (value: unknown): boolean => {
         if (isResultPayload(value)) {
@@ -482,7 +640,9 @@ export class EccCliAdapter {
       }
 
       child.stdout?.on('data', (data: unknown) => {
-        stdoutBuffer += dataToString(data)
+        const text = dataToString(data)
+        commandLog.append('stdout', text)
+        stdoutBuffer += text
         const lines = stdoutBuffer.split(/\r?\n/)
         stdoutBuffer = lines.pop() ?? ''
         for (const line of lines) {
@@ -492,18 +652,23 @@ export class EccCliAdapter {
 
       child.stderr?.on('data', (data: unknown) => {
         const text = dataToString(data)
+        commandLog.append('stderr', text)
         stderrText += text
         emitText('stderr', text)
       })
 
       child.once('error', (spawnError) => {
-        resolve(error(
+        const message = spawnError instanceof Error ? spawnError.message : String(spawnError)
+        commandLog.append('error', message)
+        announceCliLogFailure()
+        resolveAfterLogFlush(withCliLogFile(error(
           request,
-          spawnError instanceof Error ? spawnError.message : String(spawnError),
-        ))
+          message,
+        ), commandLog.path))
       })
 
       child.once('close', (code, signal) => {
+        commandLog.append('exit', `code=${code ?? 'unknown'} signal=${signal ?? 'null'}`)
         const remaining = stdoutBuffer.trim()
         if (remaining) {
           try {
@@ -524,19 +689,26 @@ export class EccCliAdapter {
             finalResult.response,
             Date.now() - start,
           )
-          resolve(finalResult)
+          if (!finalResult.ok) {
+            announceCliLogFailure()
+          }
+          resolveAfterLogFlush(withCliLogFile(finalResult, commandLog.path))
           return
         }
 
         if (code === 0 && invalidJsonLine) {
-          const result = error(request, `Invalid JSON from ECC CLI: ${invalidJsonLine}`)
+          const result = withCliLogFile(
+            error(request, `Invalid JSON from ECC CLI: ${invalidJsonLine}`),
+            commandLog.path,
+          )
           electronLogger.debug(
             '[ECC CLI] completed cmd=%s response=%s elapsed=%dms',
             request.cmd,
             result.response,
             Date.now() - start,
           )
-          resolve(result)
+          announceCliLogFailure()
+          resolveAfterLogFlush(result)
           return
         }
 
@@ -544,14 +716,18 @@ export class EccCliAdapter {
           ? `ECC CLI exited with signal ${signal}.`
           : `ECC CLI exited with code ${code ?? 'unknown'}.`
         const details = stderrText.trim() || invalidJsonLine || exitText
-        const result = error(request, details === exitText ? exitText : `${exitText} ${details}`)
+        const result = withCliLogFile(
+          error(request, details === exitText ? exitText : `${exitText} ${details}`),
+          commandLog.path,
+        )
         electronLogger.debug(
           '[ECC CLI] completed cmd=%s response=%s elapsed=%dms',
           request.cmd,
           result.response,
           Date.now() - start,
         )
-        resolve(result)
+        announceCliLogFailure()
+        resolveAfterLogFlush(result)
       })
     })
   }

--- a/ecos/gui/apps/renderer/src/components/ChatInspectorPanel.fullscreen.test.ts
+++ b/ecos/gui/apps/renderer/src/components/ChatInspectorPanel.fullscreen.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import chatInspectorSource from './ChatInspectorPanel.vue?raw'
+import messageItemSource from './MessageItem.vue?raw'
+
+describe('ChatInspectorPanel fullscreen controls', () => {
+  it('adds fullscreen support for chat and step configuration panels', () => {
+    expect(chatInspectorSource).toContain('chat-inspector-fullscreen-toggle')
+    expect(chatInspectorSource).toContain('panel-fullscreen-overlay')
+    expect(chatInspectorSource).toContain('panel-fullscreen-card')
+    expect(chatInspectorSource).toContain('isChatFullscreen')
+    expect(chatInspectorSource).toContain('isStepConfigFullscreen')
+    expect(chatInspectorSource).toContain('openPanelFullscreen')
+    expect(chatInspectorSource).toContain('closePanelFullscreen')
+    expect(chatInspectorSource).toContain('View AI Chat full screen')
+    expect(chatInspectorSource).toContain('View step configuration full screen')
+  })
+
+  it('keeps the outer panel open when an inner chat lightbox consumes Escape', () => {
+    expect(messageItemSource).toContain('e.preventDefault()')
+    expect(messageItemSource).toContain('e.stopPropagation()')
+    expect(chatInspectorSource).toContain('event.defaultPrevented')
+  })
+})

--- a/ecos/gui/apps/renderer/src/components/ChatInspectorPanel.vue
+++ b/ecos/gui/apps/renderer/src/components/ChatInspectorPanel.vue
@@ -1,36 +1,71 @@
 <template>
-  <div class="chat-inspector-panel flex flex-col h-full w-full min-w-0 max-w-full bg-(--bg-primary) overflow-hidden">
-    <div class="h-10 shrink-0 flex items-center gap-2 px-3 border-b border-(--border-color)">
-      <button type="button" @click="activeTab = 'chat'" :class="tabClass(activeTab === 'chat')" title="AI Chat">
-        <i class="ri-chat-3-line text-base"></i>
-      </button>
-      <button
-        v-if="showStepConfigInspector"
-        type="button"
-        @click="activeTab = 'inspector'"
-        :class="tabClass(activeTab === 'inspector')"
-        title="Configuration"
-      >
-        <i class="ri-layout-column-line text-base"></i>
-      </button>
-    </div>
+  <Teleport to="body" :disabled="!isAnyPanelFullscreen">
+    <div
+      :class="[
+        'chat-inspector-panel flex flex-col h-full w-full min-w-0 max-w-full bg-(--bg-primary) overflow-hidden',
+        {
+          'is-panel-fullscreen panel-fullscreen-card': isAnyPanelFullscreen,
+          'is-chat-fullscreen': isChatFullscreen,
+          'is-step-config-fullscreen': isStepConfigFullscreen,
+        },
+      ]"
+    >
+      <div class="chat-inspector-topbar h-10 shrink-0 flex items-center gap-2 px-3 border-b border-(--border-color)">
+        <div class="chat-inspector-tabs flex items-center gap-2 min-w-0">
+          <button type="button" @click="selectTab('chat')" :class="tabClass(activeTab === 'chat')" title="AI Chat">
+            <i class="ri-chat-3-line text-base"></i>
+          </button>
+          <button
+            v-if="showStepConfigInspector"
+            type="button"
+            @click="selectTab('inspector')"
+            :class="tabClass(activeTab === 'inspector')"
+            title="Configuration"
+          >
+            <i class="ri-layout-column-line text-base"></i>
+          </button>
+        </div>
 
-    <div class="flex-1 min-h-0 min-w-0 overflow-hidden flex flex-col">
-      <!-- KeepAlive：避免 v-if 销毁聊天导致 blob 图重新加载/裂图；状态与滚动由子组件 onActivated 恢复 -->
-      <KeepAlive>
-        <AIChatPanel v-if="activeTab === 'chat'" class="flex-1 min-h-0 h-full min-w-0 w-full max-w-full overflow-hidden" />
-      </KeepAlive>
+        <button
+          type="button"
+          class="chat-inspector-fullscreen-toggle"
+          :title="activePanelFullscreen ? 'Exit full screen' : 'Full screen'"
+          :aria-label="activePanelFullscreen
+            ? (activeTab === 'chat' ? 'Exit AI Chat full screen' : 'Exit step configuration full screen')
+            : (activeTab === 'chat' ? 'View AI Chat full screen' : 'View step configuration full screen')"
+          @click="toggleActivePanelFullscreen"
+        >
+          <i :class="activePanelFullscreen ? 'ri-fullscreen-exit-line' : 'ri-fullscreen-line'"></i>
+        </button>
+      </div>
 
-      <StepConfigPanel
-        v-if="activeTab === 'inspector' && showStepConfigInspector"
-        class="flex-1 min-h-0 flex flex-col h-full min-w-0 overflow-hidden"
-      />
+      <div class="flex-1 min-h-0 min-w-0 overflow-hidden flex flex-col">
+        <!-- KeepAlive：避免 v-if 销毁聊天导致 blob 图重新加载/裂图；状态与滚动由子组件 onActivated 恢复 -->
+        <KeepAlive>
+          <AIChatPanel v-if="activeTab === 'chat'" class="flex-1 min-h-0 h-full min-w-0 w-full max-w-full overflow-hidden" />
+        </KeepAlive>
+
+        <StepConfigPanel
+          v-if="activeTab === 'inspector' && showStepConfigInspector"
+          class="flex-1 min-h-0 flex flex-col h-full min-w-0 overflow-hidden"
+        />
+      </div>
     </div>
-  </div>
+  </Teleport>
+
+  <Teleport to="body">
+    <Transition name="panel-fullscreen-backdrop">
+      <div
+        v-if="isAnyPanelFullscreen"
+        class="panel-fullscreen-overlay"
+        @click="closePanelFullscreen"
+      ></div>
+    </Transition>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { StepEnum } from '@/api/type'
 import AIChatPanel from './AIChatPanel.vue'
@@ -48,6 +83,13 @@ function stepFromRoutePath(): StepEnum | undefined {
 const showStepConfigInspector = computed(() => stepFromRoutePath() !== StepEnum.SYNTHESIS)
 
 const activeTab = ref<'chat' | 'inspector'>('chat')
+const isChatFullscreen = ref(false)
+const isStepConfigFullscreen = ref(false)
+
+const isAnyPanelFullscreen = computed(() => isChatFullscreen.value || isStepConfigFullscreen.value)
+const activePanelFullscreen = computed(() =>
+  activeTab.value === 'chat' ? isChatFullscreen.value : isStepConfigFullscreen.value,
+)
 
 watch(
   () => route.path,
@@ -55,8 +97,56 @@ watch(
     if (!showStepConfigInspector.value && activeTab.value === 'inspector') {
       activeTab.value = 'chat'
     }
+    if (!showStepConfigInspector.value && isStepConfigFullscreen.value) {
+      closePanelFullscreen()
+    }
   },
 )
+
+function selectTab(tab: 'chat' | 'inspector'): void {
+  if (tab === 'inspector' && !showStepConfigInspector.value) return
+  activeTab.value = tab
+
+  if (isAnyPanelFullscreen.value) {
+    openPanelFullscreen(tab)
+  }
+}
+
+function openPanelFullscreen(panel: 'chat' | 'inspector'): void {
+  if (panel === 'inspector' && !showStepConfigInspector.value) return
+
+  activeTab.value = panel
+  isChatFullscreen.value = panel === 'chat'
+  isStepConfigFullscreen.value = panel === 'inspector'
+}
+
+function closePanelFullscreen(): void {
+  isChatFullscreen.value = false
+  isStepConfigFullscreen.value = false
+}
+
+function toggleActivePanelFullscreen(): void {
+  if (activePanelFullscreen.value) {
+    closePanelFullscreen()
+    return
+  }
+  openPanelFullscreen(activeTab.value)
+}
+
+function onFullscreenKeydown(event: KeyboardEvent): void {
+  if (event.defaultPrevented) return
+  if (event.key !== 'Escape' || !isAnyPanelFullscreen.value) return
+  closePanelFullscreen()
+  event.preventDefault()
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onFullscreenKeydown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', onFullscreenKeydown)
+})
 
 function tabClass(active: boolean) {
   return [
@@ -72,5 +162,74 @@ function tabClass(active: boolean) {
 /* Do not use contain: size — it can zero out nested flex height and black out content */
 .chat-inspector-panel {
   box-sizing: border-box;
+}
+
+.chat-inspector-panel.is-panel-fullscreen {
+  position: fixed;
+  inset: 12px;
+  z-index: 20000;
+  width: calc(100vw - 24px) !important;
+  height: calc(100vh - 24px) !important;
+  max-width: none !important;
+  min-width: 0;
+  min-height: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 0;
+  box-shadow: 0 28px 80px rgba(15, 23, 42, 0.34);
+}
+
+.chat-inspector-topbar {
+  justify-content: space-between;
+}
+
+.chat-inspector-tabs {
+  flex: 1 1 auto;
+}
+
+.chat-inspector-fullscreen-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  cursor: pointer;
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease,
+    transform 0.16s ease;
+}
+
+.chat-inspector-fullscreen-toggle:hover {
+  color: var(--accent-color);
+  border-color: var(--accent-color);
+  background: color-mix(in srgb, var(--accent-color) 8%, var(--bg-primary));
+  transform: translateY(-1px);
+}
+
+.chat-inspector-fullscreen-toggle:active {
+  transform: translateY(0);
+}
+
+.panel-fullscreen-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 19995;
+  background: rgba(0, 0, 0, 0.78);
+}
+
+.panel-fullscreen-backdrop-enter-active,
+.panel-fullscreen-backdrop-leave-active {
+  transition: opacity 0.18s ease-out;
+}
+
+.panel-fullscreen-backdrop-enter-from,
+.panel-fullscreen-backdrop-leave-to {
+  opacity: 0;
 }
 </style>

--- a/ecos/gui/apps/renderer/src/components/MessageItem.vue
+++ b/ecos/gui/apps/renderer/src/components/MessageItem.vue
@@ -346,6 +346,8 @@ function closeReportLightbox() {
 function onDocumentKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape' && reportLightbox.value.visible) {
     closeReportLightbox()
+    e.preventDefault()
+    e.stopPropagation()
   }
 }
 

--- a/ecos/gui/apps/renderer/src/views/HomeView.current-step-log.test.ts
+++ b/ecos/gui/apps/renderer/src/views/HomeView.current-step-log.test.ts
@@ -86,6 +86,15 @@ describe('HomeView current-step log viewer state', () => {
     expect(homeViewSource).not.toContain('flow-log-viewer-meta-row')
   })
 
+  it('adds a fullscreen control to the flow step log panel header', () => {
+    expect(homeViewSource).toContain('flow-log-fullscreen-toggle')
+    expect(homeViewSource).toContain('isFlowLogFullscreen')
+    expect(homeViewSource).toContain('toggleFlowLogFullscreen')
+    expect(homeViewSource).toContain('closeFlowLogFullscreen')
+    expect(homeViewSource).toContain('flow-log-fullscreen-card')
+    expect(homeViewSource).toContain('flow-log-fullscreen-active')
+  })
+
   it('lets the live watcher wait for a missing log instead of repeatedly reading on selection', () => {
     expect(homeViewSource).toContain('if (segment.live && !selectedFlowLogContent.value)')
     expect(homeViewSource).toContain('await ensureFlowLogSegmentContentLoaded(segment)')

--- a/ecos/gui/apps/renderer/src/views/HomeView.vue
+++ b/ecos/gui/apps/renderer/src/views/HomeView.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="['home-view', { 'layout-fullscreen-active': isLayoutFullscreen }]">
+  <div :class="['home-view', {
+    'layout-fullscreen-active': isLayoutFullscreen,
+    'flow-log-fullscreen-active': isFlowLogFullscreen,
+  }]">
     <!-- 背景装饰 -->
     <div class="bg-grid"></div>
 
@@ -178,6 +181,17 @@
           <div class="header-icon gds"><i class="ri-terminal-line"></i></div>
           <h2>Flow Step Log</h2>
           <span v-if="flowLogStepName" class="header-badge">{{ flowLogStepName }}</span>
+          <div class="header-actions">
+            <button
+              type="button"
+              class="action-btn flow-log-fullscreen-toggle"
+              :title="isFlowLogFullscreen ? 'Exit full screen' : 'Full screen'"
+              :aria-label="isFlowLogFullscreen ? 'Exit flow step log full screen' : 'View flow step log full screen'"
+              @click="toggleFlowLogFullscreen"
+            >
+              <i :class="isFlowLogFullscreen ? 'ri-fullscreen-exit-line' : 'ri-fullscreen-line'"></i>
+            </button>
+          </div>
         </div>
         <div class="flow-log-content">
           <div v-if="flowLogError" class="flow-log-error">{{ flowLogError }}</div>
@@ -220,7 +234,7 @@
                     :aria-expanded="isFlowLogStepChooserOpen ? 'true' : 'false'"
                     aria-haspopup="dialog"
                     :aria-label="isFlowLogStepChooserOpen ? 'Hide flow step chooser' : 'Show flow step chooser'"
-                    @click="toggleFlowLogStepChooser"
+                    @click="toggleFlowLogStepChooserFromTrigger"
                   >
                     <i class="ri-list-check"></i>
                     <span>Steps</span>
@@ -336,6 +350,139 @@
               @select="onSelectFlowLogStep"
             />
           </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- ===== Flow Step Log Fullscreen Overlay ===== -->
+    <Teleport to="body">
+      <Transition name="lightbox">
+        <div
+          v-if="isFlowLogFullscreen"
+          class="flow-log-fullscreen-overlay"
+          @click="closeFlowLogFullscreen"
+        >
+          <section class="section-card flow-log-fullscreen-card" @click.stop>
+            <div class="section-header">
+              <div class="header-icon gds"><i class="ri-terminal-line"></i></div>
+              <h2>Flow Step Log</h2>
+              <span v-if="flowLogStepName" class="header-badge">{{ flowLogStepName }}</span>
+              <div class="header-actions">
+                <button
+                  type="button"
+                  class="action-btn flow-log-fullscreen-toggle"
+                  title="Exit full screen"
+                  aria-label="Exit flow step log full screen"
+                  @click="closeFlowLogFullscreen"
+                >
+                  <i class="ri-fullscreen-exit-line"></i>
+                </button>
+              </div>
+            </div>
+            <div class="flow-log-content flow-log-fullscreen-content">
+              <div v-if="flowLogError" class="flow-log-error">{{ flowLogError }}</div>
+              <div v-else-if="flowLogListItems.length" class="flow-log-layout flow-log-fullscreen-layout">
+                <div class="flow-log-viewer-panel">
+                  <div class="flow-log-viewer-header">
+                    <div class="flow-log-viewer-header-main">
+                      <div v-if="selectedFlowLogSegment" class="flow-log-viewer-summary-row">
+                        <span class="flow-log-viewer-title">{{ selectedFlowLogSegment.stepName }}</span>
+                        <span class="flow-log-viewer-tool">{{ selectedFlowLogSegment.tool }}</span>
+                        <span
+                          class="flow-log-viewer-state"
+                          :class="{ failed: selectedFlowLogSegment.failed, live: selectedFlowLogSegment.live }"
+                        >
+                          {{ selectedFlowLogSegment.state }}
+                        </span>
+                        <span v-if="selectedFlowLogSegment.totalSize" class="flow-log-viewer-size">
+                          {{ formatKb(selectedFlowLogSegment.totalSize) }}
+                        </span>
+                        <span
+                          v-if="flowLogLoading || loadingSelectedFlowLogKey === selectedFlowLogKey"
+                          class="flow-log-viewer-loading"
+                        >
+                          <i class="ri-loader-4-line spin"></i>
+                          {{ flowLogLoading ? 'Updating…' : 'Loading log…' }}
+                        </span>
+                      </div>
+                      <div v-else class="flow-log-viewer-summary-row empty">
+                        <span class="flow-log-viewer-title">Current step</span>
+                        <span class="flow-log-viewer-tool">Select a step to inspect its output.</span>
+                      </div>
+                    </div>
+
+                    <div class="flow-log-viewer-actions">
+                      <button
+                        type="button"
+                        class="flow-log-steps-trigger"
+                        aria-controls="flow-log-step-chooser-dialog"
+                        :aria-expanded="isFlowLogStepChooserOpen ? 'true' : 'false'"
+                        aria-haspopup="dialog"
+                        :aria-label="isFlowLogStepChooserOpen ? 'Hide flow step chooser' : 'Show flow step chooser'"
+                        @click="toggleFlowLogStepChooserFromTrigger"
+                      >
+                        <i class="ri-list-check"></i>
+                        <span>Steps</span>
+                      </button>
+                      <button
+                        v-if="liveFlowLogKey && liveFlowLogKey !== selectedFlowLogKey"
+                        type="button"
+                        class="flow-log-jump-live-btn"
+                        @click="jumpToLiveStep"
+                      >
+                        <i class="ri-skip-right-line"></i>
+                        <span>Jump to live</span>
+                      </button>
+                      <button
+                        v-if="selectedFlowLogSegment?.truncated"
+                        type="button"
+                        class="flow-log-expand-btn"
+                        :disabled="expandingFlowLogKeys[selectedFlowLogKey || '']"
+                        :title="`Load full log (${formatKb(selectedFlowLogSegment.totalSize)})`"
+                        @click="onExpandFullLog(selectedFlowLogSegment)"
+                      >
+                        <i
+                          :class="[
+                            expandingFlowLogKeys[selectedFlowLogKey || '']
+                              ? 'ri-loader-4-line flow-log-expand-btn-spinner'
+                              : 'ri-expand-up-down-line',
+                          ]"
+                        ></i>
+                        <span v-if="expandingFlowLogKeys[selectedFlowLogKey || '']">Loading full log…</span>
+                        <span v-else>Show full log</span>
+                      </button>
+                    </div>
+                  </div>
+
+                  <div class="flow-log-viewer-shell">
+                    <FlowLogCodeViewer
+                      v-if="selectedFlowLogSegment"
+                      :key="`fullscreen-${selectedFlowLogKey ?? 'no-selection'}`"
+                      :content="selectedFlowLogContent"
+                      :live="Boolean(selectedFlowLogSegment.live)"
+                      :missing="selectedFlowLogSegment.missing"
+                      :loading="loadingSelectedFlowLogKey === selectedFlowLogKey"
+                    />
+                    <div v-else class="flow-log-placeholder">
+                      <i class="ri-terminal-line"></i>
+                      <p>No step selected</p>
+                      <span>Open Steps to inspect a log once a flow step is available.</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div v-else-if="flowLogLoading" class="flow-log-loading">
+                <i class="ri-loader-4-line flow-log-loading-icon"></i>
+                <p>Loading flow step logs…</p>
+                <span>Reading flow.json and log files from the workspace. Steps will appear as they load.</span>
+              </div>
+              <div v-else class="flow-log-placeholder">
+                <i class="ri-terminal-line"></i>
+                <p>No flow step log yet</p>
+                <span>Unstarted steps are hidden. Logs show up here once a step begins or finishes.</span>
+              </div>
+            </div>
+          </section>
         </div>
       </Transition>
     </Teleport>
@@ -615,6 +762,13 @@ function toggleFlowLogStepChooser(): void {
   flowLogChooser.toggleFlowLogStepChooser()
 }
 
+function toggleFlowLogStepChooserFromTrigger(event: MouseEvent): void {
+  if (event.currentTarget instanceof HTMLButtonElement) {
+    flowLogStepChooserTriggerRef.value = event.currentTarget
+  }
+  toggleFlowLogStepChooser()
+}
+
 function closeFlowLogStepChooser(): void {
   flowLogChooser.closeFlowLogStepChooser()
 }
@@ -727,6 +881,7 @@ const checklistCompletedCount = computed(() =>
 // ============ Layout 全屏 & 缩放平移 ============
 const layoutContentRef = ref<HTMLElement>()
 const isLayoutFullscreen = ref(false)
+const isFlowLogFullscreen = ref(false)
 
 // 缩放 & 平移状态
 const layoutScale = ref(1)
@@ -772,6 +927,14 @@ function closeLayoutFullscreen() {
   resetLayoutTransform()
 }
 
+function toggleFlowLogFullscreen() {
+  isFlowLogFullscreen.value = !isFlowLogFullscreen.value
+}
+
+function closeFlowLogFullscreen() {
+  isFlowLogFullscreen.value = false
+}
+
 function onFullscreenKeydown(e: KeyboardEvent) {
   if (e.key !== 'Escape') return
   flowLogChooser.onFlowLogChooserEscape(e)
@@ -783,6 +946,12 @@ function onFullscreenKeydown(e: KeyboardEvent) {
   }
   if (isLayoutFullscreen.value) {
     closeLayoutFullscreen()
+    e.preventDefault()
+    return
+  }
+  if (isFlowLogFullscreen.value) {
+    closeFlowLogFullscreen()
+    e.preventDefault()
   }
 }
 
@@ -1395,7 +1564,27 @@ function closeChartPreview() {
   box-sizing: border-box;
 }
 
+.flow-log-fullscreen-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 19995;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.78);
+  box-sizing: border-box;
+}
+
 .layout-fullscreen-card {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  border-radius: 0;
+  background: var(--bg-primary);
+}
+
+.flow-log-fullscreen-card {
   flex: 1;
   min-width: 0;
   min-height: 0;
@@ -2182,9 +2371,18 @@ html.dark .chart-card:hover {
   display: flex;
 }
 
+.flow-log-fullscreen-content {
+  padding: 10px;
+}
+
+.flow-log-fullscreen-layout {
+  border-radius: 4px;
+}
+
 .flow-log-steps-trigger,
 .flow-log-jump-live-btn,
-.flow-log-expand-btn {
+.flow-log-expand-btn,
+.flow-log-icon-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -2203,7 +2401,8 @@ html.dark .chart-card:hover {
 
 .flow-log-steps-trigger:hover:not(:disabled),
 .flow-log-jump-live-btn:hover:not(:disabled),
-.flow-log-expand-btn:hover:not(:disabled) {
+.flow-log-expand-btn:hover:not(:disabled),
+.flow-log-icon-btn:hover:not(:disabled) {
   color: var(--text-primary);
   border-color: rgba(var(--accent-rgb, 59, 130, 246), 0.45);
   background: rgba(var(--accent-rgb, 59, 130, 246), 0.08);
@@ -2216,9 +2415,17 @@ html.dark .chart-card:hover {
 
 .flow-log-steps-trigger i,
 .flow-log-jump-live-btn i,
-.flow-log-expand-btn i {
+.flow-log-expand-btn i,
+.flow-log-icon-btn i {
   font-size: 12px;
   line-height: 1;
+}
+
+.flow-log-icon-btn {
+  width: 24px;
+  height: 24px;
+  justify-content: center;
+  padding: 0;
 }
 
 .flow-log-expand-btn-spinner {
@@ -2318,7 +2525,7 @@ html.dark .chart-card:hover {
 .flow-log-chooser-overlay {
   position: fixed;
   inset: 0;
-  z-index: 18000;
+  z-index: 20010;
   background: rgba(17, 24, 39, 0.12);
 }
 


### PR DESCRIPTION
## Summary

- Capture ECC CLI stdout/stderr into per-command log files and surface the log path in runtime output/result data.
- Add fullscreen viewing controls for Home Flow Step Log, AI Chat, and Step Configuration panels.
- Prevent nested AI Chat report/image lightboxes from closing the outer fullscreen side panel on Escape.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [x] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## What Changed

- Added append-only ECC CLI command log files with command metadata, stdout/stderr chunks, completion status, and flush-on-finish handling.
- Added fullscreen overlays/controls for Flow Step Log plus the right-side AI Chat and Step Configuration panels.
- Added focused regression coverage for CLI log capture and fullscreen panel behavior.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [x] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other: `pnpm --dir ecos/gui --filter @ecos-studio/desktop-electron test -- electron/services/eccCliAdapter.test.ts`
- [x] Other: `pnpm --dir ecos/gui --filter @ecos-studio/renderer test -- src/components/ChatInspectorPanel.fullscreen.test.ts src/views/HomeView.current-step-log.test.ts src/views/HomeView.flow-log.test.ts src/views/WorkspaceView.sidePanels.test.ts`
- [x] Other: `pnpm --dir ecos/gui --filter @ecos-studio/desktop-electron typecheck`
- [x] Other: `pnpm --dir ecos/gui --filter @ecos-studio/renderer typecheck`
- [x] Other: `git diff --check`

Skipped checks and reason:

- `cd ecos/gui && pnpm run typecheck`: covered by package-specific desktop and renderer typechecks above.
- `cd ecos/gui && pnpm run test`: covered by focused desktop and renderer test commands above; the current Vitest config also ran the broader package suites for those filters.
- `cd ecos/gui && pnpm run build`: not run; change is covered by typecheck/tests and does not alter packaging/build config.
- `make build`: not run; no release packaging files changed.
- `make demo-gcd`: not run; no local demo runtime smoke was requested for this GUI/CLI logging change.
- `make demo-retrosoc`: not run; no local demo runtime smoke was requested for this GUI/CLI logging change.

## Screenshots or Recordings

<img width="1798" height="1203" alt="image" src="https://github.com/user-attachments/assets/9b841f60-3b8d-4a64-bb2d-095e79e9dfc9" />
<img width="1798" height="1203" alt="image" src="https://github.com/user-attachments/assets/5a368dc2-f227-4896-be4f-78f8a3059e3a" />


## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [x] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Parent repo `ecc` submodule gitlink is intentionally not changed in this PR.
- ECC CLI command execution now creates command log files under the active workspace `log/` directory when available, or an OS temp fallback when no workspace directory exists.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
