### PR TITLE
chore: bump version to v0.1.0-alpha.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: ECOS Studio version
       description: Use the About dialog, AppImage filename, release tag, or source commit. If unknown, write "unknown" and describe how you installed it.
-      placeholder: "v0.1.0-alpha.5, AppImage filename, or git commit"
+      placeholder: "v0.1.0-alpha.6, AppImage filename, or git commit"
     validations:
       required: true
 

--- a/ecos/gui/apps/desktop-electron/electron/services/appInfoService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/appInfoService.test.ts
@@ -29,7 +29,7 @@ describe('AppInfoService', () => {
   it('returns local GUI and structured ECC component versions through the CLI', async () => {
     const harness = createSpawnHarness()
     const service = new AppInfoService({
-      appVersionProvider: () => '0.1.0-alpha.5',
+      appVersionProvider: () => '0.1.0-alpha.6',
       env: { PATH: '/usr/bin' },
       spawn: harness.spawn,
     })
@@ -52,7 +52,7 @@ describe('AppInfoService', () => {
       dreamplace: '0.1.0a3',
       ecc: '0.1.0a5',
       eccTools: '0.1.0a2',
-      gui: '0.1.0-alpha.5',
+      gui: '0.1.0-alpha.6',
       runtime: 'ECC CLI',
     })
   })
@@ -60,7 +60,7 @@ describe('AppInfoService', () => {
   it('falls back to legacy ecc --version when structured discovery fails', async () => {
     const harness = createSpawnHarness()
     const service = new AppInfoService({
-      appVersionProvider: () => '0.1.0-alpha.5',
+      appVersionProvider: () => '0.1.0-alpha.6',
       spawn: harness.spawn,
     })
     const promise = service.getVersions()
@@ -84,7 +84,7 @@ describe('AppInfoService', () => {
   it('falls back to legacy ecc --version when structured stdout is invalid JSON', async () => {
     const harness = createSpawnHarness()
     const service = new AppInfoService({
-      appVersionProvider: () => '0.1.0-alpha.5',
+      appVersionProvider: () => '0.1.0-alpha.6',
       spawn: harness.spawn,
     })
     const promise = service.getVersions()
@@ -107,7 +107,7 @@ describe('AppInfoService', () => {
   it('falls back to legacy ecc --version when structured stdout is not an object', async () => {
     const harness = createSpawnHarness()
     const service = new AppInfoService({
-      appVersionProvider: () => '0.1.0-alpha.5',
+      appVersionProvider: () => '0.1.0-alpha.6',
       spawn: harness.spawn,
     })
     const promise = service.getVersions()
@@ -130,7 +130,7 @@ describe('AppInfoService', () => {
   it('defaults missing structured fields without rejecting version discovery', async () => {
     const harness = createSpawnHarness()
     const service = new AppInfoService({
-      appVersionProvider: () => '0.1.0-alpha.5',
+      appVersionProvider: () => '0.1.0-alpha.6',
       spawn: harness.spawn,
     })
     const promise = service.getVersions()
@@ -145,7 +145,7 @@ describe('AppInfoService', () => {
       dreamplace: 'unknown',
       ecc: '0.1.0a5',
       eccTools: 'unknown',
-      gui: '0.1.0-alpha.5',
+      gui: '0.1.0-alpha.6',
       runtime: 'ECC CLI',
     })
   })
@@ -153,7 +153,7 @@ describe('AppInfoService', () => {
   it('returns unknown component versions when structured and legacy discovery fail', async () => {
     const harness = createSpawnHarness()
     const service = new AppInfoService({
-      appVersionProvider: () => '0.1.0-alpha.5',
+      appVersionProvider: () => '0.1.0-alpha.6',
       spawn: harness.spawn,
     })
     const promise = service.getVersions()

--- a/ecos/gui/apps/desktop-electron/package.json
+++ b/ecos/gui/apps/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecos-studio/desktop-electron",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "private": true,
   "description": "ECOS Studio desktop shell built with Electron.",
   "homepage": "https://github.com/openecos-projects/ecos-studio",

--- a/ecos/gui/apps/desktop-electron/scripts/verify-package.test.ts
+++ b/ecos/gui/apps/desktop-electron/scripts/verify-package.test.ts
@@ -19,8 +19,8 @@ async function createReleaseFixture() {
   const releaseDir = join(packageRoot, 'release')
   const binariesDir = join(releaseDir, 'linux-unpacked/resources/binaries')
   await mkdir(binariesDir, { recursive: true })
-  await writeFile(join(releaseDir, 'ECOS-Studio_0.1.0-alpha.5_x86_64.AppImage'), 'appimage')
-  await writeFile(join(releaseDir, 'ECOS-Studio_0.1.0-alpha.5_amd64.deb'), 'deb')
+  await writeFile(join(releaseDir, 'ECOS-Studio_0.1.0-alpha.6_x86_64.AppImage'), 'appimage')
+  await writeFile(join(releaseDir, 'ECOS-Studio_0.1.0-alpha.6_amd64.deb'), 'deb')
   await writeFile(join(binariesDir, 'ecos-layout-packer'), 'packer')
   await writeFile(join(binariesDir, 'layout-viewer-native'), 'viewer')
   await writeFile(join(binariesDir, 'ecc'), 'ecc')
@@ -37,8 +37,8 @@ describe('verifyPackageArtifacts', () => {
 
     await expect(verifyPackageArtifacts({ packageRoot: fixture.packageRoot }))
       .resolves.toEqual({
-        appImages: ['ECOS-Studio_0.1.0-alpha.5_x86_64.AppImage'],
-        debs: ['ECOS-Studio_0.1.0-alpha.5_amd64.deb'],
+        appImages: ['ECOS-Studio_0.1.0-alpha.6_x86_64.AppImage'],
+        debs: ['ECOS-Studio_0.1.0-alpha.6_amd64.deb'],
         nativeBinaries: ['ecos-layout-packer', 'layout-viewer-native', 'ecc'],
       })
   })
@@ -53,7 +53,7 @@ describe('verifyPackageArtifacts', () => {
 
   it('rejects release directories that are missing Debian artifacts', async () => {
     const fixture = await createReleaseFixture()
-    await import('node:fs/promises').then(({ rm }) => rm(join(fixture.releaseDir, 'ECOS-Studio_0.1.0-alpha.5_amd64.deb')))
+    await import('node:fs/promises').then(({ rm }) => rm(join(fixture.releaseDir, 'ECOS-Studio_0.1.0-alpha.6_amd64.deb')))
 
     await expect(verifyPackageArtifacts({ packageRoot: fixture.packageRoot }))
       .rejects.toThrow('No Debian package artifacts found')

--- a/ecos/gui/apps/renderer/package.json
+++ b/ecos/gui/apps/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecos-studio/renderer",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ecos/gui/apps/renderer/src/components/aboutDialogVersions.test.ts
+++ b/ecos/gui/apps/renderer/src/components/aboutDialogVersions.test.ts
@@ -5,7 +5,7 @@ import { aboutVersionRows, buildAboutVersionText } from './aboutDialogVersions'
 describe('aboutDialogVersions', () => {
   it('shows ECC and ECC-Tools as distinct component versions', () => {
     const versions: VersionInfo = {
-      gui: '0.1.0-alpha.5',
+      gui: '0.1.0-alpha.6',
       runtime: 'ECC CLI',
       ecc: '0.1.0a5',
       dreamplace: '0.1.0a3',
@@ -13,7 +13,7 @@ describe('aboutDialogVersions', () => {
     }
 
     expect(aboutVersionRows(versions)).toEqual([
-      { key: 'gui', label: 'GUI', version: '0.1.0-alpha.5' },
+      { key: 'gui', label: 'GUI', version: '0.1.0-alpha.6' },
       { key: 'runtime', label: 'Runtime', version: 'ECC CLI' },
       { key: 'ecc', label: 'ECC', version: '0.1.0a5' },
       { key: 'eccTools', label: 'ECC-Tools', version: '0.1.0a2' },
@@ -23,7 +23,7 @@ describe('aboutDialogVersions', () => {
 
   it('does not use legacy bridge version fields as runtime data', () => {
     const versions = {
-      gui: '0.1.0-alpha.5',
+      gui: '0.1.0-alpha.6',
       legacyRuntime: 'legacy runtime',
       ecc: '0.1.0a5',
       dreamplace: '0.1.0a3',
@@ -38,7 +38,7 @@ describe('aboutDialogVersions', () => {
 
   it('copies the same rows shown in the dialog', () => {
     const versions: VersionInfo = {
-      gui: '0.1.0-alpha.5',
+      gui: '0.1.0-alpha.6',
       runtime: 'ECC CLI',
       ecc: '0.1.0a5',
       dreamplace: '0.1.0a3',
@@ -47,7 +47,7 @@ describe('aboutDialogVersions', () => {
 
     expect(buildAboutVersionText(versions)).toBe([
       'ECOS Studio',
-      'GUI: 0.1.0-alpha.5',
+      'GUI: 0.1.0-alpha.6',
       'Runtime: ECC CLI',
       'ECC: 0.1.0a5',
       'ECC-Tools: 0.1.0a2',

--- a/ecos/gui/default.nix
+++ b/ecos/gui/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ecos-studio";
-  version = "0.1.0-alpha.5";
+  version = "0.1.0-alpha.6";
 
   src =
     with lib.fileset;

--- a/ecos/gui/package.json
+++ b/ecos/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecos-studio-gui",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.0.9",

--- a/ecos/gui/packages/shared/package.json
+++ b/ecos/gui/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecos-studio/shared",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/ecos/server/default.nix
+++ b/ecos/server/default.nix
@@ -8,7 +8,7 @@
 
 python3Packages.buildPythonPackage {
   pname = "ecos-server";
-  version = "0.1.0-alpha.5";
+  version = "0.1.0-alpha.6";
   pyproject = true;
 
   src =

--- a/ecos/server/pyproject.toml
+++ b/ecos/server/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling"]
 
 [project]
 name = "ecos-server"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 requires-python = ">=3.11"
 dependencies = [
   "ecc==0.1.0a2",


### PR DESCRIPTION
## Summary



## Scope

Select the areas touched by this PR:

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
