### PR TITLE
fix(gui): resolve sizer workspace log paths

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.test.ts
@@ -110,6 +110,29 @@ describe('WorkspaceResourceService', () => {
     })
   })
 
+  it('uses the sizer workspace directory convention for steps with spaces', async () => {
+    const root = await tempWorkspace()
+    await writeWorkspace(root, [
+      { name: 'Timing optimization', tool: 'sizer', state: 'Incomplete' },
+    ])
+    await mkdir(join(root, 'timing_optimization_sizer', 'log'), { recursive: true })
+    await writeFile(
+      join(root, 'timing_optimization_sizer', 'log', 'Timing optimization.log'),
+      'sizer log',
+      'utf8',
+    )
+
+    const service = new WorkspaceResourceService({ projectScopeProvider: provider(root) })
+    const index = await service.getIndex()
+
+    expect(index.flow.steps[0].directory).toBe(join(root, 'timing_optimization_sizer'))
+    expect(index.flow.steps[0].resources.log.file).toMatchObject({
+      path: join(root, 'timing_optimization_sizer', 'log', 'Timing optimization.log'),
+      exists: true,
+      kind: 'log',
+    })
+  })
+
   it('exposes workspace-level view package tech resources from the design view directory', async () => {
     const root = await tempWorkspace()
     await writeWorkspace(root, [{ name: 'place', tool: 'ecc' }])

--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.ts
@@ -209,7 +209,7 @@ export class WorkspaceResourceService {
     errors: string[],
   ): Promise<WorkspaceStepResource> {
     const tool = step.tool || 'unknown'
-    const directory = join(root, `${step.name}_${tool}`)
+    const directory = join(root, workspaceStepDirectoryName(step.name, tool))
     const resources = createEmptyBuckets()
     const toolKey = tool.toLowerCase()
 
@@ -498,6 +498,13 @@ function createFile(
 
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values))
+}
+
+function workspaceStepDirectoryName(stepName: string, tool: string): string {
+  if (tool.toLowerCase() === 'sizer') {
+    return `${stepName.trim().split(/\s+/).join('_').toLowerCase()}_sizer`
+  }
+  return `${stepName}_${tool}`
 }
 
 function createEmptyBuckets(): StepFileBuckets {

--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceResourceService.ts
@@ -501,6 +501,9 @@ function uniqueStrings(values: string[]): string[] {
 }
 
 function workspaceStepDirectoryName(stepName: string, tool: string): string {
+  // Workaround for Sizer step directory name
+  // Perhaps we should establish some conventions for naming folder paths
+  // during the creation of the ecc tool directory to better unify these paths.
   if (tool.toLowerCase() === 'sizer') {
     return `${stepName.trim().split(/\s+/).join('_').toLowerCase()}_sizer`
   }


### PR DESCRIPTION
## Summary

  - Fix GUI workspace resource resolution for `sizer` steps whose names contain spaces.
  - Align `Timing optimization` log/resource lookup with ECC’s `timing_optimization_sizer` workspace directory convention.
  - Add a regression test for the sizer workspace log path.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [x] `cd ecos/gui && pnpm run build`
- [x] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [x] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
