### PR TITLE
fix(nix): provide graphics runtime libs for layout viewer

### DIFF
--- a/ecos/layout-viewer/default.nix
+++ b/ecos/layout-viewer/default.nix
@@ -8,6 +8,7 @@
   libxcursor,
   libxi,
   libxrandr,
+  makeWrapper,
   wayland,
 }:
 
@@ -32,6 +33,7 @@ rustPlatform.buildRustPackage {
   };
 
   nativeBuildInputs = [
+    makeWrapper
     pkg-config
   ];
 
@@ -70,6 +72,14 @@ rustPlatform.buildRustPackage {
 
     install -m755 "$packer_path" "$out/bin/ecos-layout-packer"
     install -m755 "$viewer_path" "$out/bin/layout-viewer-native"
+    wrapProgram "$out/bin/layout-viewer-native" \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libxkbcommon
+          libGL
+          wayland
+        ]
+      }
 
     runHook postInstall
   '';

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,14 @@
             ELECTRON_EXEC_PATH = "${pkgs.electron}/bin/electron";
             CUSTOM_FPM_PATH = "${pkgs.fpm}/bin/fpm";
             ECOS_ECC_USE_NIX = true;
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (
+              with pkgs;
+              [
+                libxkbcommon
+                libGL
+                wayland
+              ]
+            );
             nativeBuildInputs = with pkgs; [
               ecc.inputs.infra.packages.${system}.yosysWithSlang
               nodejs


### PR DESCRIPTION
## Summary

-

## Scope

Select the areas touched by this PR:

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
