### PR TITLE
feat(gui): refine Resource Manager local imports and status UI

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
@@ -90,6 +90,7 @@ function registerHandlers() {
       activatePdk: vi.fn(),
       cancelResource: vi.fn(),
       getResource: vi.fn(),
+      importLocalPath: vi.fn(),
       importPdkPath: vi.fn(),
       installResource: vi.fn(),
       listResources: vi.fn(),
@@ -218,6 +219,7 @@ describe('registerIpc', () => {
       desktopApiIpcChannels.resourcesValidatePdk,
       desktopApiIpcChannels.resourcesRemovePdkReference,
       desktopApiIpcChannels.resourcesImportPdkPath,
+      desktopApiIpcChannels.resourcesImportLocalPath,
       desktopApiIpcChannels.resourcesRefreshRegistry,
       desktopApiIpcChannels.layoutViewerOpen,
       desktopApiIpcChannels.systemOpenExternal,
@@ -288,6 +290,7 @@ describe('registerIpc', () => {
       resource_id: 'tool:yosys',
     })
     services.resourceManagerService.importPdkPath.mockResolvedValue(resources.resources[0])
+    services.resourceManagerService.importLocalPath.mockResolvedValue(resources.resources[0])
 
     await expect(handlers.get(desktopApiIpcChannels.resourcesList)?.(event)).resolves.toEqual(resources)
     await expect(
@@ -306,6 +309,12 @@ describe('registerIpc', () => {
       }),
     ).resolves.toEqual(resources.resources[0])
     await expect(
+      handlers.get(desktopApiIpcChannels.resourcesImportLocalPath)?.(event, {
+        resourceId: 'pdk:ics55',
+        path: '/tmp/pdk',
+      }),
+    ).resolves.toEqual(resources.resources[0])
+    await expect(
       handlers.get(desktopApiIpcChannels.resourcesCancel)?.(event, 'tool:yosys'),
     ).resolves.toEqual({
       status: 'cancelled',
@@ -319,6 +328,7 @@ describe('registerIpc', () => {
       expect.any(Function),
     )
     expect(services.resourceManagerService.importPdkPath).toHaveBeenCalledWith('/tmp/pdk')
+    expect(services.resourceManagerService.importLocalPath).toHaveBeenCalledWith('pdk:ics55', '/tmp/pdk')
     expect(services.resourceManagerService.cancelResource).toHaveBeenCalledWith('tool:yosys')
   })
 

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
@@ -29,6 +29,7 @@ import {
   type RemoteContentReadJsonFileRequest,
   type RemoteContentReadTextFileRequest,
   type ResourceImportPdkRequest,
+  type ResourceImportLocalRequest,
   type ResourceInstallRequest,
   type ResourceJob,
   type DesktopShellDataEvent,
@@ -144,6 +145,7 @@ export interface DesktopBridgeServices {
     validatePdk(resourceId: string): Promise<unknown>
     removePdkReference(resourceId: string): Promise<unknown>
     importPdkPath(path: string): Promise<unknown>
+    importLocalPath(resourceId: string, path: string): Promise<unknown>
     refreshRegistry(): Promise<unknown>
   }
   desktopRuntimeManager: {
@@ -817,6 +819,14 @@ export function registerIpc(
   handle(desktopApiIpcChannels.resourcesImportPdkPath, async (_event, request) => {
     return await services.resourceManagerService.importPdkPath(
       (request as ResourceImportPdkRequest).path,
+    )
+  })
+
+  handle(desktopApiIpcChannels.resourcesImportLocalPath, async (_event, request) => {
+    const importRequest = request as ResourceImportLocalRequest
+    return await services.resourceManagerService.importLocalPath(
+      importRequest.resourceId,
+      importRequest.path,
     )
   })
 

--- a/ecos/gui/apps/desktop-electron/electron/preload/index.ts
+++ b/ecos/gui/apps/desktop-electron/electron/preload/index.ts
@@ -16,6 +16,7 @@ import type {
   DesktopProjectLogTailEvent,
   RemoteContentReadJsonFileRequest,
   ResourceJob,
+  ResourceImportLocalRequest,
   ResourceInstallRequest,
   DesktopSettingsValue,
   DesktopShellDataEvent,
@@ -251,6 +252,8 @@ const desktopApi: DesktopApi = {
       invokeDesktop(desktopApiIpcChannels.resourcesRemovePdkReference, resourceId),
     importPdkPath: (request) =>
       invokeDesktop(desktopApiIpcChannels.resourcesImportPdkPath, request),
+    importLocalPath: (request: ResourceImportLocalRequest) =>
+      invokeDesktop(desktopApiIpcChannels.resourcesImportLocalPath, request),
     refreshRegistry: () =>
       invokeDesktop(desktopApiIpcChannels.resourcesRefreshRegistry),
     onProgress: (listener) =>

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -74,6 +74,86 @@ function testRegistryCachePath(cacheDir: string, registryUrl: string): string {
   return join(cacheDir, `resource-registry-${key}.json`)
 }
 
+function testResourceDirs(root: string): {
+  resourcesDir: string
+  toolsDir: string
+  pdksDir: string
+} {
+  return {
+    resourcesDir: join(root, 'state', 'resources'),
+    toolsDir: join(root, 'data', 'tools'),
+    pdksDir: join(root, 'data', 'pdks'),
+  }
+}
+
+async function writeTestManifest(
+  root: string,
+  installed: Record<string, unknown>,
+): Promise<void> {
+  const dirs = testResourceDirs(root)
+  await mkdir(dirs.resourcesDir, { recursive: true })
+  await writeFile(join(dirs.resourcesDir, 'manifest.json'), JSON.stringify({
+    schema_version: 1,
+    resources_dir: dirs.resourcesDir,
+    tools_dir: dirs.toolsDir,
+    pdks_dir: dirs.pdksDir,
+    installed,
+  }), 'utf8')
+}
+
+async function writeYosysRegistry(
+  registryPath: string,
+  options: {
+    platforms?: Record<string, unknown>
+    sha256?: string
+    size?: number
+    url?: string
+    version?: string
+    versions?: unknown[]
+  } = {},
+): Promise<void> {
+  await writeFile(registryPath, JSON.stringify({
+    schema_version: 2,
+    tools: [
+      {
+        name: 'yosys',
+        display_name: 'Yosys',
+        description: 'RTL synthesis',
+        category: 'synthesis',
+        homepage: '',
+        versions: options.versions ?? [
+          {
+            version: options.version ?? '2026-05-13',
+            platforms: options.platforms ?? {
+              'all-platform': {
+                url: options.url ?? 'file:///tmp/yosys.tar',
+                sha256: options.sha256 ?? 'managed-sha',
+                size: options.size ?? 12,
+              },
+            },
+          },
+        ],
+      },
+    ],
+    pdks: [],
+  }), 'utf8')
+}
+
+function localYosysEntry(localYosys: string): Record<string, unknown> {
+  return {
+    type: 'tool',
+    name: 'yosys',
+    version: '0.66+154',
+    path: localYosys,
+    installed_at: '2026-06-30T00:00:00Z',
+    sha256: '',
+    detected_executables: ['bin/yosys'],
+    executable: 'bin/yosys',
+    active: true,
+    managed: false,
+  }
+}
+
 describe('ResourceManagerService', () => {
   afterEach(async () => {
     await Promise.all(
@@ -383,57 +463,14 @@ describe('ResourceManagerService', () => {
     const root = await createTempDir('ecos-resources-')
     const registryPath = join(root, 'registry.json')
     const localYosys = join(root, 'local', 'oss-cad-suite')
-    await mkdir(join(root, 'state', 'resources'), { recursive: true })
-    await writeFile(registryPath, JSON.stringify({
-      schema_version: 2,
-      tools: [
-        {
-          name: 'yosys',
-          display_name: 'Yosys',
-          description: 'RTL synthesis',
-          category: 'synthesis',
-          homepage: '',
-          versions: [
-            {
-              version: '2026-05-13',
-              platforms: {
-                'all-platform': {
-                  url: 'file:///tmp/yosys.tar',
-                  sha256: 'managed-sha',
-                  size: 12,
-                },
-              },
-            },
-          ],
-        },
-      ],
-      pdks: [],
-    }), 'utf8')
-    await writeFile(join(root, 'state', 'resources', 'manifest.json'), JSON.stringify({
-      schema_version: 1,
-      resources_dir: join(root, 'state', 'resources'),
-      tools_dir: join(root, 'data', 'tools'),
-      pdks_dir: join(root, 'data', 'pdks'),
-      installed: {
-        'tool:yosys': {
-          type: 'tool',
-          name: 'yosys',
-          version: '0.66+154',
-          path: localYosys,
-          installed_at: '2026-06-30T00:00:00Z',
-          sha256: '',
-          detected_executables: ['bin/yosys'],
-          executable: 'bin/yosys',
-          active: true,
-          managed: false,
-        },
-      },
-    }), 'utf8')
+    await writeYosysRegistry(registryPath)
+    await writeTestManifest(root, {
+      'tool:yosys': localYosysEntry(localYosys),
+    })
+    const dirs = testResourceDirs(root)
     const service = new ResourceManagerService({
       registryUrl: `file://${registryPath}`,
-      resourcesDir: join(root, 'state', 'resources'),
-      toolsDir: join(root, 'data', 'tools'),
-      pdksDir: join(root, 'data', 'pdks'),
+      ...dirs,
     })
 
     await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
@@ -457,57 +494,22 @@ describe('ResourceManagerService', () => {
     const root = await createTempDir('ecos-resources-')
     const registryPath = join(root, 'registry.json')
     const localYosys = join(root, 'local', 'oss-cad-suite')
-    await mkdir(join(root, 'state', 'resources'), { recursive: true })
-    await writeFile(registryPath, JSON.stringify({
-      schema_version: 2,
-      tools: [
-        {
-          name: 'yosys',
-          display_name: 'Yosys',
-          description: 'RTL synthesis',
-          category: 'synthesis',
-          homepage: '',
-          versions: [
-            {
-              version: '2026-05-13',
-              platforms: {
-                'unsupported-platform': {
-                  url: 'file:///tmp/yosys.tar',
-                  sha256: 'managed-sha',
-                  size: 12,
-                },
-              },
-            },
-          ],
-        },
-      ],
-      pdks: [],
-    }), 'utf8')
-    await writeFile(join(root, 'state', 'resources', 'manifest.json'), JSON.stringify({
-      schema_version: 1,
-      resources_dir: join(root, 'state', 'resources'),
-      tools_dir: join(root, 'data', 'tools'),
-      pdks_dir: join(root, 'data', 'pdks'),
-      installed: {
-        'tool:yosys': {
-          type: 'tool',
-          name: 'yosys',
-          version: '0.66+154',
-          path: localYosys,
-          installed_at: '2026-06-30T00:00:00Z',
-          sha256: '',
-          detected_executables: ['bin/yosys'],
-          executable: 'bin/yosys',
-          active: true,
-          managed: false,
+    await writeYosysRegistry(registryPath, {
+      platforms: {
+        'unsupported-platform': {
+          url: 'file:///tmp/yosys.tar',
+          sha256: 'managed-sha',
+          size: 12,
         },
       },
-    }), 'utf8')
+    })
+    await writeTestManifest(root, {
+      'tool:yosys': localYosysEntry(localYosys),
+    })
+    const dirs = testResourceDirs(root)
     const service = new ResourceManagerService({
       registryUrl: `file://${registryPath}`,
-      resourcesDir: join(root, 'state', 'resources'),
-      toolsDir: join(root, 'data', 'tools'),
-      pdksDir: join(root, 'data', 'pdks'),
+      ...dirs,
     })
 
     await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
@@ -517,6 +519,172 @@ describe('ResourceManagerService', () => {
       health: expect.objectContaining({
         managed: false,
       }),
+    })
+  })
+
+  it('replaces an unmanaged local tool with a managed registry install without deleting the local directory', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const archive = await createFixtureArchive(root)
+    const registryPath = join(root, 'registry.json')
+    const localYosys = join(root, 'local', 'oss-cad-suite')
+    await mkdir(join(localYosys, 'bin'), { recursive: true })
+    await writeFile(join(localYosys, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archive.path}`,
+      sha256: archive.sha256,
+      size: archive.size,
+    })
+    await writeTestManifest(root, {
+      'tool:yosys': localYosysEntry(localYosys),
+    })
+    const extract = vi.fn(async (_archivePath: string, destination: string) => {
+      await mkdir(join(destination, 'bin'), { recursive: true })
+      const executable = join(destination, 'bin', 'yosys')
+      await writeFile(executable, '#!/bin/sh\n', 'utf8')
+      await chmod(executable, 0o755)
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+      archiveExtractor: extract,
+      sha256Verifier: vi.fn(async () => true),
+    })
+
+    await expect(service.installResource('tool:yosys')).resolves.toEqual({
+      status: 'started',
+      resource_id: 'tool:yosys',
+      version: '2026-05-13',
+    })
+
+    await expect(readFile(join(localYosys, 'bin', 'yosys'), 'utf8')).resolves.toBe('#!/bin/sh\n')
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      status: 'installed',
+      source: 'registry',
+      installed_version: '2026-05-13',
+      path: join(dirs.toolsDir, 'yosys', '2026-05-13'),
+      actions: ['uninstall'],
+      health: expect.objectContaining({
+        managed: true,
+      }),
+    })
+  })
+
+  it('preserves the local tool manifest entry when a replace install fails verification', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const archive = await createFixtureArchive(root)
+    const registryPath = join(root, 'registry.json')
+    const localYosys = join(root, 'local', 'oss-cad-suite')
+    await mkdir(localYosys, { recursive: true })
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archive.path}`,
+      sha256: archive.sha256,
+      size: archive.size,
+    })
+    await writeTestManifest(root, {
+      'tool:yosys': localYosysEntry(localYosys),
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+      sha256Verifier: vi.fn(async () => false),
+    })
+
+    await expect(service.installResource('tool:yosys')).rejects.toThrow('SHA256 verification failed for yosys')
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      status: 'installed',
+      source: 'local',
+      installed_version: '0.66+154',
+      path: localYosys,
+      actions: ['install'],
+      health: expect.objectContaining({
+        managed: false,
+      }),
+    })
+  })
+
+  it('keeps managed tool update semantics on the update path', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const archive = await createFixtureArchive(root)
+    const registryPath = join(root, 'registry.json')
+    const oldManagedYosys = join(root, 'data', 'tools', 'yosys', '2026-04-01')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archive.path}`,
+      sha256: archive.sha256,
+      size: archive.size,
+      versions: [
+        {
+          version: '2026-05-13',
+          platforms: {
+            'all-platform': {
+              url: `file://${archive.path}`,
+              sha256: archive.sha256,
+              size: archive.size,
+            },
+          },
+        },
+        {
+          version: '2026-04-01',
+          platforms: {
+            'all-platform': {
+              url: `file://${archive.path}`,
+              sha256: 'old-sha',
+              size: archive.size,
+            },
+          },
+        },
+      ],
+    })
+    await writeTestManifest(root, {
+      'tool:yosys': {
+        type: 'tool',
+        name: 'yosys',
+        version: '2026-04-01',
+        path: oldManagedYosys,
+        installed_at: '2026-04-01T00:00:00Z',
+        sha256: 'old-sha',
+        detected_executables: ['bin/yosys'],
+        executable: 'bin/yosys',
+        active: true,
+        managed: true,
+      },
+    })
+    const extract = vi.fn(async (_archivePath: string, destination: string) => {
+      await mkdir(join(destination, 'bin'), { recursive: true })
+      const executable = join(destination, 'bin', 'yosys')
+      await writeFile(executable, '#!/bin/sh\n', 'utf8')
+      await chmod(executable, 0o755)
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+      archiveExtractor: extract,
+      sha256Verifier: vi.fn(async () => true),
+    })
+    const progress = vi.fn()
+
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      status: 'update_available',
+      source: 'registry',
+      installed_version: '2026-04-01',
+      available_versions: ['2026-05-13', '2026-04-01'],
+      actions: ['update', 'uninstall'],
+    })
+    await expect(service.updateResource('tool:yosys', progress)).resolves.toEqual({
+      status: 'started',
+      resource_id: 'tool:yosys',
+      version: '2026-05-13',
+    })
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'update',
+      resource_id: 'tool:yosys',
+    }))
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      status: 'installed',
+      installed_version: '2026-05-13',
+      actions: ['uninstall'],
     })
   })
 

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -692,6 +692,20 @@ describe('ResourceManagerService', () => {
     )
   })
 
+  it('rejects a local tool import when the expected executable path is a directory', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const localYosys = join(root, 'local', 'oss-cad-suite')
+    await mkdir(join(localYosys, 'bin', 'yosys'), { recursive: true })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      ...dirs,
+    })
+
+    await expect(service.importLocalPath('tool:yosys', localYosys)).rejects.toThrow(
+      'Expected executable is not a file for yosys',
+    )
+  })
+
   it('imports a row-bound local PDK when the scanned PDK id matches', async () => {
     const root = await createTempDir('ecos-resources-')
     const pdkRoot = join(root, 'local', 'ics55')

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -634,6 +634,115 @@ describe('ResourceManagerService', () => {
     })
   })
 
+  it('imports a local tool reference from a row-bound resource id', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const registryPath = join(root, 'registry.json')
+    const localYosys = join(root, 'local', 'oss-cad-suite')
+    await mkdir(join(localYosys, 'bin'), { recursive: true })
+    await writeFile(join(localYosys, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(localYosys, 'bin', 'yosys'), 0o755)
+    await writeYosysRegistry(registryPath)
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.importLocalPath('tool:yosys', localYosys)).resolves.toMatchObject({
+      id: 'tool:yosys',
+      status: 'installed',
+      source: 'local',
+      path: localYosys,
+      actions: ['install', 'remove_reference'],
+      health: expect.objectContaining({
+        detected_executables: ['bin/yosys'],
+        executable: 'bin/yosys',
+        managed: false,
+      }),
+    })
+
+    await expect(readFile(join(localYosys, 'bin', 'yosys'), 'utf8')).resolves.toBe('#!/bin/sh\n')
+    const manifest = JSON.parse(
+      await readFile(join(dirs.resourcesDir, 'manifest.json'), 'utf8'),
+    ) as { installed: Record<string, unknown> }
+    expect(manifest.installed['tool:yosys']).toMatchObject({
+      type: 'tool',
+      name: 'yosys',
+      version: '',
+      path: localYosys,
+      sha256: '',
+      detected_executables: ['bin/yosys'],
+      executable: 'bin/yosys',
+      active: true,
+      managed: false,
+    })
+  })
+
+  it('rejects a local tool import when the expected executable is missing', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const localYosys = join(root, 'local', 'oss-cad-suite')
+    await mkdir(join(localYosys, 'bin'), { recursive: true })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      ...dirs,
+    })
+
+    await expect(service.importLocalPath('tool:yosys', localYosys)).rejects.toThrow(
+      'Expected executable not found for yosys',
+    )
+  })
+
+  it('imports a row-bound local PDK when the scanned PDK id matches', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const pdkRoot = join(root, 'local', 'ics55')
+    await mkdir(join(pdkRoot, 'IP'), { recursive: true })
+    await mkdir(join(pdkRoot, 'prtech'), { recursive: true })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      ...dirs,
+    })
+
+    await expect(service.importLocalPath('pdk:ics55', pdkRoot)).resolves.toMatchObject({
+      id: 'pdk:ics55',
+      status: 'installed',
+      source: 'local',
+      path: pdkRoot,
+      actions: ['validate', 'remove_reference'],
+      health: expect.objectContaining({
+        managed: false,
+        status: 'ok',
+      }),
+    })
+
+    const manifest = JSON.parse(
+      await readFile(join(dirs.resourcesDir, 'manifest.json'), 'utf8'),
+    ) as { installed: Record<string, unknown> }
+    expect(manifest.installed['pdk:ics55']).toMatchObject({
+      type: 'pdk',
+      id: 'ics55',
+      pdk_id: 'ics55',
+      canonical_path: pdkRoot,
+      path: pdkRoot,
+      active: true,
+      managed: false,
+      health: 'ok',
+    })
+  })
+
+  it('rejects row-bound local PDK import when the scanned PDK id differs', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const pdkRoot = join(root, 'local', 'otherpdk')
+    await mkdir(pdkRoot, { recursive: true })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      ...dirs,
+    })
+
+    await expect(service.importLocalPath('pdk:ics55', pdkRoot)).rejects.toThrow(
+      "Selected directory contains PDK 'otherpdk', expected 'ics55'",
+    )
+  })
+
   it('keeps managed tool update semantics on the update path', async () => {
     const root = await createTempDir('ecos-resources-')
     const archive = await createFixtureArchive(root)

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -483,7 +483,7 @@ describe('ResourceManagerService', () => {
       active: true,
       active_version: '0.66+154',
       path: localYosys,
-      actions: ['install'],
+      actions: ['install', 'remove_reference'],
       health: expect.objectContaining({
         managed: false,
       }),
@@ -515,7 +515,7 @@ describe('ResourceManagerService', () => {
     await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
       status: 'installed',
       source: 'local',
-      actions: [],
+      actions: ['remove_reference'],
       health: expect.objectContaining({
         managed: false,
       }),
@@ -597,10 +597,40 @@ describe('ResourceManagerService', () => {
       source: 'local',
       installed_version: '0.66+154',
       path: localYosys,
-      actions: ['install'],
+      actions: ['install', 'remove_reference'],
       health: expect.objectContaining({
         managed: false,
       }),
+    })
+  })
+
+  it('removes an unmanaged local tool reference without deleting the local directory', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const registryPath = join(root, 'registry.json')
+    const localYosys = join(root, 'local', 'oss-cad-suite')
+    await mkdir(join(localYosys, 'bin'), { recursive: true })
+    await writeFile(join(localYosys, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await writeYosysRegistry(registryPath)
+    await writeTestManifest(root, {
+      'tool:yosys': localYosysEntry(localYosys),
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.uninstallResource('tool:yosys')).resolves.toEqual({
+      status: 'removed',
+      resource_id: 'tool:yosys',
+    })
+
+    await expect(readFile(join(localYosys, 'bin', 'yosys'), 'utf8')).resolves.toBe('#!/bin/sh\n')
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      status: 'available',
+      source: 'registry',
+      installed_version: null,
+      actions: ['install'],
     })
   })
 

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -379,6 +379,147 @@ describe('ResourceManagerService', () => {
     })
   })
 
+  it('lists an unmanaged local registry tool as local with a replace install action', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const registryPath = join(root, 'registry.json')
+    const localYosys = join(root, 'local', 'oss-cad-suite')
+    await mkdir(join(root, 'state', 'resources'), { recursive: true })
+    await writeFile(registryPath, JSON.stringify({
+      schema_version: 2,
+      tools: [
+        {
+          name: 'yosys',
+          display_name: 'Yosys',
+          description: 'RTL synthesis',
+          category: 'synthesis',
+          homepage: '',
+          versions: [
+            {
+              version: '2026-05-13',
+              platforms: {
+                'all-platform': {
+                  url: 'file:///tmp/yosys.tar',
+                  sha256: 'managed-sha',
+                  size: 12,
+                },
+              },
+            },
+          ],
+        },
+      ],
+      pdks: [],
+    }), 'utf8')
+    await writeFile(join(root, 'state', 'resources', 'manifest.json'), JSON.stringify({
+      schema_version: 1,
+      resources_dir: join(root, 'state', 'resources'),
+      tools_dir: join(root, 'data', 'tools'),
+      pdks_dir: join(root, 'data', 'pdks'),
+      installed: {
+        'tool:yosys': {
+          type: 'tool',
+          name: 'yosys',
+          version: '0.66+154',
+          path: localYosys,
+          installed_at: '2026-06-30T00:00:00Z',
+          sha256: '',
+          detected_executables: ['bin/yosys'],
+          executable: 'bin/yosys',
+          active: true,
+          managed: false,
+        },
+      },
+    }), 'utf8')
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+    })
+
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      id: 'tool:yosys',
+      type: 'tool',
+      status: 'installed',
+      source: 'local',
+      installed_version: '0.66+154',
+      available_versions: ['2026-05-13'],
+      active: true,
+      active_version: '0.66+154',
+      path: localYosys,
+      actions: ['install'],
+      health: expect.objectContaining({
+        managed: false,
+      }),
+    })
+  })
+
+  it('does not offer replace for an unmanaged local registry tool without a usable platform asset', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const registryPath = join(root, 'registry.json')
+    const localYosys = join(root, 'local', 'oss-cad-suite')
+    await mkdir(join(root, 'state', 'resources'), { recursive: true })
+    await writeFile(registryPath, JSON.stringify({
+      schema_version: 2,
+      tools: [
+        {
+          name: 'yosys',
+          display_name: 'Yosys',
+          description: 'RTL synthesis',
+          category: 'synthesis',
+          homepage: '',
+          versions: [
+            {
+              version: '2026-05-13',
+              platforms: {
+                'unsupported-platform': {
+                  url: 'file:///tmp/yosys.tar',
+                  sha256: 'managed-sha',
+                  size: 12,
+                },
+              },
+            },
+          ],
+        },
+      ],
+      pdks: [],
+    }), 'utf8')
+    await writeFile(join(root, 'state', 'resources', 'manifest.json'), JSON.stringify({
+      schema_version: 1,
+      resources_dir: join(root, 'state', 'resources'),
+      tools_dir: join(root, 'data', 'tools'),
+      pdks_dir: join(root, 'data', 'pdks'),
+      installed: {
+        'tool:yosys': {
+          type: 'tool',
+          name: 'yosys',
+          version: '0.66+154',
+          path: localYosys,
+          installed_at: '2026-06-30T00:00:00Z',
+          sha256: '',
+          detected_executables: ['bin/yosys'],
+          executable: 'bin/yosys',
+          active: true,
+          managed: false,
+        },
+      },
+    }), 'utf8')
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+    })
+
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      status: 'installed',
+      source: 'local',
+      actions: [],
+      health: expect.objectContaining({
+        managed: false,
+      }),
+    })
+  })
+
   it('streams remote downloads and emits byte progress while downloading a managed tool', async () => {
     const root = await createTempDir('ecos-resources-')
     const registryPath = join(root, 'registry.json')

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -641,6 +641,9 @@ describe('ResourceManagerService', () => {
     await mkdir(join(localYosys, 'bin'), { recursive: true })
     await writeFile(join(localYosys, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
     await chmod(join(localYosys, 'bin', 'yosys'), 0o755)
+    await mkdir(join(localYosys, 'share', 'tools'), { recursive: true })
+    await writeFile(join(localYosys, 'share', 'tools', 'helper'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(localYosys, 'share', 'tools', 'helper'), 0o755)
     await writeYosysRegistry(registryPath)
     const dirs = testResourceDirs(root)
     const service = new ResourceManagerService({

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -460,7 +460,7 @@ export class ResourceManagerService {
       throw new Error(`Expected executable is not executable for ${name}`)
     }
 
-    const detected = await detectExecutables(canonicalPath)
+    const detected = [expectedExecutable]
     const resourceId = `tool:${name}`
     const manifest = await this.readManifest()
     const entry: ToolInventoryEntry = {

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -915,13 +915,19 @@ export class ResourceManagerService {
     const resourceId = `tool:${tool.name}`
     let status: ResourceStatus = 'available'
     let actions: ResourceAction[] = ['install']
+    const source = local && !local.managed ? 'local' : 'registry'
 
     if (this.activeJobs.has(resourceId)) {
       status = 'installing'
       actions = []
     } else if (local) {
-      status = versions.length > 0 && versions[0] !== local.version ? 'update_available' : 'installed'
-      actions = local.managed ? (status === 'update_available' ? ['update', 'uninstall'] : ['uninstall']) : []
+      if (local.managed) {
+        status = versions.length > 0 && versions[0] !== local.version ? 'update_available' : 'installed'
+        actions = status === 'update_available' ? ['update', 'uninstall'] : ['uninstall']
+      } else {
+        status = 'installed'
+        actions = asset ? ['install'] : []
+      }
     }
 
     return {
@@ -940,7 +946,7 @@ export class ResourceManagerService {
       managed_root: this.toolsDir,
       platform,
       size: asset?.size ?? null,
-      source: 'registry',
+      source,
       homepage: tool.homepage,
       actions,
       health: local ? toolHealth(local) : {},

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -422,12 +422,104 @@ export class ResourceManagerService {
     return this.pdkEntryToResource(manifest.installed[resourceId] as PdkInventoryEntry)
   }
 
+  async importLocalPath(resourceId: string, path: string): Promise<ResourceInfo> {
+    if (resourceId.startsWith('tool:')) {
+      return await this.importToolPath(resourceNameFromId(resourceId, 'tool'), path)
+    }
+    if (resourceId.startsWith('pdk:')) {
+      return await this.importPdkPathForResource(resourceNameFromId(resourceId, 'pdk'), path)
+    }
+    throw new Error(`Unsupported resource id: ${resourceId}`)
+  }
+
   async refreshRegistry(): Promise<{ status: string; tools_count: number }> {
     const state = await this.fetchRegistry(true)
     return {
       status: state.registry ? 'refreshed' : 'degraded',
       tools_count: state.registry?.tools.length ?? 0,
     }
+  }
+
+  private async importToolPath(name: string, path: string): Promise<ResourceInfo> {
+    const canonicalPath = resolve(path)
+    const pathStats = await stat(canonicalPath)
+    if (!pathStats.isDirectory()) {
+      throw new Error(`Not a directory: ${path}`)
+    }
+
+    const expectedExecutable = `bin/${name}`
+    const expectedPath = join(canonicalPath, ...expectedExecutable.split('/'))
+    if (!await pathExists(expectedPath)) {
+      throw new Error(`Expected executable not found for ${name}`)
+    }
+    if (!await isUsableExecutable(expectedPath, process.platform)) {
+      throw new Error(`Expected executable is not executable for ${name}`)
+    }
+
+    const detected = await detectExecutables(canonicalPath)
+    const resourceId = `tool:${name}`
+    const manifest = await this.readManifest()
+    const entry: ToolInventoryEntry = {
+      type: 'tool',
+      name,
+      version: '',
+      path: canonicalPath,
+      installed_at: utcNowIso(),
+      sha256: '',
+      detected_executables: detected,
+      executable: expectedExecutable,
+      active: true,
+      managed: false,
+    }
+    manifest.installed[resourceId] = entry
+    await this.writeManifest(manifest)
+    return await this.getResource(resourceId)
+  }
+
+  private async importPdkPathForResource(pdkId: string, path: string): Promise<ResourceInfo> {
+    const scanned = await scanPdkDirectory(path)
+    if (scanned.pdkId !== pdkId) {
+      throw new Error(`Selected directory contains PDK '${scanned.pdkId}', expected '${pdkId}'`)
+    }
+
+    const resourceId = `pdk:${pdkId}`
+    const manifest = await this.readManifest()
+    const previous = manifest.installed[resourceId]
+    const hasOtherActivePdk = Object.entries(manifest.installed).some(([id, entry]) => {
+      return id !== resourceId && isPdkEntry(entry) && entry.active
+    })
+    const active = isPdkEntry(previous)
+      ? previous.active || !hasOtherActivePdk
+      : !hasOtherActivePdk
+    if (active) {
+      for (const [id, entry] of Object.entries(manifest.installed)) {
+        if (id !== resourceId && isPdkEntry(entry)) {
+          entry.active = false
+        }
+      }
+    }
+
+    const entry: PdkInventoryEntry = {
+      type: 'pdk',
+      id: pdkId,
+      name: scanned.name,
+      pdk_id: pdkId,
+      version: '',
+      sha256: '',
+      source: 'local',
+      source_url: '',
+      canonical_path: scanned.canonicalPath,
+      path: scanned.canonicalPath,
+      detected_files: [...scanned.detectedFiles.directories, ...scanned.detectedFiles.files],
+      detected_file_groups: scanned.detectedFiles,
+      imported_at: utcNowIso(),
+      active,
+      managed: false,
+      health: 'ok',
+    }
+    manifest.installed[resourceId] = entry
+    await this.writeManifest(manifest)
+    return this.pdkEntryToResource(entry, this.findRegistryPdk(this.registryMemory, pdkId))
   }
 
   private async installTool(
@@ -1805,7 +1897,7 @@ async function collectExecutableFiles(root: string, directory: string, results: 
       await collectExecutableFiles(root, path, results)
     } else if (entry.isFile()) {
       try {
-        await access(path, 0o111)
+        await access(path, constants.X_OK)
         results.push(path.slice(root.length + 1).replace(/\\/g, '/'))
       } catch {
         // Non-executable files are ignored.

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -334,7 +334,9 @@ export class ResourceManagerService {
       throw new Error(`Tool '${name}' is not installed`)
     }
     if (!entry.managed) {
-      throw new Error(`Tool '${name}' is unmanaged and cannot be uninstalled`)
+      delete manifest.installed[resourceId]
+      await this.writeManifest(manifest)
+      return { status: 'removed', resource_id: resourceId }
     }
     await rm(entry.path, { force: true, recursive: true })
     delete manifest.installed[resourceId]
@@ -926,7 +928,7 @@ export class ResourceManagerService {
         actions = status === 'update_available' ? ['update', 'uninstall'] : ['uninstall']
       } else {
         status = 'installed'
-        actions = asset ? ['install'] : []
+        actions = asset ? ['install', 'remove_reference'] : ['remove_reference']
       }
     }
 
@@ -974,7 +976,7 @@ export class ResourceManagerService {
       size: null,
       source: 'local',
       homepage: '',
-      actions: entry.managed ? ['uninstall'] : [],
+      actions: entry.managed ? ['uninstall'] : ['remove_reference'],
       health: toolHealth(entry),
       error: null,
     }

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -452,6 +452,10 @@ export class ResourceManagerService {
     if (!await pathExists(expectedPath)) {
       throw new Error(`Expected executable not found for ${name}`)
     }
+    const expectedStats = await stat(expectedPath)
+    if (!expectedStats.isFile()) {
+      throw new Error(`Expected executable is not a file for ${name}`)
+    }
     if (!await isUsableExecutable(expectedPath, process.platform)) {
       throw new Error(`Expected executable is not executable for ${name}`)
     }

--- a/ecos/gui/apps/renderer/src/api/index.ts
+++ b/ecos/gui/apps/renderer/src/api/index.ts
@@ -35,6 +35,7 @@ export {
 export {
   activatePdkApi,
   getToolStatusApi,
+  importLocalResourcePathApi,
   importPdkPathApi,
   installResourceApi,
   installToolApi,

--- a/ecos/gui/apps/renderer/src/api/plugin.test.ts
+++ b/ecos/gui/apps/renderer/src/api/plugin.test.ts
@@ -4,6 +4,7 @@ const resourcesBridge = vi.hoisted(() => ({
   activatePdk: vi.fn(),
   cancel: vi.fn(),
   get: vi.fn(),
+  importLocalPath: vi.fn(),
   importPdkPath: vi.fn(),
   install: vi.fn(),
   list: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock('@/platform/desktop', () => ({
 
 import {
   cancelResourceApi,
+  importLocalResourcePathApi,
   importPdkPathApi,
   resourceJobToInstallProgress,
   resourceListToResources,
@@ -232,6 +234,39 @@ describe('Resource Manager tool API adapter', () => {
 
     expect(resourcesBridge.importPdkPath).toHaveBeenCalledWith({
       path: '/tmp/pdks/local55',
+    })
+  })
+
+  it('imports row-bound local resource paths through the desktop resource bridge', async () => {
+    const imported = {
+      id: 'tool:yosys',
+      type: 'tool' as const,
+      name: 'yosys',
+      display_name: 'Yosys',
+      description: 'RTL synthesis',
+      category: 'synthesis',
+      status: 'installed' as const,
+      installed_version: '',
+      available_versions: ['2026-05-13'],
+      active_version: '',
+      active: true,
+      path: '/tmp/oss-cad-suite',
+      managed_root: null,
+      platform: null,
+      size: null,
+      source: 'local',
+      homepage: '',
+      actions: ['install' as const, 'remove_reference' as const],
+      health: { managed: false },
+      error: null,
+    }
+    resourcesBridge.importLocalPath.mockResolvedValue(imported)
+
+    await expect(importLocalResourcePathApi('tool:yosys', '/tmp/oss-cad-suite')).resolves.toEqual(imported)
+
+    expect(resourcesBridge.importLocalPath).toHaveBeenCalledWith({
+      resourceId: 'tool:yosys',
+      path: '/tmp/oss-cad-suite',
     })
   })
 

--- a/ecos/gui/apps/renderer/src/api/plugin.ts
+++ b/ecos/gui/apps/renderer/src/api/plugin.ts
@@ -138,6 +138,10 @@ export function importPdkPathApi(path: string) {
   return getDesktopApi().resources.importPdkPath({ path })
 }
 
+export function importLocalResourcePathApi(resourceId: string, path: string) {
+  return getDesktopApi().resources.importLocalPath({ resourceId, path })
+}
+
 export function installResourceApi(resourceId: string, version?: string) {
   return getDesktopApi().resources.install({ resourceId, version })
 }

--- a/ecos/gui/apps/renderer/src/composables/useDesktopRuntime.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesktopRuntime.test.ts
@@ -155,6 +155,7 @@ const desktopBridge = {
     validatePdk: async (resourceId) => ({ resource_id: resourceId, health: { status: 'ok' } }),
     removePdkReference: async (resourceId) => ({ status: 'removed', resource_id: resourceId }),
     importPdkPath: async () => { throw new Error('not implemented') },
+    importLocalPath: async () => { throw new Error('not implemented') },
     refreshRegistry: async () => ({ status: 'refreshed', tools_count: 0 }),
     onProgress: () => () => undefined,
   },

--- a/ecos/gui/apps/renderer/src/composables/usePdkManager.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/usePdkManager.test.ts
@@ -32,6 +32,28 @@ const importPdkPath = vi.fn(async () => ({
   health: {},
   error: null,
 }))
+const importLocalPath = vi.fn(async () => ({
+  id: 'pdk:ics55',
+  type: 'pdk' as const,
+  name: 'ics55',
+  display_name: 'ics55',
+  description: '',
+  category: 'pdk',
+  status: 'installed' as const,
+  installed_version: null,
+  available_versions: [],
+  active_version: null,
+  active: false,
+  path: '/tmp/pdk',
+  managed_root: null,
+  platform: null,
+  size: null,
+  source: 'local',
+  homepage: '',
+  actions: ['validate' as const, 'activate' as const, 'remove_reference' as const],
+  health: {},
+  error: null,
+}))
 const removePdkReference = vi.fn(async (resourceId: string) => ({
   status: 'removed',
   resource_id: resourceId,
@@ -172,7 +194,7 @@ const desktopBridge = {
     validatePdk: async (resourceId) => ({ resource_id: resourceId, health: { status: 'ok' } }),
     removePdkReference,
     importPdkPath,
-    importLocalPath: async () => { throw new Error('not implemented') },
+    importLocalPath,
     refreshRegistry: async () => ({ status: 'refreshed', tools_count: 0 }),
     onProgress: () => () => undefined,
   },
@@ -223,6 +245,7 @@ describe('usePdkManager', () => {
     settingsDelete.mockReset()
     pickDirectory.mockReset()
     importPdkPath.mockReset()
+    importLocalPath.mockReset()
     removePdkReference.mockReset()
     scanPdkDirectory.mockReset()
     localStorageState.clear()
@@ -243,6 +266,7 @@ describe('usePdkManager', () => {
     })
     pickDirectory.mockResolvedValue('/tmp/pdk')
     importPdkPath.mockResolvedValue({} as never)
+    importLocalPath.mockResolvedValue({} as never)
     removePdkReference.mockImplementation(async (resourceId: string) => ({
       status: 'removed',
       resource_id: resourceId,
@@ -318,6 +342,26 @@ describe('usePdkManager', () => {
 
     expect(importedPdks.value).toHaveLength(1)
     expect(importPdkPath).toHaveBeenCalledWith({ path: '/tmp/pdks/ics55' })
+  })
+
+  it('imports a row-bound PDK through the local resource API and persists it for project creation', async () => {
+    const { importPdkForResource, importedPdks } = usePdkManager()
+
+    const imported = await importPdkForResource('pdk:ics55', '/tmp/pdk')
+
+    expect(imported).toMatchObject({
+      path: '/tmp/pdk',
+      pdkId: 'ics55',
+    })
+    expect(scanPdkDirectory).toHaveBeenCalledWith('/tmp/pdk')
+    expect(importLocalPath).toHaveBeenCalledWith({
+      resourceId: 'pdk:ics55',
+      path: '/tmp/pdk',
+    })
+    expect(importPdkPath).not.toHaveBeenCalled()
+    expect(importedPdks.value).toHaveLength(1)
+    expect(settingsSet).toHaveBeenCalledWith('imported_pdks', expect.any(Array))
+    expect(showToast).not.toHaveBeenCalled()
   })
 
   it('removes the resource manager PDK reference before deleting a local PDK entry', async () => {

--- a/ecos/gui/apps/renderer/src/composables/usePdkManager.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/usePdkManager.test.ts
@@ -172,6 +172,7 @@ const desktopBridge = {
     validatePdk: async (resourceId) => ({ resource_id: resourceId, health: { status: 'ok' } }),
     removePdkReference,
     importPdkPath,
+    importLocalPath: async () => { throw new Error('not implemented') },
     refreshRegistry: async () => ({ status: 'refreshed', tools_count: 0 }),
     onProgress: () => () => undefined,
   },

--- a/ecos/gui/apps/renderer/src/composables/usePdkManager.ts
+++ b/ecos/gui/apps/renderer/src/composables/usePdkManager.ts
@@ -1,9 +1,11 @@
 import { ref, toRaw } from 'vue'
 import type { DesktopApi, DesktopSettingsValue, ScannedPdkDirectory } from '@ecos-studio/shared'
-import { importPdkPathApi, removePdkReferenceApi } from '@/api/plugin'
+import { importLocalResourcePathApi, importPdkPathApi, removePdkReferenceApi } from '@/api/plugin'
 import { hasDesktopApi, waitForDesktopApi } from '@/platform/desktop'
 import { useWorkspace } from './useWorkspace'
 import type { ImportedPdk } from '../types'
+
+const INVALID_PDK_PATH_MESSAGE = 'PDK path cannot contain Chinese or spaces, please select a directory containing only English, numbers and common symbols.'
 
 /** 路径中是否包含中文或空格（不允许，会导致工具链异常） */
 function pathHasInvalidChars(path: string): boolean {
@@ -233,8 +235,35 @@ export function usePdkManager() {
     return await desktopApi.workspace.scanPdkDirectory(path)
   }
 
-  const syncImportedPdkReference = async (path: string): Promise<void> => {
+  const syncImportedPdkReference = async (path: string, resourceId?: string): Promise<void> => {
+    if (resourceId) {
+      await importLocalResourcePathApi(resourceId, path)
+      return
+    }
     await importPdkPathApi(path)
+  }
+
+  const saveDetectedPdk = async (
+    desktopApi: DesktopApi,
+    detected: ScannedPdkDirectory,
+    resourceId?: string,
+  ): Promise<ImportedPdk> => {
+    const normalizedPath = normalizePdkPath(detected.canonicalPath)
+    const existing = importedPdks.value.find(
+      p => normalizePdkPath(p.path) === normalizedPath
+    )
+    if (existing) {
+      await syncImportedPdkReference(detected.canonicalPath, resourceId)
+      return existing
+    }
+
+    await syncImportedPdkReference(detected.canonicalPath, resourceId)
+    const pdk = buildImportedPdk(detected)
+
+    importedPdks.value.push(pdk)
+    await savePdks(desktopApi)
+
+    return pdk
   }
 
   // ============ PDK 操作 ============
@@ -256,7 +285,7 @@ export function usePdkManager() {
 
       // 路径不允许包含中文或空格，避免工具链异常
       if (pathHasInvalidChars(path)) {
-        showToast({ severity: 'error', summary: 'Invalid PDK Path', detail: 'PDK path cannot contain Chinese or spaces, please select a directory containing only English, numbers and common symbols.' })
+        showToast({ severity: 'error', summary: 'Invalid PDK Path', detail: INVALID_PDK_PATH_MESSAGE })
         return null
       }
 
@@ -273,23 +302,7 @@ export function usePdkManager() {
         return null
       }
 
-      const normalizedPath = normalizePdkPath(detected.canonicalPath)
-      const existing = importedPdks.value.find(
-        p => normalizePdkPath(p.path) === normalizedPath
-      )
-      if (existing) {
-        await syncImportedPdkReference(detected.canonicalPath)
-        console.warn('[usePdkManager] PDK already imported:', detected.canonicalPath)
-        return existing
-      }
-
-      await syncImportedPdkReference(detected.canonicalPath)
-      const pdk = buildImportedPdk(detected)
-
-      importedPdks.value.push(pdk)
-      await savePdks(desktopApi)
-
-      return pdk
+      return await saveDetectedPdk(desktopApi, detected)
     } catch (error) {
       console.error('[usePdkManager] Import PDK error:', error)
       showToast({
@@ -327,22 +340,7 @@ export function usePdkManager() {
         return null
       }
 
-      const normalizedPath = normalizePdkPath(detected.canonicalPath)
-      const existing = importedPdks.value.find(
-        p => normalizePdkPath(p.path) === normalizedPath
-      )
-      if (existing) {
-        await syncImportedPdkReference(detected.canonicalPath)
-        return existing
-      }
-
-      await syncImportedPdkReference(detected.canonicalPath)
-      const pdk = buildImportedPdk(detected)
-
-      importedPdks.value.push(pdk)
-      await savePdks(desktopApi)
-
-      return pdk
+      return await saveDetectedPdk(desktopApi, detected)
     } catch (error) {
       console.error('[usePdkManager] Import PDK by path error:', error)
       showToast({
@@ -352,6 +350,25 @@ export function usePdkManager() {
       })
       return null
     }
+  }
+
+  const importPdkForResource = async (resourceId: string, path: string): Promise<ImportedPdk> => {
+    const desktopApi = await waitForDesktopApi()
+
+    if (pathHasInvalidChars(path)) {
+      throw new Error(INVALID_PDK_PATH_MESSAGE)
+    }
+
+    let detected: ScannedPdkDirectory
+    try {
+      detected = await scanPdkDirectory(desktopApi, path)
+    } catch (error) {
+      throw Object.assign(new Error('The selected PDK directory could not be scanned.'), {
+        cause: error,
+      })
+    }
+
+    return await saveDetectedPdk(desktopApi, detected, resourceId)
   }
 
   /** 删除已导入的 PDK */
@@ -381,6 +398,7 @@ export function usePdkManager() {
     loadPdks,
     importPdk,
     importPdkByPath,
+    importPdkForResource,
     removePdk,
     getPdkById,
   }

--- a/ecos/gui/apps/renderer/src/composables/useVersion.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useVersion.test.ts
@@ -131,6 +131,7 @@ function createDesktopBridge(getVersions: DesktopApi['app']['getVersions']) {
       validatePdk: async (resourceId) => ({ resource_id: resourceId, health: { status: 'ok' } }),
       removePdkReference: async (resourceId) => ({ status: 'removed', resource_id: resourceId }),
       importPdkPath: async () => { throw new Error('not implemented') },
+      importLocalPath: async () => { throw new Error('not implemented') },
       refreshRegistry: async () => ({ status: 'refreshed', tools_count: 0 }),
       onProgress: () => () => undefined,
     },

--- a/ecos/gui/apps/renderer/src/stores/pluginStore.test.ts
+++ b/ecos/gui/apps/renderer/src/stores/pluginStore.test.ts
@@ -644,6 +644,38 @@ describe('pluginStore', () => {
     })
   })
 
+  it('uses a caller-provided local importer while preserving row error handling', async () => {
+    const localPdk = makePdkResource({
+      status: 'installed',
+      source: 'local',
+      path: '/tmp/pdk',
+      actions: ['validate', 'remove_reference'],
+      health: { managed: false },
+    })
+    const importPdkForResource = vi.fn(async () => localPdk)
+
+    vi.mocked(listResourcesApi)
+      .mockResolvedValueOnce([makePdkResource()])
+      .mockResolvedValueOnce([localPdk])
+
+    const store = usePluginStore()
+    await store.fetchTools()
+    store.resourceErrors['pdk:ics55'] = 'Previous error'
+
+    await store.importLocalResource('pdk:ics55', '/tmp/pdk', importPdkForResource)
+
+    expect(importPdkForResource).toHaveBeenCalledWith('pdk:ics55', '/tmp/pdk')
+    expect(importLocalResourcePathApi).not.toHaveBeenCalled()
+    expect(store.resourceErrors['pdk:ics55']).toBeUndefined()
+    expect(listResourcesApi).toHaveBeenCalledTimes(2)
+    expect(store.resources[0]).toMatchObject({
+      id: 'pdk:ics55',
+      status: 'installed',
+      source: 'local',
+      path: '/tmp/pdk',
+    })
+  })
+
   it('stores local import errors by resourceId and refreshes resources silently', async () => {
     const availableTool = makeToolResource()
     vi.mocked(listResourcesApi)

--- a/ecos/gui/apps/renderer/src/stores/pluginStore.test.ts
+++ b/ecos/gui/apps/renderer/src/stores/pluginStore.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/api/plugin', async (importOriginal) => {
     ...actual,
     activatePdkApi: vi.fn(),
     cancelResourceApi: vi.fn(),
+    importLocalResourcePathApi: vi.fn(),
     installResourceApi: vi.fn(),
     installToolApi: vi.fn(),
     listResourcesApi: vi.fn(),
@@ -25,6 +26,7 @@ vi.mock('@/api/plugin', async (importOriginal) => {
 
 import {
   cancelResourceApi,
+  importLocalResourcePathApi,
   installResourceApi,
   listResourcesApi,
   resourceListToTools,
@@ -103,6 +105,7 @@ describe('pluginStore', () => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.mocked(cancelResourceApi).mockReset()
+    vi.mocked(importLocalResourcePathApi).mockReset()
     vi.mocked(installResourceApi).mockReset()
     vi.mocked(listResourcesApi).mockReset()
     vi.mocked(subscribeResourceProgress).mockReset()
@@ -608,5 +611,52 @@ describe('pluginStore', () => {
     expect(subscribeResourceProgress).not.toHaveBeenCalled()
     expect(listResourcesApi).toHaveBeenCalledTimes(2)
     expect(store.resources).toEqual([])
+  })
+
+  it('imports a local resource path, clears row errors, and refreshes resources', async () => {
+    const localTool = makeToolResource({
+      status: 'installed',
+      source: 'local',
+      path: '/tmp/oss-cad-suite',
+      actions: ['install', 'remove_reference'],
+      health: { managed: false },
+    })
+
+    vi.mocked(listResourcesApi)
+      .mockResolvedValueOnce([makeToolResource()])
+      .mockResolvedValueOnce([localTool])
+    vi.mocked(importLocalResourcePathApi).mockResolvedValue(localTool)
+
+    const store = usePluginStore()
+    await store.fetchTools()
+    store.resourceErrors['tool:yosys'] = 'Previous error'
+
+    await store.importLocalResource('tool:yosys', '/tmp/oss-cad-suite')
+
+    expect(importLocalResourcePathApi).toHaveBeenCalledWith('tool:yosys', '/tmp/oss-cad-suite')
+    expect(listResourcesApi).toHaveBeenCalledTimes(2)
+    expect(store.resourceErrors['tool:yosys']).toBeUndefined()
+    expect(store.resources[0]).toMatchObject({
+      id: 'tool:yosys',
+      status: 'installed',
+      source: 'local',
+      path: '/tmp/oss-cad-suite',
+    })
+  })
+
+  it('stores local import errors by resourceId and refreshes resources silently', async () => {
+    const availableTool = makeToolResource()
+    vi.mocked(listResourcesApi)
+      .mockResolvedValueOnce([availableTool])
+      .mockResolvedValueOnce([availableTool])
+    vi.mocked(importLocalResourcePathApi).mockRejectedValue(new Error('Expected executable not found for yosys'))
+
+    const store = usePluginStore()
+    await store.fetchTools()
+
+    await store.importLocalResource('tool:yosys', '/tmp/oss-cad-suite')
+
+    expect(store.resourceErrors['tool:yosys']).toBe('Expected executable not found for yosys')
+    expect(listResourcesApi).toHaveBeenCalledTimes(2)
   })
 })

--- a/ecos/gui/apps/renderer/src/stores/pluginStore.ts
+++ b/ecos/gui/apps/renderer/src/stores/pluginStore.ts
@@ -17,6 +17,7 @@ import {
 import type { InstallProgress, ResourceItem, ToolInfo } from '@/api/plugin'
 
 const PROGRESS_UPDATE_INTERVAL_MS = 180
+type LocalResourceImporter = (resourceId: string, path: string) => Promise<unknown>
 
 export const usePluginStore = defineStore('plugin', () => {
   const resources = ref<ResourceItem[]>([])
@@ -317,11 +318,15 @@ export const usePluginStore = defineStore('plugin', () => {
     await fetchTools({ silent: true })
   }
 
-  async function importLocalResource(resourceId: string, path: string): Promise<void> {
+  async function importLocalResource(
+    resourceId: string,
+    path: string,
+    importer: LocalResourceImporter = importLocalResourcePathApi,
+  ): Promise<void> {
     delete resourceErrors.value[resourceId]
     _syncLegacyToolError(resourceId)
     try {
-      await importLocalResourcePathApi(resourceId, path)
+      await importer(resourceId, path)
       await fetchTools({ silent: true })
     } catch (e) {
       _setResourceError(

--- a/ecos/gui/apps/renderer/src/stores/pluginStore.ts
+++ b/ecos/gui/apps/renderer/src/stores/pluginStore.ts
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import {
   activatePdkApi,
   cancelResourceApi,
+  importLocalResourcePathApi,
   installResourceApi,
   listResourcesApi,
   removePdkReferenceApi,
@@ -316,6 +317,21 @@ export const usePluginStore = defineStore('plugin', () => {
     await fetchTools({ silent: true })
   }
 
+  async function importLocalResource(resourceId: string, path: string): Promise<void> {
+    delete resourceErrors.value[resourceId]
+    _syncLegacyToolError(resourceId)
+    try {
+      await importLocalResourcePathApi(resourceId, path)
+      await fetchTools({ silent: true })
+    } catch (e) {
+      _setResourceError(
+        resourceId,
+        e instanceof Error ? e.message : `Failed to import ${_resourceName(resourceId)}`,
+      )
+      await fetchTools({ silent: true })
+    }
+  }
+
   async function refresh(): Promise<void> {
     refreshing.value = true
     error.value = null
@@ -360,6 +376,7 @@ export const usePluginStore = defineStore('plugin', () => {
     activatePdk,
     validatePdk,
     removePdkReference,
+    importLocalResource,
     refresh,
     cleanup,
   }

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -124,6 +124,12 @@ describe('PluginToolsView resource table layout', () => {
     expect(pluginToolsViewSource).not.toContain('{{ pluginStore.error }}')
   })
 
+  it('does not render the deprecated global PDK import action', () => {
+    expect(pluginToolsViewSource).not.toContain('handleImportPdk')
+    expect(pluginToolsViewSource).not.toContain('importingPdk')
+    expect(pluginToolsViewSource).not.toContain('Import PDK')
+  })
+
   it('renders local tool replace controls and copy separately from updates', () => {
     expect(pluginToolsViewSource).toContain("rowActionForStatus(row.resource) === 'replace'")
     expect(pluginToolsViewSource).toContain('data-title="Replace"')

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -90,4 +90,16 @@ describe('PluginToolsView resource table layout', () => {
     )
     expect(pluginToolsViewSource).not.toContain('Updates will replace the existing installed versions.')
   })
+
+  it('renders the row local import button before the primary row action', () => {
+    const importButtonIndex = pluginToolsViewSource.indexOf('data-title="Import Local"')
+    const installButtonIndex = pluginToolsViewSource.indexOf('data-title="Install"')
+
+    expect(pluginToolsViewSource).toContain('canImportLocalResource(row)')
+    expect(pluginToolsViewSource).toContain('handleLocalImport(row)')
+    expect(pluginToolsViewSource).toContain("importingResourceIds.has(row.id) ? 'ri-loader-4-line spin' : 'ri-folder-add-line'")
+    expect(importButtonIndex).toBeGreaterThan(-1)
+    expect(installButtonIndex).toBeGreaterThan(-1)
+    expect(importButtonIndex).toBeLessThan(installButtonIndex)
+  })
 })

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -53,6 +53,22 @@ describe('PluginToolsView resource table layout', () => {
     expect(pluginToolsViewSource).not.toContain('.resource-table {\n  min-width: 680px;')
   })
 
+  it('aligns row metadata to the primary resource name line', () => {
+    expect(pluginToolsViewSource).toContain('class="resource-status-cell"')
+    expect(pluginToolsViewSource).toMatch(
+      /\.resource-row\s*\{[\s\S]*align-items:\s*start;/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /\.resource-row\s*>\s*\.resource-muted,\s*\.resource-status-cell,\s*\.row-actions\s*\{[\s\S]*align-self:\s*start;/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /\.resource-copy strong\s*\{[\s\S]*line-height:\s*var\(--resource-row-primary-line\);/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /\.resource-muted\s*\{[\s\S]*min-height:\s*var\(--resource-row-primary-line\);/,
+    )
+  })
+
   it('renders mini progress with a transform driven by the row progress percent', () => {
     expect(pluginToolsViewSource).toContain(
       ":style=\"{ '--progress': row.progressPercent / 100 }\"",

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -55,6 +55,11 @@ describe('PluginToolsView resource table layout', () => {
 
   it('aligns row metadata to the primary resource name line', () => {
     expect(pluginToolsViewSource).toContain('class="resource-status-cell"')
+    expect(pluginToolsViewSource).toContain('--resource-table-columns:')
+    expect(pluginToolsViewSource).toMatch(
+      /\.resource-table-head,\s*\.resource-row\s*\{[\s\S]*grid-template-columns:\s*var\(--resource-table-columns\);/,
+    )
+    expect(pluginToolsViewSource).not.toContain('minmax(70px, auto)')
     expect(pluginToolsViewSource).toMatch(
       /\.resource-row\s*\{[\s\S]*align-items:\s*start;/,
     )
@@ -66,6 +71,9 @@ describe('PluginToolsView resource table layout', () => {
     )
     expect(pluginToolsViewSource).toMatch(
       /\.resource-muted\s*\{[\s\S]*min-height:\s*var\(--resource-row-primary-line\);/,
+    )
+    expect(pluginToolsViewSource).toMatch(
+      /\.row-actions\s*\{[\s\S]*justify-content:\s*flex-start;/,
     )
   })
 

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -75,6 +75,9 @@ describe('PluginToolsView resource table layout', () => {
     expect(pluginToolsViewSource).toMatch(
       /\.row-actions\s*\{[\s\S]*justify-content:\s*flex-start;/,
     )
+    expect(pluginToolsViewSource).toMatch(
+      /@media \(max-width: 767px\)\s*\{[\s\S]*--resource-table-columns:\s*28px minmax\(88px,\s*1fr\) minmax\(96px,\s*auto\) minmax\(68px,\s*auto\);/,
+    )
   })
 
   it('renders mini progress with a transform driven by the row progress percent', () => {

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -111,6 +111,11 @@ describe('PluginToolsView resource table layout', () => {
     expect(pluginToolsViewSource).not.toContain('data-title="Installing"')
   })
 
+  it('keeps long resource error details out of table rows', () => {
+    expect(pluginToolsViewSource).not.toContain('row-error-msg')
+    expect(pluginToolsViewSource).not.toContain('rowError(row)')
+  })
+
   it('renders local tool replace controls and copy separately from updates', () => {
     expect(pluginToolsViewSource).toContain("rowActionForStatus(row.resource) === 'replace'")
     expect(pluginToolsViewSource).toContain('data-title="Replace"')

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -82,6 +82,8 @@ describe('PluginToolsView resource table layout', () => {
   it('renders local tool replace controls and copy separately from updates', () => {
     expect(pluginToolsViewSource).toContain("rowActionForStatus(row.resource) === 'replace'")
     expect(pluginToolsViewSource).toContain('data-title="Replace"')
+    expect(pluginToolsViewSource).toContain('removalActionForRow(row)')
+    expect(pluginToolsViewSource).toContain('handleRowRemove(row)')
     expect(pluginToolsViewSource).toContain('selectedResourceMetaText(row)')
     expect(pluginToolsViewSource).toContain(
       'Updates apply to managed installs. Replace switches a local tool to the registry-managed version without deleting the original local directory.',

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -78,4 +78,14 @@ describe('PluginToolsView resource table layout', () => {
     )
     expect(pluginToolsViewSource).not.toContain('data-title="Installing"')
   })
+
+  it('renders local tool replace controls and copy separately from updates', () => {
+    expect(pluginToolsViewSource).toContain("rowActionForStatus(row.resource) === 'replace'")
+    expect(pluginToolsViewSource).toContain('data-title="Replace"')
+    expect(pluginToolsViewSource).toContain('selectedResourceMetaText(row)')
+    expect(pluginToolsViewSource).toContain(
+      'Updates apply to managed installs. Replace switches a local tool to the registry-managed version without deleting the original local directory.',
+    )
+    expect(pluginToolsViewSource).not.toContain('Updates will replace the existing installed versions.')
+  })
 })

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -78,6 +78,9 @@ describe('PluginToolsView resource table layout', () => {
       /\.row-actions\s*\{[\s\S]*justify-content:\s*flex-start;/,
     )
     expect(pluginToolsViewSource).toMatch(
+      /\.status-pill\.installing\s*\{[\s\S]*font-size:\s*10px;[\s\S]*padding:\s*0 7px;/,
+    )
+    expect(pluginToolsViewSource).toMatch(
       /@media \(max-width: 767px\)\s*\{[\s\S]*--resource-table-columns:\s*28px minmax\(88px,\s*1fr\) minmax\(96px,\s*auto\) minmax\(68px,\s*auto\);/,
     )
   })

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -112,8 +112,15 @@ describe('PluginToolsView resource table layout', () => {
   })
 
   it('keeps long resource error details out of table rows', () => {
+    expect(pluginToolsViewSource).toContain(':title="row.descriptionTitle || undefined"')
     expect(pluginToolsViewSource).not.toContain('row-error-msg')
     expect(pluginToolsViewSource).not.toContain('rowError(row)')
+  })
+
+  it('uses compact text for global resource errors', () => {
+    expect(pluginToolsViewSource).toContain('managerErrorText')
+    expect(pluginToolsViewSource).toContain(':title="pluginStore.error ?? undefined"')
+    expect(pluginToolsViewSource).not.toContain('{{ pluginStore.error }}')
   })
 
   it('renders local tool replace controls and copy separately from updates', () => {

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -55,6 +55,8 @@ describe('PluginToolsView resource table layout', () => {
 
   it('aligns row metadata to the primary resource name line', () => {
     expect(pluginToolsViewSource).toContain('class="resource-status-cell"')
+    expect(pluginToolsViewSource).toContain('v-if="row.statusIcon"')
+    expect(pluginToolsViewSource).toContain(':class="row.statusIcon"')
     expect(pluginToolsViewSource).toContain('--resource-table-columns:')
     expect(pluginToolsViewSource).toMatch(
       /\.resource-table-head,\s*\.resource-row\s*\{[\s\S]*grid-template-columns:\s*var\(--resource-table-columns\);/,

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -102,4 +102,15 @@ describe('PluginToolsView resource table layout', () => {
     expect(installButtonIndex).toBeGreaterThan(-1)
     expect(importButtonIndex).toBeLessThan(installButtonIndex)
   })
+
+  it('marks a row import busy before opening the native directory picker', () => {
+    const busyFlagIndex = pluginToolsViewSource.indexOf('importingResourceIds.value = next')
+    const directoryPickerIndex = pluginToolsViewSource.indexOf('desktopApi.dialog.pickDirectory')
+
+    expect(pluginToolsViewSource).toContain('importPdkForResource')
+    expect(pluginToolsViewSource).toContain("row.type === 'pdk' ? importPdkForResource : undefined")
+    expect(busyFlagIndex).toBeGreaterThan(-1)
+    expect(directoryPickerIndex).toBeGreaterThan(-1)
+    expect(busyFlagIndex).toBeLessThan(directoryPickerIndex)
+  })
 })

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -55,8 +55,8 @@ describe('PluginToolsView resource table layout', () => {
 
   it('aligns row metadata to the primary resource name line', () => {
     expect(pluginToolsViewSource).toContain('class="resource-status-cell"')
-    expect(pluginToolsViewSource).toContain('v-if="row.statusIcon"')
-    expect(pluginToolsViewSource).toContain(':class="row.statusIcon"')
+    expect(pluginToolsViewSource).not.toContain('row.statusIcon')
+    expect(pluginToolsViewSource).not.toContain('.status-pill i')
     expect(pluginToolsViewSource).toContain('--resource-table-columns:')
     expect(pluginToolsViewSource).toMatch(
       /\.resource-table-head,\s*\.resource-row\s*\{[\s\S]*grid-template-columns:\s*var\(--resource-table-columns\);/,

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.layout.test.ts
@@ -113,6 +113,7 @@ describe('PluginToolsView resource table layout', () => {
 
   it('keeps long resource error details out of table rows', () => {
     expect(pluginToolsViewSource).toContain(':title="row.descriptionTitle || undefined"')
+    expect(pluginToolsViewSource).toContain(':title="row.statusTitle || undefined"')
     expect(pluginToolsViewSource).not.toContain('row-error-msg')
     expect(pluginToolsViewSource).not.toContain('rowError(row)')
   })

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -169,7 +169,6 @@
                   <span class="resource-muted">{{ row.sizeLabel }}</span>
                   <span class="resource-status-cell">
                     <b class="status-pill" :class="row.statusKind">
-                      <i v-if="row.statusIcon" :class="row.statusIcon" aria-hidden="true"></i>
                       <span>{{ row.statusText }}</span>
                     </b>
                     <span
@@ -1271,7 +1270,6 @@ async function openDocs(): Promise<void> {
 .status-pill {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
   max-width: 100%;
   min-height: 22px;
   padding: 0 8px;
@@ -1279,12 +1277,6 @@ async function openDocs(): Promise<void> {
   font-size: 11px;
   font-weight: 700;
   white-space: nowrap;
-}
-
-.status-pill i {
-  flex: 0 0 auto;
-  font-size: 13px;
-  line-height: 1;
 }
 
 .status-pill span {

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -188,6 +188,7 @@
                     <template
                       v-if="
                         rowActionForStatus(row.resource) !== 'none' ||
+                        removalActionForRow(row) !== null ||
                         (
                           row.statusKind !== 'installing' &&
                           (row.actions.includes('activate') || row.actions.includes('validate'))
@@ -258,14 +259,14 @@
                         <i class="ri-shield-check-line" aria-hidden="true"></i>
                       </button>
                       <button
-                        v-if="['uninstall', 'remove_reference'].includes(rowActionForStatus(row.resource))"
+                        v-if="removalActionForRow(row) !== null"
                         type="button"
                         class="row-action-btn icon-only danger-outlined"
-                        :data-title="rowActionForStatus(row.resource) === 'remove_reference' ? 'Remove' : 'Uninstall'"
-                        @click.stop="handleRowUninstall(row)"
+                        :data-title="removalActionForRow(row) === 'remove_reference' ? 'Remove' : 'Uninstall'"
+                        @click.stop="handleRowRemove(row)"
                       >
                         <i
-                          :class="rowActionForStatus(row.resource) === 'remove_reference' ? 'ri-link-unlink' : 'ri-delete-bin-line'"
+                          :class="removalActionForRow(row) === 'remove_reference' ? 'ri-link-unlink' : 'ri-delete-bin-line'"
                           aria-hidden="true"
                         ></i>
                       </button>
@@ -357,6 +358,7 @@ import { getOptionalDesktopApi, hasDesktopApi, waitForDesktopApi } from '@/platf
 import {
   primaryActionForRow,
   resourceToRow,
+  removalActionForRow,
   resolveRowInstallPath,
   rowActionForStatus,
   selectedResourceMetaText,
@@ -561,8 +563,9 @@ async function handlePdkValidate(row: ResourceRow): Promise<void> {
   }
 }
 
-async function handleRowUninstall(row: ResourceRow): Promise<void> {
-  const action = rowActionForStatus(row.resource)
+async function handleRowRemove(row: ResourceRow): Promise<void> {
+  const action = removalActionForRow(row)
+  if (!action) return
   const isDestructive = action === 'uninstall'
   const confirmMsg = isDestructive
     ? `Are you sure you want to uninstall "${row.name}"? This action cannot be undone.`
@@ -570,7 +573,11 @@ async function handleRowUninstall(row: ResourceRow): Promise<void> {
   if (!confirm(confirmMsg)) return
 
   if (action === 'remove_reference') {
-    await pluginStore.removePdkReference(row.id)
+    if (row.type === 'pdk') {
+      await pluginStore.removePdkReference(row.id)
+      return
+    }
+    await pluginStore.uninstallResource(row.id)
     return
   }
   await pluginStore.uninstallResource(row.id)

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -387,7 +387,7 @@ type StatusFilter = 'all' | 'available' | 'installed' | 'updates'
 
 const router = useRouter()
 const pluginStore = usePluginStore()
-const { importPdk } = usePdkManager()
+const { importPdk, importPdkForResource } = usePdkManager()
 
 const searchQuery = ref('')
 const searchInput = ref('')
@@ -572,19 +572,23 @@ async function handleLocalImport(row: ResourceRow): Promise<void> {
     return
   }
 
-  const desktopApi = await waitForDesktopApi()
-  const path = await desktopApi.dialog.pickDirectory({
-    title: `Select Local ${row.name} Directory`,
-  })
-  if (!path) {
-    return
-  }
-
   const next = new Set(importingResourceIds.value)
   next.add(row.id)
   importingResourceIds.value = next
   try {
-    await pluginStore.importLocalResource(row.id, path)
+    const desktopApi = await waitForDesktopApi()
+    const path = await desktopApi.dialog.pickDirectory({
+      title: `Select Local ${row.name} Directory`,
+    })
+    if (!path) {
+      return
+    }
+
+    await pluginStore.importLocalResource(
+      row.id,
+      path,
+      row.type === 'pdk' ? importPdkForResource : undefined,
+    )
   } finally {
     const done = new Set(importingResourceIds.value)
     done.delete(row.id)

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -117,8 +117,12 @@
             </div>
           </div>
 
-          <div v-if="pluginStore.error" class="resource-error">
-            {{ pluginStore.error }}
+          <div
+            v-if="managerErrorText"
+            class="resource-error"
+            :title="pluginStore.error ?? undefined"
+          >
+            {{ managerErrorText }}
           </div>
 
           <div class="resource-table-scroll">
@@ -161,7 +165,7 @@
                     <span class="resource-avatar">{{ row.icon }}</span>
                     <span class="resource-copy">
                       <strong>{{ row.name }}</strong>
-                      <small>{{ row.description }}</small>
+                      <small :title="row.descriptionTitle || undefined">{{ row.description }}</small>
                     </span>
                   </span>
 
@@ -372,6 +376,7 @@ import { usePdkManager } from '@/composables/usePdkManager'
 import { getOptionalDesktopApi, hasDesktopApi, waitForDesktopApi } from '@/platform/desktop'
 import {
   canImportLocalResource,
+  compactResourceMessage,
   primaryActionForRow,
   resourceToRow,
   removalActionForRow,
@@ -411,6 +416,10 @@ const resourceRows = computed<ResourceRow[]>(() => {
   return pluginStore.resources.map((resource) => {
     return resourceToRow(resource, pluginStore.resourceProgress[resource.id])
   })
+})
+
+const managerErrorText = computed(() => {
+  return pluginStore.error ? compactResourceMessage(pluginStore.error, 'Resource manager error') : null
 })
 
 const filteredRows = computed(() => {

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -189,12 +189,26 @@
                       v-if="
                         rowActionForStatus(row.resource) !== 'none' ||
                         removalActionForRow(row) !== null ||
+                        canImportLocalResource(row) ||
                         (
                           row.statusKind !== 'installing' &&
                           (row.actions.includes('activate') || row.actions.includes('validate'))
                         )
                       "
                     >
+                      <button
+                        v-if="canImportLocalResource(row)"
+                        type="button"
+                        class="row-action-btn icon-only info"
+                        data-title="Import Local"
+                        :disabled="importingResourceIds.has(row.id)"
+                        @click.stop="handleLocalImport(row)"
+                      >
+                        <i
+                          :class="importingResourceIds.has(row.id) ? 'ri-loader-4-line spin' : 'ri-folder-add-line'"
+                          aria-hidden="true"
+                        ></i>
+                      </button>
                       <button
                         v-if="rowActionForStatus(row.resource) === 'install' && row.statusKind !== 'error'"
                         type="button"
@@ -356,6 +370,7 @@ import { usePluginStore } from '@/stores/pluginStore'
 import { usePdkManager } from '@/composables/usePdkManager'
 import { getOptionalDesktopApi, hasDesktopApi, waitForDesktopApi } from '@/platform/desktop'
 import {
+  canImportLocalResource,
   primaryActionForRow,
   resourceToRow,
   removalActionForRow,
@@ -389,6 +404,7 @@ const categoryFilter = ref<CategoryFilter>('all')
 const statusFilter = ref<StatusFilter>('all')
 const selectedResourceIds = ref<Set<string>>(new Set())
 const importingPdk = ref(false)
+const importingResourceIds = ref<Set<string>>(new Set())
 
 const resourceRows = computed<ResourceRow[]>(() => {
   return pluginStore.resources.map((resource) => {
@@ -548,6 +564,31 @@ async function handleImportPdk(): Promise<void> {
     }
   } finally {
     importingPdk.value = false
+  }
+}
+
+async function handleLocalImport(row: ResourceRow): Promise<void> {
+  if (importingResourceIds.value.has(row.id)) {
+    return
+  }
+
+  const desktopApi = await waitForDesktopApi()
+  const path = await desktopApi.dialog.pickDirectory({
+    title: `Select Local ${row.name} Directory`,
+  })
+  if (!path) {
+    return
+  }
+
+  const next = new Set(importingResourceIds.value)
+  next.add(row.id)
+  importingResourceIds.value = next
+  try {
+    await pluginStore.importLocalResource(row.id, path)
+  } finally {
+    const done = new Set(importingResourceIds.value)
+    done.delete(row.id)
+    importingResourceIds.value = done
   }
 }
 
@@ -1390,6 +1431,11 @@ async function openDocs(): Promise<void> {
 .row-action-btn.warn:disabled {
   cursor: not-allowed;
   opacity: 0.7;
+}
+
+.row-action-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .row-action-btn.danger {

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -1925,7 +1925,7 @@ async function openDocs(): Promise<void> {
 
   .resource-table-head,
   .resource-row {
-    --resource-table-columns: 28px minmax(130px, 1fr) 84px 96px;
+    --resource-table-columns: 28px minmax(88px, 1fr) minmax(96px, auto) minmax(68px, auto);
   }
 
   .resource-table-head span:nth-child(3),

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -167,7 +167,7 @@
 
                   <span class="resource-muted">{{ row.version }}</span>
                   <span class="resource-muted">{{ row.sizeLabel }}</span>
-                  <span>
+                  <span class="resource-status-cell">
                     <b class="status-pill" :class="row.statusKind">{{ row.statusText }}</b>
                     <span
                       v-if="row.progressPercent !== null"
@@ -1144,6 +1144,7 @@ async function openDocs(): Promise<void> {
 }
 
 .resource-row {
+  --resource-row-primary-line: 22px;
   width: 100%;
   min-height: 56px;
   padding: 8px 12px;
@@ -1152,6 +1153,7 @@ async function openDocs(): Promise<void> {
   color: var(--text-primary);
   background: transparent;
   cursor: pointer;
+  align-items: start;
   text-align: left;
   transition: background 0.15s ease;
 }
@@ -1173,6 +1175,7 @@ async function openDocs(): Promise<void> {
   display: grid;
   width: 18px;
   height: 18px;
+  margin-top: 7px;
   place-items: center;
   border: 1px solid var(--border-color);
   border-radius: 4px;
@@ -1188,7 +1191,7 @@ async function openDocs(): Promise<void> {
 
 .resource-name-cell {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   min-width: 0;
 }
 
@@ -1224,6 +1227,7 @@ async function openDocs(): Promise<void> {
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 750;
+  line-height: var(--resource-row-primary-line);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1232,16 +1236,26 @@ async function openDocs(): Promise<void> {
   display: block;
   overflow: hidden;
   max-width: min(260px, 100%);
-  margin-top: 2px;
   color: var(--text-secondary);
   font-size: 11px;
+  line-height: 14px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.resource-row > .resource-muted,
+.resource-status-cell,
+.row-actions {
+  align-self: start;
+}
+
 .resource-muted {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--resource-row-primary-line);
   color: var(--text-secondary);
   font-size: 12px;
+  line-height: 1.2;
 }
 
 /* ---- Pills ---- */

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -94,17 +94,6 @@
             <div class="manager-table-actions">
               <button
                 type="button"
-                :disabled="pluginStore.loading || importingPdk"
-                @click="handleImportPdk"
-              >
-                <i
-                  :class="importingPdk ? 'ri-loader-4-line spin' : 'ri-folder-add-line'"
-                  aria-hidden="true"
-                ></i>
-                Import PDK
-              </button>
-              <button
-                type="button"
                 :disabled="pluginStore.refreshing"
                 @click="pluginStore.refresh()"
               >
@@ -393,7 +382,7 @@ type StatusFilter = 'all' | 'available' | 'installed' | 'updates'
 
 const router = useRouter()
 const pluginStore = usePluginStore()
-const { importPdk, importPdkForResource } = usePdkManager()
+const { importPdkForResource } = usePdkManager()
 
 const searchQuery = ref('')
 const searchInput = ref('')
@@ -409,7 +398,6 @@ watch(searchInput, (val) => {
 const categoryFilter = ref<CategoryFilter>('all')
 const statusFilter = ref<StatusFilter>('all')
 const selectedResourceIds = ref<Set<string>>(new Set())
-const importingPdk = ref(false)
 const importingResourceIds = ref<Set<string>>(new Set())
 
 const resourceRows = computed<ResourceRow[]>(() => {
@@ -555,22 +543,6 @@ async function handleRowInstall(row: ResourceRow): Promise<void> {
 
 async function handleRowCancel(row: ResourceRow): Promise<void> {
   await pluginStore.cancelResource(row.id)
-}
-
-async function handleImportPdk(): Promise<void> {
-  if (importingPdk.value) {
-    return
-  }
-
-  importingPdk.value = true
-  try {
-    const imported = await importPdk()
-    if (imported) {
-      await pluginStore.fetchTools({ silent: true })
-    }
-  } finally {
-    importingPdk.value = false
-  }
 }
 
 async function handleLocalImport(row: ResourceRow): Promise<void> {

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -183,7 +183,6 @@
                     >
                       <span></span>
                     </span>
-                    <span v-if="rowError(row)" class="row-error-msg">{{ rowError(row) }}</span>
                   </span>
 
                   <span class="row-actions">
@@ -539,10 +538,6 @@ function clearFilters(): void {
   searchQuery.value = ''
   categoryFilter.value = 'all'
   statusFilter.value = 'all'
-}
-
-function rowError(row: ResourceRow): string | undefined {
-  return pluginStore.resourceErrors[row.id] || row.resource.error || undefined
 }
 
 async function handleRowInstall(row: ResourceRow): Promise<void> {
@@ -1340,14 +1335,6 @@ async function openDocs(): Promise<void> {
   transform-origin: left center;
   transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1);
   will-change: transform;
-}
-
-.row-error-msg {
-  display: block;
-  margin-top: 4px;
-  color: var(--danger-color);
-  font-size: 11px;
-  line-height: 1.3;
 }
 
 /* ---- Row actions ---- */

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -1121,15 +1121,21 @@ async function openDocs(): Promise<void> {
 }
 
 .resource-table {
+  --resource-table-columns: 32px minmax(150px, 2fr) minmax(96px, 0.6fr) minmax(68px, 0.5fr) minmax(112px, 0.7fr) 116px;
   width: 100%;
 }
 
 .resource-table-head,
 .resource-row {
   display: grid;
-  grid-template-columns: 32px minmax(150px, 2fr) minmax(68px, 0.6fr) minmax(58px, 0.5fr) minmax(88px, 0.7fr) minmax(70px, auto);
+  grid-template-columns: var(--resource-table-columns);
   align-items: center;
   gap: 0;
+}
+
+.resource-table-head > *,
+.resource-row > * {
+  min-width: 0;
 }
 
 .resource-table-head {
@@ -1337,7 +1343,7 @@ async function openDocs(): Promise<void> {
 .row-actions {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 6px;
   flex-wrap: wrap;
 }
@@ -1919,7 +1925,7 @@ async function openDocs(): Promise<void> {
 
   .resource-table-head,
   .resource-row {
-    grid-template-columns: 28px minmax(130px, 1fr) minmax(74px, auto) minmax(68px, auto);
+    --resource-table-columns: 28px minmax(130px, 1fr) 84px 96px;
   }
 
   .resource-table-head span:nth-child(3),

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -213,6 +213,15 @@
                         <i class="ri-refresh-line" aria-hidden="true"></i>
                       </button>
                       <button
+                        v-else-if="rowActionForStatus(row.resource) === 'replace'"
+                        type="button"
+                        class="row-action-btn icon-only info"
+                        data-title="Replace"
+                        @click.stop="handleRowInstall(row)"
+                      >
+                        <i class="ri-loop-left-line" aria-hidden="true"></i>
+                      </button>
+                      <button
                         v-else-if="rowActionForStatus(row.resource) === 'cancel'"
                         type="button"
                         class="row-action-btn icon-only danger"
@@ -298,9 +307,7 @@
               <span class="selected-item-body">
                 <strong>{{ row.name }}</strong>
                 <small class="selected-item-meta" :title="resolveInstallPath(row)">
-                  <b v-if="row.statusKind === 'update'">Update</b>
-                  <span v-else-if="row.statusKind === 'installing'">{{ row.statusText }}</span>
-                  <span v-else>{{ row.version }}</span>
+                  <span>{{ selectedResourceMetaText(row) }}</span>
                 </small>
               </span>
               <em>{{ row.sizeLabel }}</em>
@@ -317,7 +324,7 @@
 
           <p class="manager-note">
             <i class="ri-information-line" aria-hidden="true"></i>
-            Updates will replace the existing installed versions.
+            Updates apply to managed installs. Replace switches a local tool to the registry-managed version without deleting the original local directory.
           </p>
 
           <div class="selected-actions">
@@ -352,6 +359,7 @@ import {
   resourceToRow,
   resolveRowInstallPath,
   rowActionForStatus,
+  selectedResourceMetaText,
   runBatchDownload,
   runPrimaryAction,
 } from './pluginToolsRows'

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -172,7 +172,7 @@
                   <span class="resource-muted">{{ row.version }}</span>
                   <span class="resource-muted">{{ row.sizeLabel }}</span>
                   <span class="resource-status-cell">
-                    <b class="status-pill" :class="row.statusKind">
+                    <b class="status-pill" :class="row.statusKind" :title="row.statusTitle || undefined">
                       <span>{{ row.statusText }}</span>
                     </b>
                     <span

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -1308,6 +1308,9 @@ async function openDocs(): Promise<void> {
 }
 
 .status-pill.installing {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 0 7px;
   color: var(--info-color);
   background: var(--info-bg);
 }

--- a/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
+++ b/ecos/gui/apps/renderer/src/views/PluginToolsView.vue
@@ -168,7 +168,10 @@
                   <span class="resource-muted">{{ row.version }}</span>
                   <span class="resource-muted">{{ row.sizeLabel }}</span>
                   <span class="resource-status-cell">
-                    <b class="status-pill" :class="row.statusKind">{{ row.statusText }}</b>
+                    <b class="status-pill" :class="row.statusKind">
+                      <i v-if="row.statusIcon" :class="row.statusIcon" aria-hidden="true"></i>
+                      <span>{{ row.statusText }}</span>
+                    </b>
                     <span
                       v-if="row.progressPercent !== null"
                       class="mini-progress"
@@ -1268,11 +1271,25 @@ async function openDocs(): Promise<void> {
 .status-pill {
   display: inline-flex;
   align-items: center;
+  gap: 4px;
+  max-width: 100%;
   min-height: 22px;
   padding: 0 8px;
   border-radius: 6px;
   font-size: 11px;
   font-weight: 700;
+  white-space: nowrap;
+}
+
+.status-pill i {
+  flex: 0 0 auto;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.status-pill span {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .status-pill.installed {
@@ -1291,9 +1308,8 @@ async function openDocs(): Promise<void> {
 }
 
 .status-pill.installing {
-  color: var(--text-secondary);
-  background: transparent;
-  padding: 0;
+  color: var(--info-color);
+  background: var(--info-bg);
 }
 
 .status-pill.error {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -87,7 +87,7 @@ describe('pluginToolsRows', () => {
 
     expect(row.statusKind).toBe('installing')
     expect(row.statusText).toBe('Downloading')
-    expect(row.statusIcon).toBe('ri-download-line')
+    expect(row).not.toHaveProperty('statusIcon')
     expect(row.progressPercent).toBe(50)
   })
 
@@ -103,7 +103,7 @@ describe('pluginToolsRows', () => {
 
     expect(row.statusKind).toBe('installing')
     expect(row.statusText).toBe('Post-install')
-    expect(row.statusIcon).toBeNull()
+    expect(row).not.toHaveProperty('statusIcon')
   })
 
   it('formats resource sizes from bytes', () => {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -212,6 +212,33 @@ describe('pluginToolsRows', () => {
     expect(removalActionForRow(row)).toBe('remove_reference')
   })
 
+  it('maps local unmanaged tools with unknown versions to local rows', () => {
+    const row = resourceToRow(
+      resource({
+        id: 'tool:yosys',
+        type: 'tool',
+        name: 'yosys',
+        display_name: 'Yosys',
+        description: 'RTL synthesis',
+        category: 'synthesis',
+        status: 'installed',
+        installed_version: null,
+        available_versions: ['2026-05-13'],
+        active_version: null,
+        active: true,
+        path: '/tmp/oss-cad-suite',
+        managed_root: '/home/user/.local/share/ecos-studio/tools',
+        source: 'local',
+        actions: ['install', 'remove_reference'],
+        health: { managed: false },
+      }),
+      undefined,
+    )
+
+    expect(row.version).toBe('Local')
+    expect(row.statusText).toBe('Local')
+  })
+
   it('runs batch download for selected available PDKs and updateable tools', async () => {
     const installResource = vi.fn(async () => undefined)
     const updateResource = vi.fn(async () => undefined)

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -103,7 +103,7 @@ describe('pluginToolsRows', () => {
 
     expect(row.statusKind).toBe('installing')
     expect(row.statusText).toBe('Post-install')
-    expect(row.statusIcon).toBe('ri-settings-3-line')
+    expect(row.statusIcon).toBeNull()
   })
 
   it('formats resource sizes from bytes', () => {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -125,6 +125,7 @@ describe('pluginToolsRows', () => {
     expect(row.description).not.toContain('https://')
     expect(row.description).not.toContain('UND_ERR')
     expect(row.descriptionTitle).toBe(error)
+    expect(row.statusTitle).toBe(error)
   })
 
   it('prefers compact error summaries over registry descriptions on failed rows', () => {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ResourceItem } from '@/api/plugin'
 import {
+  compactResourceMessage,
   formatResourceSize,
   managedInstallLocation,
   primaryActionForRow,
@@ -104,6 +105,52 @@ describe('pluginToolsRows', () => {
     expect(row.statusKind).toBe('installing')
     expect(row.statusText).toBe('Post-install')
     expect(row).not.toHaveProperty('statusIcon')
+  })
+
+  it('keeps backend error details compact in visible row copy', () => {
+    const error = 'Failed to download https://github.com/openecos-projects/icsprout55-pdk/archive/refs/tags/v1.10.100.tar.gz: fetch failed (UND_ERR_CONNECT_TIMEOUT: Connect Timeout)'
+    const row = resourceToRow(
+      resource({
+        status: 'error',
+        description: '',
+        path: null,
+        error,
+      }),
+      undefined,
+    )
+
+    expect(row.statusKind).toBe('error')
+    expect(row.statusText).toBe('Error')
+    expect(row.description).toBe('Connection timeout')
+    expect(row.description).not.toContain('https://')
+    expect(row.description).not.toContain('UND_ERR')
+    expect(row.descriptionTitle).toBe(error)
+  })
+
+  it('prefers compact error summaries over registry descriptions on failed rows', () => {
+    const error = 'Failed to download https://github.com/openecos-projects/icsprout55-pdk/archive/refs/tags/v1.10.100.tar.gz: fetch failed (UND_ERR_CONNECT_TIMEOUT: Connect Timeout)'
+    const row = resourceToRow(
+      resource({
+        status: 'error',
+        description: 'Integrated Circuit Systems 55nm PDK',
+        path: null,
+        error,
+      }),
+      undefined,
+    )
+
+    expect(row.description).toBe('Connection timeout')
+    expect(row.descriptionTitle).toBe(error)
+  })
+
+  it('compacts verbose resource messages for visible alerts', () => {
+    expect(
+      compactResourceMessage(
+        'Failed to download https://github.com/openecos-projects/icsprout55-pdk/archive/refs/tags/v1.10.100.tar.gz: fetch failed (UND_ERR_CONNECT_TIMEOUT: Connect Timeout)',
+      ),
+    ).toBe('Connection timeout')
+    expect(compactResourceMessage('Failed to download https://example.invalid/archive.tar.gz: fetch failed')).toBe('Download failed')
+    expect(compactResourceMessage('Checksum mismatch')).toBe('Checksum mismatch')
   })
 
   it('formats resource sizes from bytes', () => {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -7,7 +7,9 @@ import {
   primaryActionForRow,
   resourceToRow,
   rowActionForStatus,
+  selectedResourceMetaText,
   runBatchDownload,
+  createPrimaryActionTask,
 } from './pluginToolsRows'
 
 function resource(overrides: Partial<ResourceItem>): ResourceItem {
@@ -139,6 +141,43 @@ describe('pluginToolsRows', () => {
         ),
       ),
     ).toBeNull()
+  })
+
+  it('maps local unmanaged tools with install action to replace rows', async () => {
+    const installResource = vi.fn(async () => undefined)
+    const updateResource = vi.fn(async () => undefined)
+    const row = resourceToRow(
+      resource({
+        id: 'tool:yosys',
+        type: 'tool',
+        name: 'yosys',
+        display_name: 'Yosys',
+        description: 'RTL synthesis',
+        category: 'synthesis',
+        status: 'installed',
+        installed_version: '0.66+154',
+        available_versions: ['2026-05-13'],
+        active_version: '0.66+154',
+        active: true,
+        path: '/tmp/oss-cad-suite',
+        managed_root: '/home/user/.local/share/ecos-studio/tools',
+        source: 'local',
+        actions: ['install'],
+        health: { managed: false },
+      }),
+      undefined,
+    )
+
+    expect(row.statusKind).toBe('installed')
+    expect(row.statusText).toBe('Local')
+    expect(rowActionForStatus(row.resource)).toBe('replace')
+    expect(primaryActionForRow(row)).toBe('replace')
+    expect(selectedResourceMetaText(row)).toBe('Replace with managed v2026-05-13')
+
+    await createPrimaryActionTask(row, { installResource, updateResource })
+
+    expect(installResource).toHaveBeenCalledWith('tool:yosys')
+    expect(updateResource).not.toHaveBeenCalled()
   })
 
   it('runs batch download for selected available PDKs and updateable tools', async () => {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -82,11 +82,12 @@ describe('pluginToolsRows', () => {
       tool: 'ics55',
       phase: 'downloading',
       progress: 0.5,
-      message: 'Downloading...',
+      message: 'Downloading ICsprout 55nm PDK post-install asset 1/7: ics55_LLSC_H7CH_liberty.tar.bz2',
     })
 
     expect(row.statusKind).toBe('installing')
-    expect(row.statusText).toBe('Downloading 50%')
+    expect(row.statusText).toBe('Downloading')
+    expect(row.statusIcon).toBe('ri-download-line')
     expect(row.progressPercent).toBe(50)
   })
 
@@ -101,7 +102,8 @@ describe('pluginToolsRows', () => {
     })
 
     expect(row.statusKind).toBe('installing')
-    expect(row.statusText).toBe('Running PDK post-install steps...')
+    expect(row.statusText).toBe('Post-install')
+    expect(row.statusIcon).toBe('ri-settings-3-line')
   })
 
   it('formats resource sizes from bytes', () => {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -6,6 +6,7 @@ import {
   managedInstallLocation,
   primaryActionForRow,
   resourceToRow,
+  removalActionForRow,
   rowActionForStatus,
   selectedResourceMetaText,
   runBatchDownload,
@@ -162,7 +163,7 @@ describe('pluginToolsRows', () => {
         path: '/tmp/oss-cad-suite',
         managed_root: '/home/user/.local/share/ecos-studio/tools',
         source: 'local',
-        actions: ['install'],
+        actions: ['install', 'remove_reference'],
         health: { managed: false },
       }),
       undefined,
@@ -172,12 +173,42 @@ describe('pluginToolsRows', () => {
     expect(row.statusText).toBe('Local')
     expect(rowActionForStatus(row.resource)).toBe('replace')
     expect(primaryActionForRow(row)).toBe('replace')
+    expect(removalActionForRow(row)).toBe('remove_reference')
     expect(selectedResourceMetaText(row)).toBe('Replace with managed v2026-05-13')
 
     await createPrimaryActionTask(row, { installResource, updateResource })
 
     expect(installResource).toHaveBeenCalledWith('tool:yosys')
     expect(updateResource).not.toHaveBeenCalled()
+  })
+
+  it('maps local unmanaged tools without install action to removable local rows', () => {
+    const row = resourceToRow(
+      resource({
+        id: 'tool:yosys',
+        type: 'tool',
+        name: 'yosys',
+        display_name: 'Yosys',
+        description: 'RTL synthesis',
+        category: 'synthesis',
+        status: 'installed',
+        installed_version: '0.66+154',
+        available_versions: ['2026-05-13'],
+        active_version: '0.66+154',
+        active: true,
+        path: '/tmp/oss-cad-suite',
+        managed_root: '/home/user/.local/share/ecos-studio/tools',
+        source: 'local',
+        actions: ['remove_reference'],
+        health: { managed: false },
+      }),
+      undefined,
+    )
+
+    expect(row.statusText).toBe('Local')
+    expect(rowActionForStatus(row.resource)).toBe('remove_reference')
+    expect(primaryActionForRow(row)).toBeNull()
+    expect(removalActionForRow(row)).toBe('remove_reference')
   })
 
   it('runs batch download for selected available PDKs and updateable tools', async () => {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.test.ts
@@ -11,6 +11,7 @@ import {
   selectedResourceMetaText,
   runBatchDownload,
   createPrimaryActionTask,
+  canImportLocalResource,
 } from './pluginToolsRows'
 
 function resource(overrides: Partial<ResourceItem>): ResourceItem {
@@ -257,6 +258,41 @@ describe('pluginToolsRows', () => {
     expect(installResource).toHaveBeenCalledWith('pdk:ics55')
     expect(updateResource).toHaveBeenCalledTimes(1)
     expect(updateResource).toHaveBeenCalledWith('tool:yosys')
+  })
+
+  it('allows local import for tool and PDK rows that are not currently mutating', () => {
+    expect(
+      canImportLocalResource(resourceToRow(resource({
+        id: 'tool:yosys',
+        type: 'tool',
+        status: 'available',
+        actions: ['install'],
+      }), undefined)),
+    ).toBe(true)
+    expect(
+      canImportLocalResource(resourceToRow(resource({
+        id: 'pdk:ics55',
+        type: 'pdk',
+        status: 'available',
+        actions: ['install'],
+      }), undefined)),
+    ).toBe(true)
+    expect(
+      canImportLocalResource(resourceToRow(resource({
+        id: 'tool:yosys',
+        type: 'tool',
+        status: 'installing',
+        actions: [],
+      }), undefined)),
+    ).toBe(false)
+    expect(
+      canImportLocalResource(resourceToRow(resource({
+        id: 'tool:yosys',
+        type: 'tool',
+        status: 'uninstalling',
+        actions: [],
+      }), undefined)),
+    ).toBe(false)
   })
 
   it('derives managed install location from downloadable resource types', () => {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -215,6 +215,10 @@ export function removalActionForRow(row: ResourceRow): RemovalRowAction | null {
   return null
 }
 
+export function canImportLocalResource(row: ResourceRow): boolean {
+  return (row.type === 'tool' || row.type === 'pdk') && row.statusKind !== 'installing'
+}
+
 export function createPrimaryActionTask(
   row: ResourceRow,
   executor: ResourceActionExecutor,

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -4,6 +4,7 @@ export type ResourceType = 'tool' | 'pdk'
 export type StatusKind = 'available' | 'installed' | 'update' | 'installing' | 'error'
 export type RowAction = 'install' | 'update' | 'replace' | 'cancel' | 'uninstall' | 'remove_reference' | 'none'
 export type PrimaryRowAction = 'install' | 'update' | 'replace'
+export type RemovalRowAction = 'uninstall' | 'remove_reference'
 
 export interface ResourceActionExecutor {
   installResource(resourceId: string): Promise<void>
@@ -199,6 +200,17 @@ export function primaryActionForRow(row: ResourceRow): PrimaryRowAction | null {
   const action = rowActionForStatus(row.resource)
   if (action === 'install' || action === 'update' || action === 'replace') {
     return action
+  }
+  return null
+}
+
+export function removalActionForRow(row: ResourceRow): RemovalRowAction | null {
+  const action = rowActionForStatus(row.resource)
+  if (action === 'uninstall' || action === 'remove_reference') {
+    return action
+  }
+  if (action === 'replace' && row.resource.actions.includes('remove_reference')) {
+    return 'remove_reference'
   }
   return null
 }

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -23,6 +23,7 @@ export interface ResourceRow {
   sizeMb: number
   platform: string
   statusText: string
+  statusTitle: string
   statusKind: StatusKind
   icon: string
   accent: string
@@ -391,6 +392,7 @@ export function resourceToRow(
     sizeMb: size.sizeMb,
     platform: resource.platform || (resource.source === 'local' ? 'Local' : ''),
     statusText: status.text,
+    statusTitle: status.kind === 'error' ? resource.error || '' : '',
     statusKind: status.kind,
     icon: iconFor(resource),
     accent: accentFor(resource),

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -51,7 +51,9 @@ export function formatResourceSize(size: number | null): { sizeLabel: string; si
 }
 
 function versionLabel(resource: ResourceItem): string {
-  const version = resource.active_version || resource.installed_version || resource.available_versions[0]
+  const version = resource.active_version
+    || resource.installed_version
+    || (resource.source === 'local' ? undefined : resource.available_versions[0])
   if (!version) {
     return resource.source === 'local' ? 'Local' : '-'
   }

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -23,6 +23,7 @@ export interface ResourceRow {
   platform: string
   statusText: string
   statusKind: StatusKind
+  statusIcon: string | null
   icon: string
   accent: string
   progressPercent: number | null
@@ -119,51 +120,53 @@ function errorStatusText(resource: ResourceItem): string {
   return 'Error'
 }
 
-function progressStatusText(progress: InstallProgress | undefined, percent: number | null): string {
-  if (progress?.phase === 'uninstalling') {
-    return 'Removing'
+function progressStatus(progress: InstallProgress | undefined): { text: string; icon: string } {
+  switch (progress?.phase) {
+    case 'downloading':
+      return { text: 'Downloading', icon: 'ri-download-line' }
+    case 'verifying':
+      return { text: 'Verifying', icon: 'ri-shield-check-line' }
+    case 'extracting':
+      return { text: 'Extracting', icon: 'ri-box-3-line' }
+    case 'post_install':
+      return { text: 'Post-install', icon: 'ri-settings-3-line' }
+    case 'uninstalling':
+      return { text: 'Removing', icon: 'ri-delete-bin-line' }
+    case 'done':
+      return { text: 'Installed', icon: 'ri-check-line' }
+    case 'cancelled':
+      return { text: 'Cancelled', icon: 'ri-close-line' }
+    case 'error':
+      return { text: 'Error', icon: 'ri-alert-line' }
+    default:
+      return { text: 'Installing', icon: 'ri-loader-4-line spin' }
   }
-  if (percent !== null && progress?.phase === 'downloading') {
-    return `Downloading ${percent}%`
-  }
-  if (percent !== null && progress?.phase === 'extracting') {
-    return `Extracting ${percent}%`
-  }
-  if (progress?.phase === 'post_install') {
-    return progress.message || 'Initializing'
-  }
-  if (progress?.message) {
-    return progress.message
-  }
-  if (percent !== null) {
-    return `Installing ${percent}%`
-  }
-  return 'Installing'
 }
 
 function mapStatus(
   resource: ResourceItem,
   progress: InstallProgress | undefined,
-): { kind: StatusKind; text: string } {
-  const percent = progressPercentFor(progress)
+): { kind: StatusKind; text: string; icon: string | null } {
   if (progress || resource.status === 'installing' || resource.status === 'uninstalling' || resource.status === 'removing') {
+    const status = progressStatus(progress)
     return {
       kind: 'installing',
-      text: progressStatusText(progress, percent),
+      text: status.text,
+      icon: status.icon,
     }
   }
 
   switch (resource.status) {
     case 'installed':
-      return { kind: 'installed', text: installedStatusText(resource) }
+      return { kind: 'installed', text: installedStatusText(resource), icon: null }
     case 'update_available':
-      return { kind: 'update', text: 'Update' }
+      return { kind: 'update', text: 'Update', icon: null }
     case 'error':
     case 'missing':
     case 'invalid':
-      return { kind: 'error', text: errorStatusText(resource) }
+      return { kind: 'error', text: errorStatusText(resource), icon: null }
     default:
-      return { kind: 'available', text: 'Available' }
+      return { kind: 'available', text: 'Available', icon: null }
   }
 }
 
@@ -354,6 +357,7 @@ export function resourceToRow(
     platform: resource.platform || (resource.source === 'local' ? 'Local' : ''),
     statusText: status.text,
     statusKind: status.kind,
+    statusIcon: status.icon,
     icon: iconFor(resource),
     accent: accentFor(resource),
     progressPercent,

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -120,7 +120,7 @@ function errorStatusText(resource: ResourceItem): string {
   return 'Error'
 }
 
-function progressStatus(progress: InstallProgress | undefined): { text: string; icon: string } {
+function progressStatus(progress: InstallProgress | undefined): { text: string; icon: string | null } {
   switch (progress?.phase) {
     case 'downloading':
       return { text: 'Downloading', icon: 'ri-download-line' }
@@ -129,7 +129,7 @@ function progressStatus(progress: InstallProgress | undefined): { text: string; 
     case 'extracting':
       return { text: 'Extracting', icon: 'ri-box-3-line' }
     case 'post_install':
-      return { text: 'Post-install', icon: 'ri-settings-3-line' }
+      return { text: 'Post-install', icon: null }
     case 'uninstalling':
       return { text: 'Removing', icon: 'ri-delete-bin-line' }
     case 'done':

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -23,7 +23,6 @@ export interface ResourceRow {
   platform: string
   statusText: string
   statusKind: StatusKind
-  statusIcon: string | null
   icon: string
   accent: string
   progressPercent: number | null
@@ -120,53 +119,51 @@ function errorStatusText(resource: ResourceItem): string {
   return 'Error'
 }
 
-function progressStatus(progress: InstallProgress | undefined): { text: string; icon: string | null } {
+function progressStatusText(progress: InstallProgress | undefined): string {
   switch (progress?.phase) {
     case 'downloading':
-      return { text: 'Downloading', icon: 'ri-download-line' }
+      return 'Downloading'
     case 'verifying':
-      return { text: 'Verifying', icon: 'ri-shield-check-line' }
+      return 'Verifying'
     case 'extracting':
-      return { text: 'Extracting', icon: 'ri-box-3-line' }
+      return 'Extracting'
     case 'post_install':
-      return { text: 'Post-install', icon: null }
+      return 'Post-install'
     case 'uninstalling':
-      return { text: 'Removing', icon: 'ri-delete-bin-line' }
+      return 'Removing'
     case 'done':
-      return { text: 'Installed', icon: 'ri-check-line' }
+      return 'Installed'
     case 'cancelled':
-      return { text: 'Cancelled', icon: 'ri-close-line' }
+      return 'Cancelled'
     case 'error':
-      return { text: 'Error', icon: 'ri-alert-line' }
+      return 'Error'
     default:
-      return { text: 'Installing', icon: 'ri-loader-4-line spin' }
+      return 'Installing'
   }
 }
 
 function mapStatus(
   resource: ResourceItem,
   progress: InstallProgress | undefined,
-): { kind: StatusKind; text: string; icon: string | null } {
+): { kind: StatusKind; text: string } {
   if (progress || resource.status === 'installing' || resource.status === 'uninstalling' || resource.status === 'removing') {
-    const status = progressStatus(progress)
     return {
       kind: 'installing',
-      text: status.text,
-      icon: status.icon,
+      text: progressStatusText(progress),
     }
   }
 
   switch (resource.status) {
     case 'installed':
-      return { kind: 'installed', text: installedStatusText(resource), icon: null }
+      return { kind: 'installed', text: installedStatusText(resource) }
     case 'update_available':
-      return { kind: 'update', text: 'Update', icon: null }
+      return { kind: 'update', text: 'Update' }
     case 'error':
     case 'missing':
     case 'invalid':
-      return { kind: 'error', text: errorStatusText(resource), icon: null }
+      return { kind: 'error', text: errorStatusText(resource) }
     default:
-      return { kind: 'available', text: 'Available', icon: null }
+      return { kind: 'available', text: 'Available' }
   }
 }
 
@@ -357,7 +354,6 @@ export function resourceToRow(
     platform: resource.platform || (resource.source === 'local' ? 'Local' : ''),
     statusText: status.text,
     statusKind: status.kind,
-    statusIcon: status.icon,
     icon: iconFor(resource),
     accent: accentFor(resource),
     progressPercent,

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -2,8 +2,8 @@ import type { InstallProgress, ResourceAction, ResourceItem } from '@/api/plugin
 
 export type ResourceType = 'tool' | 'pdk'
 export type StatusKind = 'available' | 'installed' | 'update' | 'installing' | 'error'
-export type RowAction = 'install' | 'update' | 'cancel' | 'uninstall' | 'remove_reference' | 'none'
-export type PrimaryRowAction = 'install' | 'update'
+export type RowAction = 'install' | 'update' | 'replace' | 'cancel' | 'uninstall' | 'remove_reference' | 'none'
+export type PrimaryRowAction = 'install' | 'update' | 'replace'
 
 export interface ResourceActionExecutor {
   installResource(resourceId: string): Promise<void>
@@ -90,10 +90,24 @@ function progressPercentFor(progress: InstallProgress | undefined): number | nul
 }
 
 function installedStatusText(resource: ResourceItem): string {
+  if (isLocalTool(resource)) {
+    return 'Local'
+  }
   if (resource.type === 'pdk' && resource.active) {
     return 'Active'
   }
   return 'Installed'
+}
+
+function isLocalTool(resource: ResourceItem): boolean {
+  return resource.type === 'tool' &&
+    resource.status === 'installed' &&
+    resource.source === 'local' &&
+    resource.health.managed === false
+}
+
+function isReplaceableLocalTool(resource: ResourceItem): boolean {
+  return isLocalTool(resource) && resource.actions.includes('install')
 }
 
 function errorStatusText(resource: ResourceItem): string {
@@ -165,6 +179,9 @@ export function rowActionForStatus(resource: ResourceItem): RowAction {
   ) {
     return 'update'
   }
+  if (isReplaceableLocalTool(resource)) {
+    return 'replace'
+  }
   if ((resource.status === 'available' || resource.status === 'error') && actions.has('install')) {
     return 'install'
   }
@@ -180,7 +197,7 @@ export function rowActionForStatus(resource: ResourceItem): RowAction {
 
 export function primaryActionForRow(row: ResourceRow): PrimaryRowAction | null {
   const action = rowActionForStatus(row.resource)
-  if (action === 'install' || action === 'update') {
+  if (action === 'install' || action === 'update' || action === 'replace') {
     return action
   }
   return null
@@ -194,7 +211,7 @@ export function createPrimaryActionTask(
   if (action === 'update') {
     return executor.updateResource(row.id)
   }
-  if (action === 'install') {
+  if (action === 'install' || action === 'replace') {
     return executor.installResource(row.id)
   }
   return null
@@ -227,10 +244,28 @@ export async function runBatchDownload(
 
 function targetVersionForRow(row: ResourceRow): string | null {
   const resource = row.resource
-  if (resource.status === 'update_available' || resource.status === 'available') {
+  if (
+    resource.status === 'update_available' ||
+    resource.status === 'available' ||
+    primaryActionForRow(row) === 'replace'
+  ) {
     return resource.available_versions[0] ?? null
   }
   return resource.installed_version ?? resource.active_version ?? resource.available_versions[0] ?? null
+}
+
+export function selectedResourceMetaText(row: ResourceRow): string {
+  if (primaryActionForRow(row) === 'replace') {
+    const version = row.resource.available_versions[0]
+    return version ? `Replace with managed v${String(version).replace(/^v/i, '')}` : 'Replace with managed version'
+  }
+  if (row.statusKind === 'update') {
+    return 'Update'
+  }
+  if (row.statusKind === 'installing') {
+    return row.statusText
+  }
+  return row.version
 }
 
 function joinInstallPath(root: string, segments: string[]): string {

--- a/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
+++ b/ecos/gui/apps/renderer/src/views/pluginToolsRows.ts
@@ -17,6 +17,7 @@ export interface ResourceRow {
   name: string
   resourceName: string
   description: string
+  descriptionTitle: string
   version: string
   sizeLabel: string
   sizeMb: number
@@ -92,6 +93,30 @@ function progressPercentFor(progress: InstallProgress | undefined): number | nul
   return Math.max(0, Math.min(100, Math.round((progress.progress || 0) * 100)))
 }
 
+export function compactResourceMessage(
+  message: string | null | undefined,
+  fallback: string = 'Resource operation failed',
+): string {
+  const text = message?.trim()
+  if (!text) return fallback
+
+  const lower = text.toLowerCase()
+  const hasUrl = /https?:\/\//i.test(text)
+  const isShortDisplayText = text.length <= 80 &&
+    !hasUrl &&
+    !text.includes('\n') &&
+    !lower.includes('fetch failed') &&
+    !lower.includes('und_err')
+
+  if (isShortDisplayText) return text
+  if (lower.includes('timeout') || lower.includes('und_err_connect_timeout')) return 'Connection timeout'
+  if (lower.includes('failed to download') || lower.includes('fetch failed') || hasUrl) return 'Download failed'
+  if (lower.includes('checksum') || lower.includes('hash') || lower.includes('integrity')) return 'Verification failed'
+  if (lower.includes('post-install') || lower.includes('post_install')) return 'Post-install failed'
+  if (lower.includes('not found') || lower.includes('missing')) return 'Resource not found'
+  return fallback
+}
+
 function installedStatusText(resource: ResourceItem): string {
   if (isLocalTool(resource)) {
     return 'Local'
@@ -117,6 +142,17 @@ function errorStatusText(resource: ResourceItem): string {
   if (resource.status === 'missing') return 'Missing'
   if (resource.status === 'invalid') return 'Invalid'
   return 'Error'
+}
+
+function rowDescription(resource: ResourceItem): { text: string; title: string } {
+  const text = resource.description || resource.path || ''
+  if (resource.error) {
+    return {
+      text: compactResourceMessage(resource.error),
+      title: resource.error,
+    }
+  }
+  return { text, title: text }
 }
 
 function progressStatusText(progress: InstallProgress | undefined): string {
@@ -341,13 +377,15 @@ export function resourceToRow(
   const progressPercent = progressPercentFor(progress)
   const size = formatResourceSize(resource.size)
   const status = mapStatus(resource, progress)
+  const description = rowDescription(resource)
 
   return {
     id: resource.id,
     type: resource.type,
     name: resource.display_name || resource.name,
     resourceName: resource.name,
-    description: resource.description || resource.path || resource.error || '',
+    description: description.text,
+    descriptionTitle: description.title,
     version: versionLabel(resource),
     sizeLabel: size.sizeLabel,
     sizeMb: size.sizeMb,

--- a/ecos/gui/packages/shared/src/constants/ipcChannels.ts
+++ b/ecos/gui/packages/shared/src/constants/ipcChannels.ts
@@ -50,6 +50,7 @@ export const desktopApiIpcChannels = {
   resourcesValidatePdk: 'resources:validate-pdk',
   resourcesRemovePdkReference: 'resources:remove-pdk-reference',
   resourcesImportPdkPath: 'resources:import-pdk-path',
+  resourcesImportLocalPath: 'resources:import-local-path',
   resourcesRefreshRegistry: 'resources:refresh-registry',
   layoutViewerOpen: 'layout-viewer:open',
   cliExecute: 'cli:execute',

--- a/ecos/gui/packages/shared/src/contracts/desktopApi.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopApi.ts
@@ -9,6 +9,7 @@ import type {
 } from '../types/designFiles.ts'
 import type {
   ResourceImportPdkRequest,
+  ResourceImportLocalRequest,
   ResourceInfo,
   ResourceInstallRequest,
   ResourceJob,
@@ -216,6 +217,7 @@ export interface DesktopApi {
     validatePdk(resourceId: string): Promise<{ resource_id: string; health: { status: string } }>
     removePdkReference(resourceId: string): Promise<ResourceOperationResult>
     importPdkPath(request: ResourceImportPdkRequest): Promise<ResourceInfo>
+    importLocalPath(request: ResourceImportLocalRequest): Promise<ResourceInfo>
     refreshRegistry(): Promise<{ status: string; tools_count: number }>
     onProgress(listener: (event: ResourceJob) => void): DesktopEventUnsubscribe
   }

--- a/ecos/gui/packages/shared/src/contracts/resources.ts
+++ b/ecos/gui/packages/shared/src/contracts/resources.ts
@@ -68,6 +68,11 @@ export interface ResourceImportPdkRequest {
   path: string
 }
 
+export interface ResourceImportLocalRequest {
+  resourceId: string
+  path: string
+}
+
 export interface ResourceInstallRequest {
   resourceId: string
   version?: string

--- a/ecos/gui/packages/shared/src/index.ts
+++ b/ecos/gui/packages/shared/src/index.ts
@@ -33,6 +33,7 @@ export type {
 } from './contracts/desktopCli.ts';
 export type {
   ResourceAction,
+  ResourceImportLocalRequest,
   ResourceImportPdkRequest,
   ResourceInfo,
   ResourceInstallRequest,


### PR DESCRIPTION
## Summary

  This PR refines Resource Manager local resource handling and table presentation.

  It adds row-bound local import support for tools and PDKs, persists local resource references through the Electron ResourceManagerService, and exposes local imports through the row action toolbar
  instead of a global PDK import button.

  It also separates local unmanaged resources from registry-managed installs. Local tools are labeled as `Local`, can be replaced with the registry-managed version when available, and can have their
  reference removed without deleting the original local directory. Local PDK imports are bound to their Resource Manager row and remain available for project creation.

  The Resource Manager table UI is tightened so rows stay aligned across available, installed, selected, progress, and error states. Status pills now use compact text only, long operation messages are
  summarized in-row, and full error details are available by hovering the `Error` status.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [x] `cd ecos/gui && pnpm run build`
- [x] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [x] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
