### PR TITLE
fix(layout-viewer): improve visibility controls

### DIFF
--- a/ecos/layout-viewer/Cargo.lock
+++ b/ecos/layout-viewer/Cargo.lock
@@ -1168,6 +1168,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1855,7 @@ name = "layoutpkg-packer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "filetime",
  "flate2",
  "layoutpkg-format",
  "serde",

--- a/ecos/layout-viewer/Cargo.toml
+++ b/ecos/layout-viewer/Cargo.toml
@@ -24,6 +24,7 @@ byteorder = "1.5"
 clap = { version = "4.5", features = ["derive"] }
 eframe = "0.31"
 egui = "0.31"
+filetime = "0.2"
 flate2 = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/ecos/layout-viewer/apps/layout-viewer-native/src/main.rs
+++ b/ecos/layout-viewer/apps/layout-viewer-native/src/main.rs
@@ -16,13 +16,12 @@ use eframe::egui;
 use flate2::read::GzDecoder;
 use layout_display::{Color, DisplayModel, LayerStyle, Pattern, ResolvedDisplayLayer};
 use layout_render::{
-    classify_lod, DrawItem, LodHysteresisState, LodLevel, LodStats, PickHit, PickHitTarget,
-    PickRequest, RenderPlan, RenderPlanSource, RenderPlane, RenderPlanner, RenderSettings,
-    Viewport,
+    classify_lod, DrawItem, LodHysteresisState, LodLevel, LodStats, PickHit, PickRequest,
+    RenderPlan, RenderPlanSource, RenderPlane, RenderPlanner, RenderSettings, Viewport,
 };
 use layoutdb::{
-    CellViewState, HierarchyPolicy, InstancePath, LayoutSession, PackageLayoutSource, Rect,
-    ShapeKind, ViewportLoadBatch,
+    CellViewState, HierarchyPolicy, LayoutSession, PackageLayoutSource, Rect, ShapeKind,
+    ViewportLoadBatch,
 };
 use serde_json::Value;
 
@@ -1233,15 +1232,6 @@ fn sync_hierarchy_policy_from_tuning(policy: &mut HierarchyPolicy, tuning: LodTu
     policy.max_depth = tuning.hierarchy_expand_depth.max(1);
 }
 
-fn enter_path_for_hit(hit: &PickHit) -> Option<InstancePath> {
-    if hit.instance_path.is_empty() {
-        return None;
-    }
-    match hit.target {
-        PickHitTarget::Shape | PickHitTarget::Instance { .. } => Some(hit.instance_path.clone()),
-    }
-}
-
 #[cfg(test)]
 fn selection_summary_text_with_layer(hit: &PickHit, layer: SelectionLayerMetadata<'_>) -> String {
     selection_inspector_rows(hit, None, None, layer)
@@ -1263,26 +1253,8 @@ fn selection_inspector_rows(
     net_name: Option<&str>,
     layer: SelectionLayerMetadata<'_>,
 ) -> Vec<(&'static str, String)> {
-    let target = match hit.target {
-        PickHitTarget::Shape => "shape".to_owned(),
-        PickHitTarget::Instance {
-            parent_cell,
-            child_cell,
-            instance_id,
-            array_column,
-            array_row,
-        } => format!(
-            "instance id={} parent={} child={} array={},{}",
-            instance_id,
-            parent_cell.raw(),
-            child_cell.raw(),
-            array_column,
-            array_row
-        ),
-    };
     let (source_kind, source_file) = source_trace_for_hit(hit);
     let mut rows = vec![
-        ("Target", target),
         ("Source Kind", source_kind.to_owned()),
         ("Source File", source_file.to_owned()),
         ("Source ID", hit.source_id.to_string()),
@@ -1300,9 +1272,6 @@ fn selection_inspector_rows(
             "Layer Type",
             layer.layer_type.unwrap_or("Unknown").to_owned(),
         ),
-        ("Shape Kind", shape_kind_label(hit.kind).to_owned()),
-        ("Cell", hit.cell.raw().to_string()),
-        ("Depth", hit.depth.to_string()),
         (
             "Display BBox",
             format!(
@@ -1310,8 +1279,6 @@ fn selection_inspector_rows(
                 hit.bbox.x1, hit.bbox.y1, hit.bbox.x2, hit.bbox.y2
             ),
         ),
-        ("Instance Path", instance_path_summary(&hit.instance_path)),
-        ("Object Path", object_path_summary(&hit.object_path)),
     ]);
     rows
 }
@@ -1342,7 +1309,7 @@ fn source_trace_for_hit(hit: &PickHit) -> (&'static str, &'static str) {
             "design/regular_wires.json | design/special_wires.json | design/io_pins.json",
         ),
         ShapeKind::IoPin if is_hierarchy_cell_shape(hit) => {
-            ("cell_master_pin", "tech/cell_masters.json")
+            ("instance_pin", "tech/cell_masters.json")
         }
         ShapeKind::IoPin => ("io_pin", "design/io_pins.json"),
         ShapeKind::Blockage => ("blockage", "design/blockages.json"),
@@ -1375,73 +1342,6 @@ fn hierarchy_pin_shape_index(hit: &PickHit) -> Option<usize> {
         return None;
     };
     Some(shape.shape_index)
-}
-
-fn shape_kind_label(kind: ShapeKind) -> &'static str {
-    match kind {
-        ShapeKind::Die => "die",
-        ShapeKind::Core => "core",
-        ShapeKind::Instance => "instance",
-        ShapeKind::RegularWire => "regular_wire",
-        ShapeKind::SpecialWire => "special_wire",
-        ShapeKind::Via => "via",
-        ShapeKind::IoPin => "io_pin",
-        ShapeKind::Blockage => "blockage",
-        ShapeKind::Fill => "fill",
-        ShapeKind::Region => "region",
-        ShapeKind::Row => "row",
-        ShapeKind::Track => "track",
-        ShapeKind::GCellGrid => "gcell_grid",
-    }
-}
-
-fn instance_path_summary(path: &InstancePath) -> String {
-    if path.is_empty() {
-        return "top".to_owned();
-    }
-    path.elements()
-        .iter()
-        .map(|element| {
-            format!(
-                "{}:{}->{}[{},{}]",
-                element.instance_id,
-                element.parent_cell.raw(),
-                element.child_cell.raw(),
-                element.array_column,
-                element.array_row
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(" / ")
-}
-
-fn object_path_summary(path: &layoutdb::ObjectPath) -> String {
-    match &path.target {
-        layoutdb::ObjectPathTarget::Shape(shape) => {
-            format!(
-                "shape cell={} index={} source={}",
-                shape.cell.raw(),
-                shape.shape_index,
-                shape.source_id
-            )
-        }
-        layoutdb::ObjectPathTarget::Instance {
-            parent_cell,
-            instance_id,
-            source_id,
-            child_cell,
-            array_column,
-            array_row,
-        } => format!(
-            "instance id={} source={} parent={} child={} array={},{}",
-            instance_id,
-            source_id,
-            parent_cell.raw(),
-            child_cell.raw(),
-            array_column,
-            array_row
-        ),
-    }
 }
 
 fn canvas_interaction_sense() -> egui::Sense {
@@ -2159,15 +2059,6 @@ impl LayoutViewerV2App {
                                             ui.end_row();
                                         }
                                     });
-                                let enter_path = enter_path_for_hit(&hit);
-                                if ui
-                                    .add_enabled(enter_path.is_some(), egui::Button::new("Enter"))
-                                    .clicked()
-                                {
-                                    if let Some(path) = enter_path {
-                                        self.enter_instance_path(&mut loaded, path);
-                                    }
-                                }
                             } else {
                                 ui.label("No object selected");
                             }
@@ -2282,13 +2173,6 @@ impl LayoutViewerV2App {
         self.last_render_plan_interaction_coarse = false;
         self.last_plan_reused = false;
         self.layer_counts_cache.clear();
-    }
-
-    fn enter_instance_path(&mut self, loaded: &mut LoadedViewerState, path: InstancePath) {
-        loaded.cell_view = CellViewState::from_path(loaded.cell_view.context_cell(), path);
-        self.selected = None;
-        self.clear_render_history();
-        focus_view_on_cell_bbox(&mut self.view, loaded.session.db(), &loaded.cell_view);
     }
 }
 
@@ -3199,15 +3083,15 @@ mod tests {
             .iter()
             .any(|(label, value)| *label == "Layer Type" && value == "ROUTING"));
         assert!(!rows.iter().any(|(label, _value)| *label == "Display Layer"));
+        assert!(!rows.iter().any(|(label, _value)| *label == "Shape Kind"));
+        assert!(!rows.iter().any(|(label, _value)| *label == "Target"));
+        assert!(!rows.iter().any(|(label, _value)| *label == "Cell"));
+        assert!(!rows.iter().any(|(label, _value)| *label == "Depth"));
+        assert!(!rows.iter().any(|(label, _value)| *label == "Instance Path"));
+        assert!(!rows.iter().any(|(label, _value)| *label == "Object Path"));
         assert!(rows
             .iter()
             .any(|(label, value)| *label == "Display BBox" && value == "2, 2, 8, 8"));
-        assert!(rows.iter().any(|(label, value)| {
-            *label == "Instance Path" && value.contains("10") && value.contains("20")
-        }));
-        assert!(rows.iter().any(|(label, value)| {
-            *label == "Object Path" && value.contains("shape") && value.contains("source=9")
-        }));
     }
 
     #[test]
@@ -3259,7 +3143,7 @@ mod tests {
 
         assert!(rows
             .iter()
-            .any(|(label, value)| *label == "Source Kind" && value == "cell_master_pin"));
+            .any(|(label, value)| *label == "Source Kind" && value == "instance_pin"));
         assert!(rows.iter().any(|(label, value)| {
             *label == "Source File" && value == "tech/cell_masters.json"
         }));
@@ -4021,18 +3905,8 @@ mod tests {
     }
 
     #[test]
-    fn enter_path_for_shape_hit_uses_shape_instance_path() {
+    fn selection_summary_omits_internal_hierarchy_fields() {
         let (_db, leaf_view) = hierarchy_test_db_and_leaf_view();
-        let hit = sample_pick_hit(PickHitTarget::Shape, leaf_view.specific_path().clone());
-
-        let enter_path = super::enter_path_for_hit(&hit).expect("shape path should be enterable");
-
-        assert_eq!(enter_path, leaf_view.specific_path().clone());
-    }
-
-    #[test]
-    fn selection_summary_includes_target_and_path_depth() {
-        let (db, leaf_view) = hierarchy_test_db_and_leaf_view();
         let hit = sample_pick_hit(PickHitTarget::Shape, leaf_view.specific_path().clone());
 
         let text = super::selection_summary_text_with_layer(
@@ -4043,9 +3917,11 @@ mod tests {
             },
         );
 
-        assert!(text.contains("target: shape"));
-        assert!(text.contains("depth: 2"));
-        assert!(text.contains(&format!("cell: {}", db.cell_by_name("leaf").unwrap().raw())));
+        assert!(!text.contains("target:"));
+        assert!(!text.contains("cell:"));
+        assert!(!text.contains("depth:"));
+        assert!(!text.contains("instance path:"));
+        assert!(!text.contains("object path:"));
         assert!(text.contains("layer: M1"));
         assert!(text.contains("layer id: 1"));
         assert!(text.contains("layer type: ROUTING"));

--- a/ecos/layout-viewer/apps/layout-viewer-native/src/main.rs
+++ b/ecos/layout-viewer/apps/layout-viewer-native/src/main.rs
@@ -36,10 +36,12 @@ const DETAIL_LOAD_MAX_VIEWPORT_WORLD_AREA_RATIO: f64 = 0.15;
 const SIDEBAR_DEFAULT_WIDTH: f32 = 320.0;
 const SIDEBAR_MIN_WIDTH: f32 = 190.0;
 const SIDEBAR_MAX_WIDTH: f32 = 640.0;
+const SIDEBAR_VALUE_MIN_WIDTH: f32 = 80.0;
 const MAX_PATTERN_OPS_PER_RECT: usize = 512;
 const MAX_HATCH_OPS_PER_RECT: usize = 256;
 const PATTERN_TILE_PX: f32 = 10.0;
 const SPARSE_DOT_SPACING_PX: f32 = 9.0;
+const DENSE_DOT_SPACING_PX: f32 = 5.0;
 const NEAR_RASTER_ITEM_THRESHOLD: usize = 10_000;
 const NEAR_RASTER_OPS_THRESHOLD: usize = 6_000;
 const DIE_BOUNDARY_WIDTH: f32 = 2.0;
@@ -111,13 +113,17 @@ struct LayoutViewerV2App {
     last_paint_ops: usize,
     last_lod_stats: LodStats,
     layer_counts_cache: LayerCountsCache,
+    sidebar_had_selection: bool,
 }
 
 struct LoadedViewerState {
     session: LayoutSession,
     display: DisplayModel,
     cell_view: CellViewState,
+    package_root: PathBuf,
     selection_names: SelectionNameIndex,
+    selection_name_load: Option<SelectionNameLoadHandle>,
+    selection_names_loaded: bool,
     background_load: BackgroundLoadHandle,
 }
 
@@ -774,6 +780,10 @@ struct SessionLoadHandle {
     results: Receiver<Result<LoadedViewerState, String>>,
 }
 
+struct SelectionNameLoadHandle {
+    results: Receiver<Result<SelectionNameIndex, String>>,
+}
+
 impl SessionLoadHandle {
     fn spawn(package_root: PathBuf, cache_capacity: usize) -> Self {
         let (result_tx, result_rx) = mpsc::channel::<Result<LoadedViewerState, String>>();
@@ -795,15 +805,32 @@ fn load_viewer_state(package_root: PathBuf, cache_capacity: usize) -> Result<Loa
     let session = LayoutSession::from_source(source)?;
     let display = DisplayModel::from_layout_layers(session.db().layers());
     let cell_view = CellViewState::top(session.db());
-    let selection_names = SelectionNameIndex::load(&package_root).unwrap_or_default();
-    let background_load = BackgroundLoadHandle::spawn(package_root, cache_capacity);
+    let background_load = BackgroundLoadHandle::spawn(package_root.clone(), cache_capacity);
     Ok(LoadedViewerState {
         session,
         display,
         cell_view,
-        selection_names,
+        package_root,
+        selection_names: SelectionNameIndex::default(),
+        selection_name_load: None,
+        selection_names_loaded: false,
         background_load,
     })
+}
+
+impl SelectionNameLoadHandle {
+    fn spawn(package_root: PathBuf) -> Self {
+        let (result_tx, result_rx) = mpsc::channel::<Result<SelectionNameIndex, String>>();
+        std::thread::spawn(move || {
+            let result = SelectionNameIndex::load(&package_root).map_err(|error| error.to_string());
+            let _ = result_tx.send(result);
+        });
+        Self { results: result_rx }
+    }
+
+    fn try_recv(&self) -> Option<Result<SelectionNameIndex, String>> {
+        self.results.try_recv().ok()
+    }
 }
 
 impl BackgroundLoadHandle {
@@ -1138,7 +1165,7 @@ struct ObjectVisibilityRow {
     kind: ShapeKind,
 }
 
-fn object_visibility_rows() -> [ObjectVisibilityRow; 3] {
+fn object_visibility_rows() -> [ObjectVisibilityRow; 4] {
     [
         ObjectVisibilityRow {
             label: "Instances",
@@ -1151,6 +1178,10 @@ fn object_visibility_rows() -> [ObjectVisibilityRow; 3] {
         ObjectVisibilityRow {
             label: "Net",
             kind: ShapeKind::RegularWire,
+        },
+        ObjectVisibilityRow {
+            label: "IO Pin",
+            kind: ShapeKind::IoPin,
         },
     ]
 }
@@ -1469,6 +1500,18 @@ fn sidebar_title_text() -> Option<&'static str> {
     None
 }
 
+fn sidebar_value_width(available_width: f32, item_spacing_x: f32) -> f32 {
+    (available_width - item_spacing_x).max(SIDEBAR_VALUE_MIN_WIDTH)
+}
+
+fn should_reset_sidebar_width(had_selection: bool, has_selection: bool) -> bool {
+    had_selection && !has_selection
+}
+
+fn selection_row_value_width(available_width: f32) -> f32 {
+    available_width.max(SIDEBAR_VALUE_MIN_WIDTH)
+}
+
 fn draw_layer_visibility_row(
     ui: &mut egui::Ui,
     visible: &mut bool,
@@ -1492,6 +1535,7 @@ fn object_visibility_color(kind: ShapeKind) -> Color {
         ShapeKind::Instance => Color::rgb(176, 155, 255),
         ShapeKind::SpecialWire => Color::rgb(255, 214, 118),
         ShapeKind::RegularWire => Color::rgb(160, 218, 255),
+        ShapeKind::IoPin => Color::rgb(144, 208, 255),
         _ => Color::rgb(132, 146, 156),
     }
 }
@@ -1674,6 +1718,7 @@ impl LayoutViewerV2App {
             last_paint_ops: 0,
             last_lod_stats: LodStats::default(),
             layer_counts_cache: LayerCountsCache::default(),
+            sidebar_had_selection: false,
         })
     }
 
@@ -1698,6 +1743,35 @@ impl LayoutViewerV2App {
                 ctx.request_repaint_after(TARGET_REPAINT_INTERVAL);
             }
         }
+    }
+
+    fn poll_selection_name_load(&mut self, ctx: &egui::Context) {
+        let Some(loaded) = self.loaded.as_mut() else {
+            return;
+        };
+        if self.selected.is_some()
+            && !loaded.selection_names_loaded
+            && loaded.selection_name_load.is_none()
+        {
+            loaded.selection_name_load =
+                Some(SelectionNameLoadHandle::spawn(loaded.package_root.clone()));
+        }
+        let Some(result) = loaded
+            .selection_name_load
+            .as_ref()
+            .and_then(SelectionNameLoadHandle::try_recv)
+        else {
+            if loaded.selection_name_load.is_some() {
+                ctx.request_repaint_after(TARGET_REPAINT_INTERVAL);
+            }
+            return;
+        };
+        if let Ok(selection_names) = result {
+            loaded.selection_names = selection_names;
+        }
+        loaded.selection_name_load = None;
+        loaded.selection_names_loaded = true;
+        ctx.request_repaint();
     }
 
     fn draw_loading_canvas(&self, ui: &mut egui::Ui, rect: egui::Rect) {
@@ -2015,59 +2089,55 @@ impl LayoutViewerV2App {
     }
 
     fn draw_sidebar(&mut self, ctx: &egui::Context) {
-        egui::SidePanel::right("v2-display-panel-default-320")
+        let has_selection = self.selected.is_some();
+        let reset_width = should_reset_sidebar_width(self.sidebar_had_selection, has_selection);
+        self.sidebar_had_selection = has_selection;
+
+        let mut panel = egui::SidePanel::right("v2-display-panel-default-320")
             .resizable(true)
             .default_width(SIDEBAR_DEFAULT_WIDTH)
             .min_width(SIDEBAR_MIN_WIDTH)
-            .max_width(SIDEBAR_MAX_WIDTH)
-            .show(ctx, |ui| {
-                egui::ScrollArea::vertical()
-                    .id_salt("v2-display-panel-scroll")
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
-                        if let Some(mut loaded) = self.loaded.take() {
-                            self.draw_layers_panel(ui, &mut loaded);
+            .max_width(SIDEBAR_MAX_WIDTH);
+        if reset_width {
+            panel = panel.exact_width(SIDEBAR_DEFAULT_WIDTH);
+        }
+        panel.show(ctx, |ui| {
+            egui::ScrollArea::vertical()
+                .id_salt("v2-display-panel-scroll")
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    if let Some(mut loaded) = self.loaded.take() {
+                        self.draw_layers_panel(ui, &mut loaded);
+                        ui.separator();
+                        self.draw_objects_panel(ui, &mut loaded);
+                        #[cfg(debug_assertions)]
+                        if should_show_debug_panel() {
                             ui.separator();
-                            self.draw_objects_panel(ui, &mut loaded);
-                            #[cfg(debug_assertions)]
-                            if should_show_debug_panel() {
-                                ui.separator();
-                                self.draw_debug_panel(ui);
-                            }
-                            ui.separator();
-                            ui.label("Selection");
-                            if let Some(hit) = self.selected.clone() {
-                                egui::Grid::new("selection-inspector-grid")
-                                    .num_columns(2)
-                                    .striped(true)
-                                    .show(ui, |ui| {
-                                        let source_name = loaded.selection_names.name_for_hit(&hit);
-                                        let net_name =
-                                            loaded.selection_names.net_name_for_hit(&hit);
-                                        let layer = selection_layer_metadata_for_id(
-                                            loaded.session.db().layers(),
-                                            hit.layer_id,
-                                        );
-                                        for (label, value) in selection_inspector_rows(
-                                            &hit,
-                                            source_name,
-                                            net_name,
-                                            layer,
-                                        ) {
-                                            ui.label(label);
-                                            ui.monospace(value);
-                                            ui.end_row();
-                                        }
-                                    });
-                            } else {
-                                ui.label("No object selected");
-                            }
-                            self.loaded = Some(loaded);
-                        } else {
-                            ui.label(self.last_error.as_deref().unwrap_or("Loading layout..."));
+                            self.draw_debug_panel(ui);
                         }
-                    });
-            });
+                        ui.separator();
+                        ui.label("Selection");
+                        if let Some(hit) = self.selected.clone() {
+                            let source_name = loaded.selection_names.name_for_hit(&hit);
+                            let net_name = loaded.selection_names.net_name_for_hit(&hit);
+                            let layer = selection_layer_metadata_for_id(
+                                loaded.session.db().layers(),
+                                hit.layer_id,
+                            );
+                            for (label, value) in
+                                selection_inspector_rows(&hit, source_name, net_name, layer)
+                            {
+                                Self::draw_selection_row(ui, label, value);
+                            }
+                        } else {
+                            ui.label("No object selected");
+                        }
+                        self.loaded = Some(loaded);
+                    } else {
+                        ui.label(self.last_error.as_deref().unwrap_or("Loading layout..."));
+                    }
+                });
+        });
     }
 
     #[cfg(debug_assertions)]
@@ -2096,6 +2166,20 @@ impl LayoutViewerV2App {
         }
     }
 
+    fn draw_selection_row(ui: &mut egui::Ui, label: &'static str, value: String) {
+        egui::Frame::NONE
+            .fill(ui.visuals().faint_bg_color)
+            .inner_margin(egui::Margin::symmetric(4, 3))
+            .show(ui, |ui| {
+                ui.label(label);
+                let value_width = selection_row_value_width(ui.available_width());
+                ui.add_sized(
+                    egui::vec2(value_width, 0.0),
+                    egui::Label::new(egui::RichText::new(value).monospace()).wrap(),
+                );
+            });
+    }
+
     #[cfg(debug_assertions)]
     fn draw_debug_panel(&self, ui: &mut egui::Ui) {
         ui.label("Debug");
@@ -2106,7 +2190,7 @@ impl LayoutViewerV2App {
                 for (label, value) in debug_panel_rows(self.debug_panel_snapshot()) {
                     ui.label(label);
                     let value_width =
-                        (ui.available_width() - ui.spacing().item_spacing.x).max(80.0);
+                        sidebar_value_width(ui.available_width(), ui.spacing().item_spacing.x);
                     ui.add_sized(
                         egui::vec2(value_width, 0.0),
                         egui::Label::new(egui::RichText::new(value).monospace()).wrap(),
@@ -2155,6 +2239,7 @@ impl LayoutViewerV2App {
                 ShapeKind::Instance => &mut visibility.instances,
                 ShapeKind::SpecialWire => &mut visibility.pdn,
                 ShapeKind::RegularWire => &mut visibility.net,
+                ShapeKind::IoPin => &mut visibility.io_pin,
                 _ => unreachable!("object visibility row uses supported kinds"),
             };
             draw_layer_visibility_row(
@@ -2179,6 +2264,7 @@ impl LayoutViewerV2App {
 impl eframe::App for LayoutViewerV2App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.poll_session_load(ctx);
+        self.poll_selection_name_load(ctx);
         self.draw_sidebar(ctx);
         let mut layout_active_frame = false;
         egui::CentralPanel::default().show(ctx, |ui| {
@@ -2351,8 +2437,13 @@ fn draw_plan_vectors(
                 (RenderPlane::Fill, DrawItem::Rect(item)) => {
                     let draw_rect = world_rect_to_screen(item.world, view, rect);
                     if let Some(fill_rect) = clipped_screen_rect(draw_rect, rect) {
-                        paint_ops +=
-                            draw_fill_rect(painter, fill_rect, &batch.style, interaction_active);
+                        paint_ops += draw_fill_rect(
+                            painter,
+                            fill_rect,
+                            &batch.style,
+                            interaction_active,
+                            draw_rect.size(),
+                        );
                     }
                 }
                 (RenderPlane::Hierarchy, DrawItem::Rect(item)) => {
@@ -2396,6 +2487,7 @@ fn draw_plan_vectors(
                                 fill_rect,
                                 &batch.style,
                                 interaction_active,
+                                draw_rect.size(),
                             );
                         }
                         painter.rect_stroke(
@@ -2637,6 +2729,7 @@ enum FillDrawMode {
     None,
     Solid,
     SparseDots,
+    DenseDots,
     DiagonalHatch,
     CrossHatch,
 }
@@ -2645,12 +2738,13 @@ fn fill_draw_mode(pattern: Pattern, interaction_active: bool) -> FillDrawMode {
     match pattern {
         Pattern::Hollow => FillDrawMode::None,
         Pattern::Solid => FillDrawMode::Solid,
-        Pattern::SparseDots | Pattern::DiagonalHatch | Pattern::CrossHatch
+        Pattern::SparseDots | Pattern::DenseDots | Pattern::DiagonalHatch | Pattern::CrossHatch
             if interaction_active =>
         {
             FillDrawMode::Solid
         }
         Pattern::SparseDots => FillDrawMode::SparseDots,
+        Pattern::DenseDots => FillDrawMode::DenseDots,
         Pattern::DiagonalHatch => FillDrawMode::DiagonalHatch,
         Pattern::CrossHatch => FillDrawMode::CrossHatch,
     }
@@ -2661,6 +2755,7 @@ fn draw_fill_rect(
     rect: egui::Rect,
     style: &LayerStyle,
     interaction_active: bool,
+    orientation_size: egui::Vec2,
 ) -> usize {
     match fill_draw_mode(style.fill_pattern, interaction_active) {
         FillDrawMode::None => 0,
@@ -2679,9 +2774,14 @@ fn draw_fill_rect(
             );
             1
         }
-        FillDrawMode::SparseDots => draw_sparse_dots(painter, rect, style),
-        FillDrawMode::DiagonalHatch => draw_diagonal_hatch(painter, rect, style, false),
-        FillDrawMode::CrossHatch => draw_diagonal_hatch(painter, rect, style, true),
+        FillDrawMode::SparseDots => draw_dots(painter, rect, style, SPARSE_DOT_SPACING_PX),
+        FillDrawMode::DenseDots => draw_dots(painter, rect, style, DENSE_DOT_SPACING_PX),
+        FillDrawMode::DiagonalHatch => {
+            draw_diagonal_hatch(painter, rect, style, false, orientation_size)
+        }
+        FillDrawMode::CrossHatch => {
+            draw_diagonal_hatch(painter, rect, style, true, orientation_size)
+        }
     }
 }
 
@@ -2693,9 +2793,14 @@ fn interaction_fill_alpha(pattern: Pattern, alpha: u8, interaction_active: bool)
     }
 }
 
-fn draw_sparse_dots(painter: &egui::Painter, rect: egui::Rect, style: &LayerStyle) -> usize {
+fn draw_dots(
+    painter: &egui::Painter,
+    rect: egui::Rect,
+    style: &LayerStyle,
+    base_spacing: f32,
+) -> usize {
     let color = color_to_egui(style.fill_color, style.fill_alpha);
-    let spacing = dot_spacing_for_rect(rect, SPARSE_DOT_SPACING_PX);
+    let spacing = dot_spacing_for_rect(rect, base_spacing);
     let mut ops = 0;
     let mut y = snap_to_grid(rect.top(), spacing);
     while y <= rect.bottom() {
@@ -2722,29 +2827,39 @@ fn draw_diagonal_hatch(
     rect: egui::Rect,
     style: &LayerStyle,
     cross: bool,
+    orientation_size: egui::Vec2,
 ) -> usize {
     let color = color_to_egui(style.fill_color, style.fill_alpha);
     let stroke = egui::Stroke::new(1.0, color);
     let mut ops = 0;
-    for segment in hatch_segments(rect, cross) {
+    for segment in hatch_segments(rect, cross, orientation_size) {
         painter.line_segment(segment, stroke);
         ops += 1;
     }
     ops
 }
 
-fn hatch_segments(rect: egui::Rect, cross: bool) -> Vec<[egui::Pos2; 2]> {
+fn hatch_segments(
+    rect: egui::Rect,
+    cross: bool,
+    orientation_size: egui::Vec2,
+) -> Vec<[egui::Pos2; 2]> {
     let rect = rect.shrink(2.0);
     if rect.width() < 3.0 || rect.height() < 3.0 {
         return Vec::new();
     }
     let spacing = hatch_spacing_for_rect(rect, PATTERN_TILE_PX, cross);
     let mut segments = Vec::new();
-    append_hatch_segments(&mut segments, rect, spacing, false);
+    let reverse = !cross && use_reversed_diagonal_hatch(orientation_size.x, orientation_size.y);
+    append_hatch_segments(&mut segments, rect, spacing, reverse);
     if cross {
         append_hatch_segments(&mut segments, rect, spacing, true);
     }
     segments
+}
+
+fn use_reversed_diagonal_hatch(width: f32, height: f32) -> bool {
+    width > height
 }
 
 fn append_hatch_segments(
@@ -2903,6 +3018,7 @@ fn estimated_vector_paint_ops(plan: &layout_render::RenderPlan) -> usize {
             let item_cost = match (batch.plane, batch.style.fill_pattern) {
                 (RenderPlane::Fill | RenderPlane::Frame, Pattern::CrossHatch) => 4,
                 (RenderPlane::Fill | RenderPlane::Frame, Pattern::DiagonalHatch) => 3,
+                (RenderPlane::Fill | RenderPlane::Frame, Pattern::DenseDots) => 3,
                 (RenderPlane::Fill | RenderPlane::Frame, Pattern::SparseDots) => 2,
                 (RenderPlane::Frame, _) => 2,
                 _ => 1,
@@ -2944,10 +3060,23 @@ mod tests {
     use std::{
         collections::BTreeMap,
         fs,
+        path::PathBuf,
         sync::atomic::{AtomicU64, Ordering},
     };
 
     static HIERARCHY_TEST_PACKAGE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn hatch_segment_has_positive_slope(segment: &[egui::Pos2; 2]) -> bool {
+        let dx = segment[1].x - segment[0].x;
+        let dy = segment[1].y - segment[0].y;
+        dx.abs() >= f32::EPSILON && dy / dx > 0.0
+    }
+
+    fn hatch_segment_has_negative_slope(segment: &[egui::Pos2; 2]) -> bool {
+        let dx = segment[1].x - segment[0].x;
+        let dy = segment[1].y - segment[0].y;
+        dx.abs() >= f32::EPSILON && dy / dx < 0.0
+    }
 
     #[test]
     fn app_open_returns_before_package_io() {
@@ -3172,8 +3301,7 @@ mod tests {
         assert_eq!(missing_metadata.layer_type, None);
     }
 
-    #[test]
-    fn selection_name_index_reads_io_pin_names_from_source_root() {
+    fn name_index_test_package() -> (PathBuf, PathBuf) {
         let root = std::env::temp_dir().join(format!(
             "layout_viewer_native_name_index_test_{}_{}",
             std::process::id(),
@@ -3189,12 +3317,17 @@ mod tests {
             format!(
                 r#"{{
                     "schema": "ecos.layoutpkg.v1",
+                    "design_name": "unit",
+                    "world_bbox": [0, 0, 1000, 1000],
+                    "tilesets": {{ "detail": "detail/index.json" }},
                     "source": {{ "kind": "view-json", "root": "{}" }}
                 }}"#,
                 source_root.display()
             ),
         )
         .unwrap();
+        fs::create_dir_all(package_root.join("detail")).unwrap();
+        fs::write(package_root.join("detail/index.json"), r#"{ "tiles": [] }"#).unwrap();
         fs::write(
             source_root.join("manifest.json"),
             r#"{
@@ -3314,6 +3447,53 @@ mod tests {
             }"#,
         )
         .unwrap();
+
+        (root, package_root)
+    }
+
+    #[test]
+    fn load_viewer_state_defers_selection_name_index_loading() {
+        let (root, package_root) = name_index_test_package();
+
+        let loaded = super::load_viewer_state(package_root, 1).unwrap();
+
+        assert!(loaded.selection_names.io_pins.is_empty());
+        assert!(loaded.selection_name_load.is_none());
+        assert!(!loaded.selection_names_loaded);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn selection_name_load_handle_loads_io_pin_names_in_background() {
+        let (root, package_root) = name_index_test_package();
+
+        let load = super::SelectionNameLoadHandle::spawn(package_root);
+        let mut loaded_names = None;
+        for _ in 0..100 {
+            if let Some(result) = load.try_recv() {
+                loaded_names = Some(result.unwrap());
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let names = loaded_names.expect("background selection name index load should finish");
+
+        let (_db, leaf_view) = hierarchy_test_db_and_leaf_view();
+        let mut hit = sample_pick_hit(PickHitTarget::Shape, leaf_view.specific_path().clone());
+        hit.kind = ShapeKind::IoPin;
+        hit.source_id = 14;
+        hit.instance_path = InstancePath::new();
+        hit.object_path.instance_path = InstancePath::new();
+
+        assert_eq!(names.name_for_hit(&hit), Some("req_msg_12_"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn selection_name_index_reads_io_pin_names_from_source_root() {
+        let (root, package_root) = name_index_test_package();
 
         let names = super::SelectionNameIndex::load(&package_root).unwrap();
         let (_db, leaf_view) = hierarchy_test_db_and_leaf_view();
@@ -3935,6 +4115,22 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_selection_values_wrap_within_default_width() {
+        let value_width = super::sidebar_value_width(super::SIDEBAR_DEFAULT_WIDTH, 8.0);
+
+        assert!(value_width > super::SIDEBAR_DEFAULT_WIDTH - 16.0);
+        assert!(value_width >= super::SIDEBAR_VALUE_MIN_WIDTH);
+    }
+
+    #[test]
+    fn sidebar_width_resets_when_selection_is_cleared() {
+        assert!(super::should_reset_sidebar_width(true, false));
+        assert!(!super::should_reset_sidebar_width(false, false));
+        assert!(!super::should_reset_sidebar_width(false, true));
+        assert!(!super::should_reset_sidebar_width(true, true));
+    }
+
+    #[test]
     fn sidebar_omits_redundant_display_title() {
         assert_eq!(super::sidebar_title_text(), None);
     }
@@ -3959,12 +4155,12 @@ mod tests {
     }
 
     #[test]
-    fn sidebar_objects_panel_lists_instances_pdn_and_net() {
+    fn sidebar_objects_panel_lists_instances_pdn_net_and_io_pin() {
         let rows = super::object_visibility_rows();
 
         assert_eq!(
             rows.iter().map(|row| row.label).collect::<Vec<_>>(),
-            vec!["Instances", "PDN", "Net"]
+            vec!["Instances", "PDN", "Net", "IO Pin"]
         );
         assert_eq!(
             rows.iter().map(|row| row.kind).collect::<Vec<_>>(),
@@ -3972,6 +4168,7 @@ mod tests {
                 ShapeKind::Instance,
                 ShapeKind::SpecialWire,
                 ShapeKind::RegularWire,
+                ShapeKind::IoPin,
             ]
         );
     }
@@ -4493,7 +4690,7 @@ mod tests {
     fn hatch_pattern_uses_continuous_visible_segments() {
         let rect = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(120.0, 90.0));
 
-        let segments = super::hatch_segments(rect, true);
+        let segments = super::hatch_segments(rect, true, rect.size());
 
         assert!(!segments.is_empty());
         assert!(segments.iter().any(|segment| {
@@ -4504,10 +4701,41 @@ mod tests {
     }
 
     #[test]
+    fn diagonal_hatch_reverses_for_horizontal_rects() {
+        let horizontal = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(80.0, 20.0));
+        let vertical = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(20.0, 80.0));
+        let square = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(40.0, 40.0));
+
+        let horizontal_segments = super::hatch_segments(horizontal, false, horizontal.size());
+        let vertical_segments = super::hatch_segments(vertical, false, vertical.size());
+        let square_segments = super::hatch_segments(square, false, square.size());
+
+        assert!(horizontal_segments
+            .iter()
+            .any(hatch_segment_has_positive_slope));
+        assert!(vertical_segments
+            .iter()
+            .any(hatch_segment_has_negative_slope));
+        assert!(square_segments.iter().any(hatch_segment_has_negative_slope));
+    }
+
+    #[test]
+    fn diagonal_hatch_keeps_horizontal_direction_after_clipping() {
+        let clipped_visible_part =
+            egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(8.0, 20.0));
+        let original_size = egui::vec2(100.0, 20.0);
+
+        let segments = super::hatch_segments(clipped_visible_part, false, original_size);
+
+        assert!(segments.iter().any(hatch_segment_has_positive_slope));
+        assert!(!segments.iter().any(hatch_segment_has_negative_slope));
+    }
+
+    #[test]
     fn hatch_pattern_segments_scale_with_perimeter_not_area() {
         let rect = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(500.0, 300.0));
 
-        let segments = super::hatch_segments(rect, true);
+        let segments = super::hatch_segments(rect, true, rect.size());
 
         assert!(segments.len() <= 180);
     }
@@ -4516,7 +4744,7 @@ mod tests {
     fn hatch_pattern_keeps_viewport_sized_rects_under_budget() {
         let rect = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(1000.0, 1000.0));
 
-        let segments = super::hatch_segments(rect, true);
+        let segments = super::hatch_segments(rect, true, rect.size());
 
         assert!(segments.len() <= 300);
     }
@@ -4525,7 +4753,7 @@ mod tests {
     fn hatch_pattern_caps_large_screen_rect_segments() {
         let rect = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(2400.0, 1600.0));
 
-        let segments = super::hatch_segments(rect, true);
+        let segments = super::hatch_segments(rect, true, rect.size());
 
         assert!(segments.len() <= 512);
         assert!(!segments.is_empty());
@@ -4535,6 +4763,10 @@ mod tests {
     fn patterned_fills_degrade_to_solid_during_interaction() {
         assert_eq!(
             fill_draw_mode(Pattern::SparseDots, true),
+            FillDrawMode::Solid
+        );
+        assert_eq!(
+            fill_draw_mode(Pattern::DenseDots, true),
             FillDrawMode::Solid
         );
         assert_eq!(
@@ -4548,6 +4780,10 @@ mod tests {
         assert_eq!(fill_draw_mode(Pattern::Hollow, true), FillDrawMode::None);
 
         assert_eq!(
+            fill_draw_mode(Pattern::DenseDots, false),
+            FillDrawMode::DenseDots
+        );
+        assert_eq!(
             fill_draw_mode(Pattern::DiagonalHatch, false),
             FillDrawMode::DiagonalHatch
         );
@@ -4557,6 +4793,10 @@ mod tests {
     fn patterned_interaction_fill_uses_low_alpha_placeholder() {
         assert_eq!(
             super::interaction_fill_alpha(Pattern::SparseDots, 90, true),
+            40
+        );
+        assert_eq!(
+            super::interaction_fill_alpha(Pattern::DenseDots, 90, true),
             40
         );
         assert_eq!(

--- a/ecos/layout-viewer/apps/layout-viewer-native/src/render_surface.rs
+++ b/ecos/layout-viewer/apps/layout-viewer-native/src/render_surface.rs
@@ -100,6 +100,7 @@ fn rgba(color: Color, alpha: u8) -> [u8; 4] {
 const PATTERN_TILE_PX: i32 = 10;
 const PATTERN_INSET_PX: i32 = 2;
 const SPARSE_DOT_SPACING_PX: i32 = 9;
+const DENSE_DOT_SPACING_PX: i32 = 5;
 
 fn rasterize_fill_rect(
     plane: &mut crate::raster_plane::RasterPlane,
@@ -114,30 +115,32 @@ fn rasterize_fill_rect(
     match style.fill_pattern {
         Pattern::Hollow => {}
         Pattern::Solid => plane.fill_rect(rect, color),
-        Pattern::SparseDots => rasterize_sparse_dots(plane, rect, color),
+        Pattern::SparseDots => rasterize_dots(plane, rect, color, SPARSE_DOT_SPACING_PX),
+        Pattern::DenseDots => rasterize_dots(plane, rect, color, DENSE_DOT_SPACING_PX),
         Pattern::DiagonalHatch => rasterize_hatch(plane, rect, color, false),
         Pattern::CrossHatch => rasterize_hatch(plane, rect, color, true),
     }
 }
 
-fn rasterize_sparse_dots(
+fn rasterize_dots(
     plane: &mut crate::raster_plane::RasterPlane,
     rect: [i32; 4],
     color: [u8; 4],
+    spacing: i32,
 ) {
     let Some([x0, y0, x1, y1]) = clipped_screen_rect(plane, rect) else {
         return;
     };
-    let mut y = snap_down_to_grid(y0, SPARSE_DOT_SPACING_PX);
+    let mut y = snap_down_to_grid(y0, spacing);
     while y < y1 {
-        let mut x = snap_down_to_grid(x0, SPARSE_DOT_SPACING_PX);
+        let mut x = snap_down_to_grid(x0, spacing);
         while x < x1 {
             if x >= x0 && y >= y0 {
                 plane.fill_rect([x, y, x + 1, y + 1], color);
             }
-            x += SPARSE_DOT_SPACING_PX;
+            x += spacing;
         }
-        y += SPARSE_DOT_SPACING_PX;
+        y += spacing;
     }
 }
 
@@ -147,9 +150,11 @@ fn rasterize_hatch(
     color: [u8; 4],
     cross: bool,
 ) {
+    let [rect_x0, rect_y0, rect_x1, rect_y1] = rect;
     let Some([x0, y0, x1, y1]) = clipped_screen_rect(plane, rect) else {
         return;
     };
+    let reverse = !cross && use_reversed_diagonal_hatch(rect_x1 - rect_x0, rect_y1 - rect_y0);
     let mut y = snap_down_to_grid(y0, PATTERN_TILE_PX);
     while y < y1 {
         let mut x = snap_down_to_grid(x0, PATTERN_TILE_PX);
@@ -159,12 +164,21 @@ fn rasterize_hatch(
             let right = (x + PATTERN_TILE_PX).min(x1);
             let bottom = (y + PATTERN_TILE_PX).min(y1);
             if right - left >= 3 && bottom - top >= 3 {
-                rasterize_screen_line(
-                    plane,
-                    (left + PATTERN_INSET_PX, bottom - PATTERN_INSET_PX),
-                    (right - PATTERN_INSET_PX, top + PATTERN_INSET_PX),
-                    color,
-                );
+                if reverse {
+                    rasterize_screen_line(
+                        plane,
+                        (left + PATTERN_INSET_PX, top + PATTERN_INSET_PX),
+                        (right - PATTERN_INSET_PX, bottom - PATTERN_INSET_PX),
+                        color,
+                    );
+                } else {
+                    rasterize_screen_line(
+                        plane,
+                        (left + PATTERN_INSET_PX, bottom - PATTERN_INSET_PX),
+                        (right - PATTERN_INSET_PX, top + PATTERN_INSET_PX),
+                        color,
+                    );
+                }
                 if cross {
                     rasterize_screen_line(
                         plane,
@@ -178,6 +192,10 @@ fn rasterize_hatch(
         }
         y += PATTERN_TILE_PX;
     }
+}
+
+fn use_reversed_diagonal_hatch(width: i32, height: i32) -> bool {
+    width > height
 }
 
 fn clipped_screen_rect(
@@ -532,6 +550,62 @@ mod tests {
     }
 
     #[test]
+    fn rasterize_plan_reverses_diagonal_hatch_for_horizontal_rects() {
+        let mut style = LayerStyle::new(Color::rgb(10, 20, 30), Color::rgb(200, 210, 220));
+        style.fill_alpha = 123;
+        style.fill_pattern = Pattern::DiagonalHatch;
+        let plan = RenderPlan {
+            batches: vec![DrawBatch {
+                plane: RenderPlane::Fill,
+                display_layer_id: "m1".to_owned(),
+                style,
+                items: vec![DrawItem::Rect(DrawRect {
+                    world: Rect::new(0, 0, 20, 8),
+                    color: Color::rgb(200, 210, 220),
+                    source_id: 1,
+                    layer_id: 1,
+                    composition: layout_display::CompositionMode::MaskPattern,
+                })],
+            }],
+            source: RenderPlanSource::HierarchyMid,
+            ..Default::default()
+        };
+
+        let plane = rasterize_plan(&plan, 20, 8, rect_to_screen);
+
+        assert_eq!(pixel(&plane, 2, 2), [10, 20, 30, 123]);
+        assert_eq!(pixel(&plane, 2, 6), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn rasterize_plan_keeps_horizontal_hatch_direction_after_clipping() {
+        let mut style = LayerStyle::new(Color::rgb(10, 20, 30), Color::rgb(200, 210, 220));
+        style.fill_alpha = 123;
+        style.fill_pattern = Pattern::DiagonalHatch;
+        let plan = RenderPlan {
+            batches: vec![DrawBatch {
+                plane: RenderPlane::Fill,
+                display_layer_id: "m1".to_owned(),
+                style,
+                items: vec![DrawItem::Rect(DrawRect {
+                    world: Rect::new(-92, 0, 8, 20),
+                    color: Color::rgb(200, 210, 220),
+                    source_id: 1,
+                    layer_id: 1,
+                    composition: layout_display::CompositionMode::MaskPattern,
+                })],
+            }],
+            source: RenderPlanSource::HierarchyMid,
+            ..Default::default()
+        };
+
+        let plane = rasterize_plan(&plan, 8, 20, rect_to_screen);
+
+        assert_eq!(pixel(&plane, 2, 2), [10, 20, 30, 123]);
+        assert_eq!(pixel(&plane, 2, 16), [0, 0, 0, 0]);
+    }
+
+    #[test]
     fn rasterize_plan_applies_sparse_dot_patterns() {
         let mut style = LayerStyle::new(Color::rgb(10, 20, 30), Color::rgb(200, 210, 220));
         style.fill_alpha = 123;
@@ -558,6 +632,35 @@ mod tests {
         assert_eq!(pixel(&plane, 0, 0), [10, 20, 30, 123]);
         assert_eq!(pixel(&plane, 1, 1), [0, 0, 0, 0]);
         assert_eq!(pixel(&plane, 9, 9), [10, 20, 30, 123]);
+    }
+
+    #[test]
+    fn rasterize_plan_applies_dense_dot_patterns() {
+        let mut style = LayerStyle::new(Color::rgb(10, 20, 30), Color::rgb(200, 210, 220));
+        style.fill_alpha = 123;
+        style.fill_pattern = Pattern::DenseDots;
+        let plan = RenderPlan {
+            batches: vec![DrawBatch {
+                plane: RenderPlane::Fill,
+                display_layer_id: "instance".to_owned(),
+                style,
+                items: vec![DrawItem::Rect(DrawRect {
+                    world: Rect::new(0, 0, 12, 12),
+                    color: Color::rgb(200, 210, 220),
+                    source_id: 1,
+                    layer_id: 1,
+                    composition: layout_display::CompositionMode::MaskPattern,
+                })],
+            }],
+            source: RenderPlanSource::HierarchyMid,
+            ..Default::default()
+        };
+
+        let plane = rasterize_plan(&plan, 12, 12, rect_to_screen);
+
+        assert_eq!(pixel(&plane, 0, 0), [10, 20, 30, 123]);
+        assert_eq!(pixel(&plane, 5, 5), [10, 20, 30, 123]);
+        assert_eq!(pixel(&plane, 9, 9), [0, 0, 0, 0]);
     }
 
     #[test]

--- a/ecos/layout-viewer/crates/layout-display/src/lib.rs
+++ b/ecos/layout-viewer/crates/layout-display/src/lib.rs
@@ -48,6 +48,7 @@ pub enum Pattern {
     Solid,
     Hollow,
     SparseDots,
+    DenseDots,
     DiagonalHatch,
     CrossHatch,
 }
@@ -410,13 +411,7 @@ fn core_style() -> LayerStyle {
 }
 
 fn instance_style() -> LayerStyle {
-    let mut style = layer_style(
-        Color::rgb(176, 155, 255),
-        34,
-        205,
-        220,
-        Pattern::DiagonalHatch,
-    );
+    let mut style = layer_style(Color::rgb(176, 155, 255), 34, 205, 220, Pattern::DenseDots);
     style.line_width_px = 1;
     style
 }
@@ -444,6 +439,7 @@ pub struct ObjectVisibility {
     pub instances: bool,
     pub pdn: bool,
     pub net: bool,
+    pub io_pin: bool,
 }
 
 impl Default for ObjectVisibility {
@@ -452,6 +448,7 @@ impl Default for ObjectVisibility {
             instances: true,
             pdn: true,
             net: true,
+            io_pin: true,
         }
     }
 }
@@ -462,6 +459,7 @@ impl ObjectVisibility {
             ShapeKind::Instance => self.instances,
             ShapeKind::SpecialWire => self.pdn,
             ShapeKind::RegularWire => self.net,
+            ShapeKind::IoPin => self.io_pin,
             _ => true,
         }
     }
@@ -707,6 +705,7 @@ mod tests {
         assert!(model.object_visibility().instances);
         assert!(model.object_visibility().pdn);
         assert!(model.object_visibility().net);
+        assert!(model.object_visibility().io_pin);
         assert!(layers.iter().any(|layer| layer.source
             == SourceSelector::ShapeKind(ShapeKind::Die)
             && !layer.visible
@@ -719,7 +718,7 @@ mod tests {
             == SourceSelector::ShapeKind(ShapeKind::Instance)
             && layer.visible
             && layer.name == "Instance"
-            && layer.style.fill_pattern != Pattern::Hollow
+            && layer.style.fill_pattern == Pattern::DenseDots
             && layer.style.fill_alpha > 0));
     }
 

--- a/ecos/layout-viewer/crates/layout-render/src/lib.rs
+++ b/ecos/layout-viewer/crates/layout-render/src/lib.rs
@@ -517,6 +517,7 @@ impl RenderPlanner {
                     &mut occupancy,
                     cell_view,
                     policy,
+                    object_visibility,
                     if is_top_cell_view(db, cell_view) {
                         1
                     } else {
@@ -1093,8 +1094,12 @@ impl RenderPlanner {
         occupancy: &mut ScreenOccupancy,
         cell_view: &CellViewState,
         policy: &HierarchyPolicy,
+        object_visibility: ObjectVisibility,
         min_depth: usize,
     ) {
+        if !object_visibility.instances {
+            return;
+        }
         let visible = VisibleShapeSources::from_layers(layers);
         if visible.is_empty() {
             return;
@@ -2229,6 +2234,7 @@ fn render_cache_key(
         hash.write_u8(u8::from(layer.object_visibility.instances));
         hash.write_u8(u8::from(layer.object_visibility.pdn));
         hash.write_u8(u8::from(layer.object_visibility.net));
+        hash.write_u8(u8::from(layer.object_visibility.io_pin));
         hash.write_u8(layer.style.fill_color.r);
         hash.write_u8(layer.style.fill_color.g);
         hash.write_u8(layer.style.fill_color.b);
@@ -2322,8 +2328,9 @@ fn pattern_code(pattern: Pattern) -> u8 {
         Pattern::Solid => 1,
         Pattern::Hollow => 2,
         Pattern::SparseDots => 3,
-        Pattern::DiagonalHatch => 4,
-        Pattern::CrossHatch => 5,
+        Pattern::DenseDots => 4,
+        Pattern::DiagonalHatch => 5,
+        Pattern::CrossHatch => 6,
     }
 }
 
@@ -4301,6 +4308,28 @@ mod tests {
     }
 
     #[test]
+    fn object_visibility_hides_near_expanded_instance_master_shapes() {
+        let db = hierarchy_db();
+        let mut model = one_layer_display_model();
+        model.object_visibility_mut().instances = false;
+
+        let plan = RenderPlanner::new(RenderSettings {
+            hierarchy_bbox_units_per_pixel: 100.0,
+            ..Default::default()
+        })
+        .plan(
+            &db,
+            &model,
+            Viewport::new(Rect::new(990, 1990, 1120, 2100), 400.0, 400.0),
+        );
+
+        assert_eq!(plan.source, RenderPlanSource::HierarchyNear);
+        assert!(!plan_contains_source_id(&plan, 9));
+        assert!(plan_contains_source_id(&plan, 42));
+        assert!(hierarchy_item_bboxes(&plan).is_empty());
+    }
+
+    #[test]
     fn near_expand_skips_hidden_physical_layers_before_querying_shapes() {
         let db = hierarchy_db();
         let mut model = one_layer_display_model();
@@ -4652,6 +4681,25 @@ mod tests {
             .is_some());
 
         model.object_visibility_mut().pdn = false;
+
+        let hit = RenderPlanner::new(RenderSettings::default()).pick(
+            &db,
+            &model,
+            PickRequest::new(50, 50, 2),
+        );
+
+        assert!(hit.is_none());
+    }
+
+    #[test]
+    fn picking_respects_io_pin_object_visibility() {
+        let db = one_shape_db_with_kind(Rect::new(10, 10, 110, 110), ShapeKind::IoPin);
+        let mut model = one_layer_display_model();
+        assert!(RenderPlanner::new(RenderSettings::default())
+            .pick(&db, &model, PickRequest::new(50, 50, 2))
+            .is_some());
+
+        model.object_visibility_mut().io_pin = false;
 
         let hit = RenderPlanner::new(RenderSettings::default()).pick(
             &db,
@@ -5296,7 +5344,7 @@ mod tests {
     }
 
     #[test]
-    fn object_visibility_filters_net_and_pdn_shapes_on_physical_layers() {
+    fn object_visibility_filters_net_pdn_and_io_pin_shapes_on_physical_layers() {
         let mut db = LayoutDb::new("unit", Rect::new(0, 0, 10_000, 10_000));
         db.add_layer(LayerInfo::new(1, "M1"));
         let top = db.top_cell();
@@ -5321,6 +5369,15 @@ mod tests {
         db.add_shape(
             top,
             ShapeRecord::new(
+                Rect::new(4_200, 4_200, 4_800, 4_800),
+                1,
+                ShapeKind::IoPin,
+                404,
+            ),
+        );
+        db.add_shape(
+            top,
+            ShapeRecord::new(
                 Rect::new(8_500, 8_500, 9_000, 9_000),
                 1,
                 ShapeKind::Via,
@@ -5330,6 +5387,7 @@ mod tests {
         let mut model = DisplayModel::from_layout_layers(db.layers());
         model.object_visibility_mut().net = false;
         model.object_visibility_mut().pdn = false;
+        model.object_visibility_mut().io_pin = false;
 
         let plan = RenderPlanner::new(RenderSettings::default()).plan(
             &db,
@@ -5349,6 +5407,7 @@ mod tests {
 
         assert!(!rendered_sources.contains(&101));
         assert!(!rendered_sources.contains(&202));
+        assert!(!rendered_sources.contains(&404));
         assert!(rendered_sources.contains(&303));
     }
 

--- a/ecos/layout-viewer/crates/layoutpkg-packer/Cargo.toml
+++ b/ecos/layout-viewer/crates/layoutpkg-packer/Cargo.toml
@@ -17,5 +17,6 @@ viewjson-importer = { path = "../viewjson-importer" }
 sha2.workspace = true
 
 [dev-dependencies]
+filetime.workspace = true
 flate2.workspace = true
 tempfile.workspace = true

--- a/ecos/layout-viewer/crates/layoutpkg-packer/src/lib.rs
+++ b/ecos/layout-viewer/crates/layoutpkg-packer/src/lib.rs
@@ -2509,6 +2509,32 @@ mod tests {
     }
 
     #[test]
+    fn source_fingerprint_changes_when_same_size_same_mtime_content_changes() {
+        let input = create_minimal_viewjson_package();
+        let manifest: ViewJsonManifest =
+            serde_json::from_str(&fs::read_to_string(input.path().join("manifest.json")).unwrap())
+                .unwrap();
+        let wire_path = input.path().join("design/regular_wires.json");
+        fs::write(&wire_path, b"aaaaaaaa").unwrap();
+        let metadata = fs::metadata(&wire_path).unwrap();
+        let modified = metadata.modified().unwrap();
+
+        let before = source_fingerprint(input.path(), &manifest).unwrap();
+
+        fs::write(&wire_path, b"bbbbbbbb").unwrap();
+        filetime::set_file_mtime(&wire_path, filetime::FileTime::from_system_time(modified))
+            .unwrap();
+        let after = source_fingerprint(input.path(), &manifest).unwrap();
+
+        assert_eq!(fs::metadata(&wire_path).unwrap().len(), metadata.len());
+        assert_eq!(
+            fs::metadata(&wire_path).unwrap().modified().unwrap(),
+            modified
+        );
+        assert_ne!(after, before);
+    }
+
+    #[test]
     fn source_fingerprint_matches_read_all_reference_hash() {
         let input = create_minimal_viewjson_package();
         let manifest: ViewJsonManifest =


### PR DESCRIPTION
## Summary

- Fix native layout viewer object visibility so instance toggles hide expanded master content and IO pins can be toggled independently.
- Update instance and hatch fill rendering, including dense dot instance patterns and horizontal hatch direction handling.
- Improve Selection sidebar wrapping/reset behavior and defer source name index loading until a selection needs it.
- Add a source fingerprint regression test for same-size, same-mtime source changes.

## Scope

Select the areas touched by this PR:

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.
- [x] Other: layout viewer native renderer and layout package tooling.

## What Changed

- Added IO Pin object visibility state and made picking/rendering respect it.
- Made instance visibility suppress hierarchy-expanded master shapes and switched instance fill to dense dots.
- Reversed diagonal hatch direction for horizontal rectangles in vector and raster paths.
- Reworked Selection sidebar rows to wrap long values and reset width after clearing selection.
- Deferred Selection name/net index loading until first selection, keeping viewer startup lighter.
- Added a content-hash regression test for source fingerprint correctness when file metadata does not change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other:
  - `cd ecos/layout-viewer && cargo fmt -p layoutpkg-packer -- --check && cargo fmt -p layout-viewer-native -- --check`
  - `cd ecos/layout-viewer && cargo test -p layoutpkg-packer`
  - `cd ecos/layout-viewer && cargo test -p layout-viewer-native`
  - `cd ecos/gui && pnpm --filter @ecos-studio/desktop-electron exec vitest run electron/services/layoutViewerService.test.ts`

Skipped checks and reason:

- Full GUI typecheck/test/build and make targets were not run; this change is scoped to the Rust layout viewer and packer, with one targeted desktop Electron service test run for the native viewer launch path.

## Screenshots or Recordings

Required for visible GUI changes.

- Not captured. Native layout viewer rendering/side panel behavior is covered by targeted Rust tests.

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Adds a Rust test-only `filetime` dev-dependency for layout package fingerprint regression coverage.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
