### PR TITLE
chore: remove bazel and ecos/server in devcontainer and docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,7 +61,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
     && npm install -g pnpm \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust (for Tauri).
+# Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 # Install uv (Python package manager used by ecos/server).
@@ -84,22 +84,22 @@ COPY . /workspace
 # Init submodules (ip/, eda/, pdk/)
 RUN git submodule update --init --recursive || true
 
-# Install ecos/server dependencies (includes ecc wheel)
+# Install ecc
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
-    cd ecos/server && rm -rf .venv \
+    cd ecc && rm -rf .venv \
     && uv sync --frozen --all-groups --python 3.11
 
 # Install GUI frontend dependencies
 RUN cd ecos/gui && pnpm install --frozen-lockfile
 
-ENV VIRTUAL_ENV="/workspace/ecos/server/.venv"
-ENV PATH="/workspace/ecos/server/.venv/bin:${PATH}"
+ENV VIRTUAL_ENV="/workspace/ecc/.venv"
+ENV PATH="/workspace/ecc/.venv/bin:${PATH}"
 ENV CHIPCOMPILER_OSS_CAD_DIR="/workspace/eda/oss-cad-suite"
 ENV CHIPCOMPILER_ICS55_PDK_ROOT="/workspace/pdk/icsprout55-pdk"
-RUN echo 'if [ -f /workspace/ecos/server/.venv/bin/activate ]; then source /workspace/ecos/server/.venv/bin/activate; fi' >> /root/.bashrc
+RUN echo 'if [ -f /workspace/ecc/.venv/bin/activate ]; then source /workspace/ecc/.venv/bin/activate; fi' >> /root/.bashrc
 
 
 # Build commands:

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,10 +64,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
 # Install Rust (for Tauri).
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-# Install Bazel
-RUN wget https://github.com/bazelbuild/bazel/releases/download/8.5.0/bazel-8.5.0-linux-x86_64 -O /usr/local/bin/bazel \
-    && chmod +x /usr/local/bin/bazel
-
 # Install uv (Python package manager used by ecos/server).
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && ln -s /root/.local/bin/uv /usr/local/bin/uv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,6 @@
   "containerEnv": {
     "PROJECT_ROOT": "${containerWorkspaceFolder}"
   },
-  "postCreateCommand": "cd ecc && SKIP_VENV=1 bazel run //:prepare_dev && cd ../ecos/server && uv sync && cd ../gui && pnpm install",
+  "postCreateCommand": ".github/scripts/build-binaries.sh",
   "remoteUser": "root"
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,7 @@ body:
         - GUI
         - ECC
         - Resource management
-        - Build, packaging, Bazel, Nix, or release workflow
+        - Build, packaging, Nix, or release workflow
         - CI
         - Documentation only
         - Not sure

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,7 +29,7 @@ body:
         - GUI
         - ECC
         - Resource management
-        - Build, packaging, Bazel, Nix, or release workflow
+        - Build, packaging, Nix, or release workflow
         - CI
         - Documentation only
         - Not sure

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Select the areas touched by this PR:
 - [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
 - [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
 - [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
-- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
+- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
 - [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
 - [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.
 

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
     paths:
-      - "MODULE.bazel"
       - "ecos/gui/default.nix"
       - "ecos/gui/package.json"
       - "ecos/gui/apps/*/package.json"


### PR DESCRIPTION
## Summary

-

## Scope

Select the areas touched by this PR:

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Bazel, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
