### PR TITLE
feat(gui): support cancelling ECC flow runs

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
@@ -104,6 +104,7 @@ function registerHandlers() {
       getVersions: vi.fn(),
     },
     desktopRuntimeManager: {
+      cancel: vi.fn(),
       execute: vi.fn(),
       onEvent: vi.fn(),
     },
@@ -285,6 +286,33 @@ describe('registerIpc', () => {
     expect(services.resourceManagerService.cancelResource).toHaveBeenCalledWith(
       'tool:yosys',
     )
+  })
+
+  it('delegates CLI cancellation to the desktop runtime manager', async () => {
+    const { handlers, services } = registerHandlers()
+    const event = { sender: { id: 'web-contents' } }
+    services.desktopRuntimeManager.cancel.mockResolvedValue({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for rtl2gds.'],
+      ok: false,
+      response: 'cancelled',
+    })
+
+    await expect(
+      handlers.get(desktopApiIpcChannels.cliCancel)?.(event, {
+        directory: '/work/demo',
+      }),
+    ).resolves.toEqual({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for rtl2gds.'],
+      ok: false,
+      response: 'cancelled',
+    })
+    expect(services.desktopRuntimeManager.cancel).toHaveBeenCalledWith({
+      directory: '/work/demo',
+    })
   })
 
   it('delegates remote content requests to the remote content service', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
@@ -10,6 +10,7 @@ import { stat } from 'node:fs/promises'
 import {
   desktopApiEventChannels,
   desktopApiIpcChannels,
+  type DesktopCliCancelRequest,
   type DesktopCliCommandEvent,
   type DesktopCliCommandRequest,
   type DesktopCliCommandResult,
@@ -158,6 +159,7 @@ export interface DesktopBridgeServices {
     refreshRegistry(): Promise<unknown>
   }
   desktopRuntimeManager: {
+    cancel(request: DesktopCliCancelRequest): Promise<DesktopCliCommandResult>
     execute(
       request: DesktopCliCommandRequest,
       listener?: (event: DesktopCliCommandEvent) => void,
@@ -810,6 +812,10 @@ export function registerIpc(
         }
       },
     )
+  })
+
+  handle(desktopApiIpcChannels.cliCancel, async (_event, request) => {
+    return await services.desktopRuntimeManager.cancel(request as DesktopCliCancelRequest)
   })
 
   handle(desktopApiIpcChannels.shellCreateSession, async (event, options) => {

--- a/ecos/gui/apps/desktop-electron/electron/preload/index.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/preload/index.test.ts
@@ -30,6 +30,8 @@ async function loadDesktopBridge() {
       getVersions(): Promise<unknown>
     }
     cli: {
+      cancel(request: unknown): Promise<unknown>
+      execute(request: unknown): Promise<unknown>
       onEvent(listener: (event: unknown) => void): () => void
     }
     workspace: {
@@ -57,6 +59,8 @@ describe('preload desktop bridge contract', () => {
           getVersions: expect.any(Function),
         }),
         cli: expect.objectContaining({
+          cancel: expect.any(Function),
+          execute: expect.any(Function),
           onEvent: expect.any(Function),
         }),
         workspace: expect.objectContaining({
@@ -85,6 +89,25 @@ describe('preload desktop bridge contract', () => {
       desktopApiIpcChannels.workspaceReadProjectTextFile,
       'rtl/top.sv',
     )
+  })
+
+  it('routes CLI cancellation through the shared IPC channel constant', async () => {
+    const bridge = await loadDesktopBridge()
+    ipcRenderer.invoke.mockResolvedValueOnce({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for rtl2gds.'],
+      ok: false,
+      response: 'cancelled',
+    })
+
+    await expect(bridge.cli.cancel({ directory: '/work/demo' })).resolves.toMatchObject({
+      cmd: 'rtl2gds',
+      response: 'cancelled',
+    })
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(desktopApiIpcChannels.cliCancel, {
+      directory: '/work/demo',
+    })
   })
 
   it('subscribes and unsubscribes with shared event channel constants', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/preload/index.ts
+++ b/ecos/gui/apps/desktop-electron/electron/preload/index.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../packages/shared/src/constants/ipcChannels.ts'
 import type {
   DesktopApi,
+  DesktopCliCancelRequest,
   DesktopCliCommandEvent,
   DesktopCliCommandRequest,
   DesktopDirectoryDialogOptions,
@@ -274,6 +275,8 @@ const desktopApi: DesktopApi = {
       ),
   },
   cli: {
+    cancel: (request: DesktopCliCancelRequest) =>
+      invokeDesktop(desktopApiIpcChannels.cliCancel, request),
     execute: (request: DesktopCliCommandRequest) =>
       invokeDesktop(desktopApiIpcChannels.cliExecute, request),
     onEvent: (listener) =>

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts
@@ -612,6 +612,32 @@ describe('DesktopRuntimeManager', () => {
     )
   })
 
+  it('delegates workspace runtime cancellation to the adapter', async () => {
+    const cancel = vi.fn(async (request) =>
+      result({
+        cmd: 'rtl2gds',
+        data: { directory: request.directory },
+        message: ['Cancellation requested for rtl2gds.'],
+        ok: false,
+        response: 'cancelled',
+      }),
+    )
+    const manager = createManager({
+      adapter: {
+        cancel,
+        execute: vi.fn(),
+      },
+    })
+
+    await expect(manager.cancel({ directory: '/work/demo' })).resolves.toMatchObject({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      ok: false,
+      response: 'cancelled',
+    })
+    expect(cancel).toHaveBeenCalledWith({ directory: '/work/demo' })
+  })
+
   it('clears the active long-running job after adapter errors', async () => {
     const manager = createManager({
       adapter: {

--- a/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/desktopRuntimeManager.ts
@@ -1,4 +1,5 @@
 import type {
+  DesktopCliCancelRequest,
   DesktopCliCommandEvent,
   DesktopCliCommandName,
   DesktopCliCommandRequest,
@@ -18,6 +19,9 @@ export interface DesktopRuntimeAdapterContext {
 }
 
 export interface DesktopRuntimeAdapter {
+  cancel?(
+    request: DesktopCliCancelRequest,
+  ): Promise<DesktopCliCommandResult> | DesktopCliCommandResult
   execute(
     request: DesktopCliCommandRequest,
     context: DesktopRuntimeAdapterContext,
@@ -61,10 +65,11 @@ function createResult(
   cmd: DesktopCliCommandName,
   response: DesktopCliCommandResult['response'],
   message: string[],
+  data: Record<string, unknown> = {},
 ): DesktopCliCommandResult {
   return {
     cmd,
-    data: {},
+    data,
     message,
     ok: response === 'success' || response === 'warning',
     response,
@@ -103,7 +108,10 @@ function resultLifecycleEvent(
     jobId,
     ...eventWorkspaceForScope(scope),
     result,
-    stream: result.ok ? 'system' : result.response === 'warning' ? 'system' : 'stderr',
+    stream:
+      result.ok || result.response === 'warning' || result.response === 'cancelled'
+        ? 'system'
+        : 'stderr',
     text: result.message.join('\n'),
     type:
       result.response === 'cancelled' ? 'cancelled' : result.ok ? 'completed' : 'failed',
@@ -118,9 +126,11 @@ type DesktopSharedRuntimeManager = SharedRuntimeManager<
 >
 
 export class DesktopRuntimeManager {
+  private readonly adapter: DesktopRuntimeAdapter
   private readonly runtimeManager: DesktopSharedRuntimeManager
 
   constructor(options: DesktopRuntimeManagerOptions) {
+    this.adapter = options.adapter
     this.runtimeManager = new SharedRuntimeManager<
       DesktopCliCommandRequest,
       DesktopCliCommandResult,
@@ -210,5 +220,37 @@ export class DesktopRuntimeManager {
     }
 
     return this.runtimeManager.execute(request, listener)
+  }
+
+  async cancel(request: DesktopCliCancelRequest): Promise<DesktopCliCommandResult> {
+    const directory = normalizeDirectoryScope(readString(request.directory))
+    const cmd = request.cmd ?? 'rtl2gds'
+
+    if (!isSupportedCommand(cmd)) {
+      return {
+        cmd: cmd as DesktopCliCommandName,
+        data: { directory },
+        message: [`Unknown command: ${cmd}`],
+        ok: false,
+        response: 'error',
+      }
+    }
+
+    if (!directory) {
+      return createResult(cmd, 'error', ['missing required field: directory'])
+    }
+
+    if (!this.adapter.cancel) {
+      return createResult(
+        cmd,
+        'warning',
+        ['The active ECOS command runtime does not support cancellation.'],
+        { directory },
+      )
+    }
+
+    return await this.adapter.cancel(
+      request.cmd ? { cmd: request.cmd, directory } : { directory },
+    )
   }
 }

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.test.ts
@@ -13,7 +13,10 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { DesktopCliCommandRequest } from '@ecos-studio/shared'
+import type {
+  DesktopCliCancelRequest,
+  DesktopCliCommandRequest,
+} from '@ecos-studio/shared'
 import { EccCliAdapter } from './eccCliAdapter'
 import { electronLogger } from './logger'
 
@@ -21,11 +24,14 @@ interface SpawnCall {
   args: string[]
   command: string
   options: {
+    detached?: boolean
     env?: NodeJS.ProcessEnv
+    stdio?: string[]
   }
 }
 
 class FakeChild extends EventEmitter {
+  readonly pid = 12345
   readonly stdout = new EventEmitter()
   readonly stderr = new EventEmitter()
   readonly kill = vi.fn()
@@ -484,6 +490,162 @@ describe('EccCliAdapter', () => {
         refreshed: true,
       },
       ok: true,
+    })
+  })
+
+  it('kills an active rtl2gds command and resolves the run as cancelled', async () => {
+    const harness = createSpawnHarness()
+    const emit = vi.fn()
+    const processKiller = vi.fn(
+      (child: { kill(signal: NodeJS.Signals): void }, signal: NodeJS.Signals) => {
+        child.kill(signal)
+      },
+    )
+    const adapter = new EccCliAdapter({
+      processKiller,
+      spawn: harness.spawn,
+    })
+    const runPromise = adapter.execute(
+      request('rtl2gds', {
+        directory: '/work/demo',
+        rerun: false,
+      }),
+      { emit },
+    )
+
+    await waitForSpawn(harness, 0)
+
+    await expect(
+      adapter.cancel({
+        directory: '/work/demo',
+      } satisfies DesktopCliCancelRequest),
+    ).resolves.toMatchObject({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      ok: false,
+      response: 'cancelled',
+    })
+    expect(processKiller).toHaveBeenCalledWith(harness.children[0], 'SIGTERM')
+    expect(harness.children[0].kill).toHaveBeenCalledWith('SIGTERM')
+
+    harness.children[0].emit('close', null, 'SIGTERM')
+
+    await expect(runPromise).resolves.toMatchObject({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      ok: false,
+      response: 'cancelled',
+    })
+    expect(emit).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining('[ECC CLI log] Command failed. Full log:'),
+      }),
+    )
+  })
+
+  it('matches active commands by normalized workspace directory when cancelling', async () => {
+    const harness = createSpawnHarness()
+    const processKiller = vi.fn(
+      (child: { kill(signal: NodeJS.Signals): void }, signal: NodeJS.Signals) => {
+        child.kill(signal)
+      },
+    )
+    const adapter = new EccCliAdapter({
+      processKiller,
+      spawn: harness.spawn,
+    })
+    const runPromise = adapter.execute(
+      request('rtl2gds', {
+        directory: '/work/demo/',
+        rerun: false,
+      }),
+      { emit: vi.fn() },
+    )
+
+    await waitForSpawn(harness, 0)
+
+    await expect(
+      adapter.cancel({
+        directory: '/work/demo',
+      }),
+    ).resolves.toMatchObject({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      ok: false,
+      response: 'cancelled',
+    })
+    expect(processKiller).toHaveBeenCalledWith(harness.children[0], 'SIGTERM')
+
+    harness.children[0].emit('close', null, 'SIGTERM')
+
+    await expect(runPromise).resolves.toMatchObject({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      ok: false,
+      response: 'cancelled',
+    })
+  })
+
+  it('keeps the active rtl2gds cancellation target after read-only commands for the same workspace', async () => {
+    const harness = createSpawnHarness()
+    const processKiller = vi.fn(
+      (child: { kill(signal: NodeJS.Signals): void }, signal: NodeJS.Signals) => {
+        child.kill(signal)
+      },
+    )
+    const adapter = new EccCliAdapter({
+      processKiller,
+      spawn: harness.spawn,
+    })
+    const runPromise = adapter.execute(
+      request('rtl2gds', {
+        directory: '/work/demo',
+        rerun: false,
+      }),
+      { emit: vi.fn() },
+    )
+    await waitForSpawn(harness, 0)
+
+    const infoPromise = adapter.execute(
+      request('get_info', {
+        directory: '/work/demo',
+        id: 'layout',
+        step: 'Floorplan',
+      }),
+      { emit: vi.fn() },
+    )
+    await waitForSpawn(harness, 1)
+    complete(harness.children[1], {
+      cmd: 'get_info',
+      data: { id: 'layout', info: {}, step: 'Floorplan' },
+      message: ['info'],
+      response: 'success',
+    })
+    await expect(infoPromise).resolves.toMatchObject({
+      cmd: 'get_info',
+      ok: true,
+    })
+
+    await expect(
+      adapter.cancel({
+        cmd: 'rtl2gds',
+        directory: '/work/demo',
+      }),
+    ).resolves.toMatchObject({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      ok: false,
+      response: 'cancelled',
+    })
+    expect(processKiller).toHaveBeenCalledWith(harness.children[0], 'SIGTERM')
+
+    harness.children[0].emit('close', null, 'SIGTERM')
+
+    await expect(runPromise).resolves.toMatchObject({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      ok: false,
+      response: 'cancelled',
     })
   })
 

--- a/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccCliAdapter.ts
@@ -5,6 +5,7 @@ import { appendFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import type {
+  DesktopCliCancelRequest,
   DesktopCliCommandName,
   DesktopCliCommandRequest,
   DesktopCliCommandResponse,
@@ -12,15 +13,22 @@ import type {
 } from '@ecos-studio/shared'
 import type { DesktopRuntimeAdapterContext } from './desktopRuntimeManager'
 import { electronLogger } from './logger'
+import { normalizeDirectoryScope } from './runtime/runtimeScopes'
 
 type SpawnLike = typeof spawnChild
+type KillableChildProcess = Pick<ReturnType<SpawnLike>, 'kill' | 'pid'>
+type ProcessKiller = (child: KillableChildProcess, signal: NodeJS.Signals) => void
 type RuntimeEnvProvider = () => Promise<NodeJS.ProcessEnv> | NodeJS.ProcessEnv
 
+const cancellableCommands = new Set<DesktopCliCommandName>(['rtl2gds', 'run_step'])
+
 export interface EccCliAdapterOptions {
+  cancelGraceMs?: number
   command?: string
   env?: NodeJS.ProcessEnv
   envProvider?: RuntimeEnvProvider
   isPackaged?: boolean
+  processKiller?: ProcessKiller
   spawn?: SpawnLike
   tempDir?: string
 }
@@ -28,6 +36,14 @@ export interface EccCliAdapterOptions {
 interface PreparedCommand {
   args: string[]
   cleanup?: () => void
+}
+
+interface ActiveCliCommand {
+  child: KillableChildProcess
+  cmd: DesktopCliCommandName
+  cancelled: boolean
+  directory: string
+  forceKillTimer?: ReturnType<typeof setTimeout>
 }
 
 type CliEventType =
@@ -82,6 +98,23 @@ function result(
     ok: response === 'success' || response === 'warning',
     response,
   }
+}
+
+function defaultProcessKiller(child: KillableChildProcess, signal: NodeJS.Signals): void {
+  if (process.platform !== 'win32' && typeof child.pid === 'number') {
+    try {
+      process.kill(-child.pid, signal)
+      return
+    } catch {
+      // Fall back to the direct child when the process group is unavailable.
+    }
+  }
+
+  child.kill(signal)
+}
+
+function isCancellableCommand(cmd: DesktopCliCommandName): boolean {
+  return cancellableCommands.has(cmd)
 }
 
 function failed(
@@ -340,19 +373,24 @@ class CliCommandLog {
 }
 
 export class EccCliAdapter {
+  private readonly activeCommandsByDirectory = new Map<string, ActiveCliCommand>()
+  private readonly cancelGraceMs: number
   private readonly command: string
   private readonly env: NodeJS.ProcessEnv
   private readonly envProvider?: RuntimeEnvProvider
   private readonly isPackaged: boolean
+  private readonly processKiller: ProcessKiller
   private readonly spawnImpl: SpawnLike
   private readonly tempDir: string
   private activeWorkspace: string | null = null
 
   constructor(options: EccCliAdapterOptions = {}) {
+    this.cancelGraceMs = options.cancelGraceMs ?? 3000
     this.command = options.command ?? 'ecc'
     this.env = { ...(options.env ?? process.env) }
     this.envProvider = options.envProvider
     this.isPackaged = options.isPackaged ?? true
+    this.processKiller = options.processKiller ?? defaultProcessKiller
     this.spawnImpl = options.spawn ?? spawnChild
     this.tempDir = options.tempDir ?? tmpdir()
   }
@@ -382,6 +420,59 @@ export class EccCliAdapter {
     } finally {
       prepared.cleanup?.()
     }
+  }
+
+  async cancel(request: DesktopCliCancelRequest): Promise<DesktopCliCommandResult> {
+    const directory = normalizeDirectoryScope(readString(request.directory))
+    const requestedCmd = request.cmd
+    const active = directory ? this.activeCommandsByDirectory.get(directory) : null
+    const cmd = requestedCmd ?? active?.cmd ?? 'rtl2gds'
+
+    if (!directory) {
+      return error(
+        { cmd, data: {}, source: 'button' },
+        'missing required field: directory',
+      )
+    }
+
+    if (!active) {
+      return result(
+        cmd,
+        'warning',
+        [`No active ECC command is running for ${directory}.`],
+        {
+          directory,
+        },
+      )
+    }
+
+    if (requestedCmd && active.cmd !== requestedCmd) {
+      return result(
+        requestedCmd,
+        'warning',
+        [`Active ${active.cmd} is running for ${directory}, not ${requestedCmd}.`],
+        { directory },
+      )
+    }
+
+    active.cancelled = true
+    this.processKiller(active.child, 'SIGTERM')
+
+    if (this.cancelGraceMs > 0 && !active.forceKillTimer) {
+      active.forceKillTimer = setTimeout(() => {
+        if (this.activeCommandsByDirectory.get(directory) === active) {
+          active.forceKillTimer = undefined
+          this.processKiller(active.child, 'SIGKILL')
+        }
+      }, this.cancelGraceMs)
+    }
+
+    return result(
+      active.cmd,
+      'cancelled',
+      [`Cancellation requested for ${active.cmd}.`],
+      { directory },
+    )
   }
 
   private prepareCommand(
@@ -522,7 +613,10 @@ export class EccCliAdapter {
       let stderrText = ''
       let invalidJsonLine: string | null = null
       let failureLogAnnounced = false
+      let activeCommand: ActiveCliCommand | null = null
       const start = Date.now()
+      const activeDirectory = directoryFromRequest(request, this.activeWorkspace)
+      const activeDirectoryKey = normalizeDirectoryScope(activeDirectory)
       const resolvedCommand = resolveCommandFromPath(this.command, env)
       const fallbackCommand =
         !this.isPackaged && this.command === 'ecc' && resolvedCommand === '(not found)'
@@ -570,6 +664,19 @@ export class EccCliAdapter {
         })
       }
 
+      const clearActiveCommand = (): void => {
+        if (!activeCommand) return
+        if (activeCommand.forceKillTimer) {
+          clearTimeout(activeCommand.forceKillTimer)
+          activeCommand.forceKillTimer = undefined
+        }
+        if (
+          this.activeCommandsByDirectory.get(activeCommand.directory) === activeCommand
+        ) {
+          this.activeCommandsByDirectory.delete(activeCommand.directory)
+        }
+      }
+
       electronLogger.debug(
         '[ECC CLI] spawn command=%s resolved=%s args=%s pathHead=%s',
         spawnCommand,
@@ -579,9 +686,19 @@ export class EccCliAdapter {
       )
 
       const child = this.spawnImpl(spawnCommand, prepared.args, {
+        detached: process.platform !== 'win32',
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
       })
+      if (activeDirectoryKey && isCancellableCommand(request.cmd)) {
+        activeCommand = {
+          child,
+          cmd: request.cmd,
+          cancelled: false,
+          directory: activeDirectoryKey,
+        }
+        this.activeCommandsByDirectory.set(activeDirectoryKey, activeCommand)
+      }
 
       announceCliLogStart()
 
@@ -658,6 +775,7 @@ export class EccCliAdapter {
       })
 
       child.once('error', (spawnError) => {
+        clearActiveCommand()
         const message =
           spawnError instanceof Error ? spawnError.message : String(spawnError)
         commandLog.append('error', message)
@@ -666,6 +784,8 @@ export class EccCliAdapter {
       })
 
       child.once('close', (code, signal) => {
+        const wasCancelled = activeCommand?.cancelled === true
+        clearActiveCommand()
         commandLog.append('exit', `code=${code ?? 'unknown'} signal=${signal ?? 'null'}`)
         const remaining = stdoutBuffer.trim()
         if (remaining) {
@@ -687,10 +807,29 @@ export class EccCliAdapter {
             finalResult.response,
             Date.now() - start,
           )
-          if (!finalResult.ok) {
+          if (!finalResult.ok && finalResult.response !== 'cancelled') {
             announceCliLogFailure()
           }
           resolveAfterLogFlush(withCliLogFile(finalResult, commandLog.path))
+          return
+        }
+
+        if (wasCancelled) {
+          const result = withCliLogFile(
+            {
+              ...error(request, `Cancelled ${request.cmd}.`),
+              data: activeDirectoryKey ? { directory: activeDirectoryKey } : {},
+              response: 'cancelled',
+            },
+            commandLog.path,
+          )
+          electronLogger.debug(
+            '[ECC CLI] completed cmd=%s response=%s elapsed=%dms',
+            request.cmd,
+            result.response,
+            Date.now() - start,
+          )
+          resolveAfterLogFlush(result)
           return
         }
 

--- a/ecos/gui/apps/renderer/src/api/flow.desktop-ipc.test.ts
+++ b/ecos/gui/apps/renderer/src/api/flow.desktop-ipc.test.ts
@@ -28,6 +28,16 @@ describe('flow API desktop bridge payloads', () => {
   })
 
   it('sends structured-cloneable requests when flow command data is reactive', async () => {
+    const cancel = vi.fn(async (request: unknown) => {
+      expect(() => structuredClone(request)).not.toThrow()
+      return {
+        cmd: 'rtl2gds',
+        data: {},
+        message: ['cancelled'],
+        ok: false,
+        response: 'cancelled',
+      }
+    })
     const execute = vi.fn(async (request: unknown) => {
       expect(() => structuredClone(request)).not.toThrow()
       return {
@@ -42,13 +52,20 @@ describe('flow API desktop bridge payloads', () => {
     setWindow({
       ecosDesktop: {
         cli: {
+          cancel,
           execute,
         },
       },
     })
 
-    const { getInfoApi, refreshConfigApi, rtl2gdsApi, runStepApi, syncConfigApi } =
-      await import('./flow')
+    const {
+      cancelFlowApi,
+      getInfoApi,
+      refreshConfigApi,
+      rtl2gdsApi,
+      runStepApi,
+      syncConfigApi,
+    } = await import('./flow')
 
     await runStepApi(
       reactive({
@@ -91,6 +108,14 @@ describe('flow API desktop bridge payloads', () => {
         cmd: CMDEnum.sync_config,
         data: {
           config_path: '/work/demo/config/rt_default_config.json',
+          directory: '/work/demo',
+        },
+      }),
+    )
+    await cancelFlowApi(
+      reactive({
+        cmd: CMDEnum.rtl2gds,
+        data: {
           directory: '/work/demo',
         },
       }),
@@ -147,5 +172,44 @@ describe('flow API desktop bridge payloads', () => {
         },
       }),
     )
+    expect(cancel).toHaveBeenCalledWith({
+      cmd: 'rtl2gds',
+      directory: '/work/demo',
+    })
+  })
+
+  it('omits the command when cancelling by active workspace only', async () => {
+    const cancel = vi.fn(async (request: unknown) => {
+      expect(() => structuredClone(request)).not.toThrow()
+      return {
+        cmd: 'run_step',
+        data: {},
+        message: ['cancelled'],
+        ok: false,
+        response: 'cancelled',
+      }
+    })
+
+    setWindow({
+      ecosDesktop: {
+        cli: {
+          cancel,
+        },
+      },
+    })
+
+    const { cancelFlowApi } = await import('./flow')
+
+    await cancelFlowApi(
+      reactive({
+        data: {
+          directory: '/work/demo',
+        },
+      }),
+    )
+
+    expect(cancel).toHaveBeenCalledWith({
+      directory: '/work/demo',
+    })
   })
 })

--- a/ecos/gui/apps/renderer/src/api/flow.ts
+++ b/ecos/gui/apps/renderer/src/api/flow.ts
@@ -1,5 +1,6 @@
 import { toDesktopCliData } from './desktopPayload'
 import { RequestData, ResponseData, StepEnum, InfoEnum, StateEnum } from './type'
+import type { DesktopCliCancelRequest } from '@ecos-studio/shared'
 import { getDesktopApi } from '@/platform/desktop'
 
 export interface GetInfoRequest {
@@ -36,6 +37,29 @@ export function rtl2gdsApi(request: RequestData<RTL2GDSRequest>) {
     data: toDesktopCliData(request.data as unknown as Record<string, unknown>),
     source: 'button',
   }) as unknown as Promise<ResponseData<RTL2GDSResponse>>
+}
+
+export interface CancelFlowRequest {
+  directory: string
+}
+
+export interface CancelFlowApiRequest {
+  cmd?: DesktopCliCancelRequest['cmd']
+  data: CancelFlowRequest
+}
+
+export function cancelFlowApi(request: CancelFlowApiRequest) {
+  const data = toDesktopCliData(request.data as unknown as Record<string, unknown>)
+  const cancelRequest: DesktopCliCancelRequest = {
+    directory: String(data.directory ?? ''),
+  }
+  if (request.cmd) {
+    cancelRequest.cmd = request.cmd
+  }
+
+  return getDesktopApi().cli.cancel(cancelRequest) as unknown as Promise<
+    ResponseData<{ directory: string }>
+  >
 }
 
 export interface RunStepRequest {

--- a/ecos/gui/apps/renderer/src/api/type.ts
+++ b/ecos/gui/apps/renderer/src/api/type.ts
@@ -238,6 +238,7 @@ export enum ResponseEnum {
   failed = 'failed',
   error = 'error',
   warning = 'warning',
+  cancelled = 'cancelled',
 }
 
 export enum StateEnum {

--- a/ecos/gui/apps/renderer/src/components/LeftSidebar.vue
+++ b/ecos/gui/apps/renderer/src/components/LeftSidebar.vue
@@ -332,7 +332,7 @@
               <button
                 class="mode-trigger"
                 @click="showModeMenu = !showModeMenu"
-                :disabled="flowRunControlBusy"
+                :disabled="flowRunControlBusy || isCancelling || isStopping"
               >
                 <i :class="runModes[activeRunMode].icon" class="mode-trigger-icon"></i>
                 <span>{{ runModes[activeRunMode].label }}</span>
@@ -365,13 +365,20 @@
             <!-- 执行按钮 -->
             <button
               @click="handleRunFlow"
-              :disabled="flowRunControlBusy"
+              :disabled="flowRunControlDisabled"
               class="run-go-btn"
-              :class="{ running: flowRunControlBusy }"
+              :class="{
+                running: flowRunControlBusy && !isCancelling && !isStopping,
+                stopping: flowRunControlBusy || isStopping,
+              }"
             >
               <i
                 :class="
-                  flowRunControlBusy ? 'ri-loader-4-line animate-spin' : 'ri-play-fill'
+                  isCancelling || isStopping
+                    ? 'ri-loader-4-line animate-spin'
+                    : flowRunControlBusy
+                      ? 'ri-stop-fill'
+                      : 'ri-play-fill'
                 "
               ></i>
             </button>
@@ -595,7 +602,7 @@
               <button
                 class="mode-trigger"
                 @click="showModeMenu = !showModeMenu"
-                :disabled="flowRunControlBusy"
+                :disabled="flowRunControlBusy || isCancelling || isStopping"
               >
                 <i :class="runModes[activeRunMode].icon" class="mode-trigger-icon"></i>
                 <span>{{ runModes[activeRunMode].label }}</span>
@@ -626,15 +633,20 @@
 
             <button
               @click="handleRunFlow"
-              :disabled="flowRunControlBusy"
+              :disabled="flowRunControlDisabled"
               class="run-go-btn"
-              :class="{ running: flowRunControlBusy }"
+              :class="{
+                running: flowRunControlBusy && !isCancelling && !isStopping,
+                stopping: flowRunControlBusy || isStopping,
+              }"
             >
               <i
                 :class="
-                  flowRunControlBusy
+                  isCancelling || isStopping
                     ? 'ri-loader-4-line animate-spin'
-                    : runModes[activeRunMode].icon
+                    : flowRunControlBusy
+                      ? 'ri-stop-fill'
+                      : runModes[activeRunMode].icon
                 "
               ></i>
             </button>
@@ -653,6 +665,7 @@ import { useFlowRunner } from '@/composables/useFlowRunner'
 import { useFlowRunMode } from '@/composables/useFlowRunMode'
 import { useCurrentStage } from '@/composables/useCurrentStage'
 import { useWorkspace } from '@/composables/useWorkspace'
+import { StateEnum } from '@/api/type'
 
 // ============ Composables ============
 
@@ -663,6 +676,7 @@ const {
   refreshFlowStages,
   setFirstRunStepOngoing,
   setRunStepOngoingByPath,
+  markOngoingRunStagesIncomplete,
 } = useFlowStages()
 
 // 子流程管理
@@ -680,7 +694,16 @@ const {
 } = useSubflow()
 
 // 流程运行器
-const { isRunning, runFlow, runAllFlow } = useFlowRunner()
+const {
+  isRunning,
+  isCancelling,
+  isStopping,
+  state: flowRunState,
+  error: flowRunError,
+  runFlow,
+  runAllFlow,
+  cancelRunningFlow,
+} = useFlowRunner()
 
 // Workspace runtime events
 // const { runtimeEvents } = useWorkspace()
@@ -724,6 +747,7 @@ const flowResult = computed(() => {
 })
 
 const flowRunControlBusy = computed(() => isRunning.value || hasOngoingRunStage.value)
+const flowRunControlDisabled = computed(() => isCancelling.value || isStopping.value)
 
 // ============ 运行模式 ============
 const showModeMenu = ref(false)
@@ -744,9 +768,29 @@ onUnmounted(() => document.removeEventListener('click', closeMenu))
 const { ensureApiReady } = useWorkspace()
 
 // ============ 事件处理 ============
+const refreshAfterCancel = async () => {
+  if (currentStage.value === 'home') {
+    await refreshFlowStages()
+    return
+  }
+
+  await Promise.all([refreshCurrentSubflow(), refreshFlowStages()])
+}
+
 const handleRunFlow = async () => {
   closeMenu()
-  if (flowRunControlBusy.value) return
+  if (flowRunControlDisabled.value) return
+  if (flowRunControlBusy.value) {
+    const stopped = await cancelRunningFlow()
+    if (stopped) {
+      await markOngoingRunStagesIncomplete()
+    }
+    await refreshAfterCancel()
+    if (stopped) {
+      await markOngoingRunStagesIncomplete()
+    }
+    return
+  }
 
   if (!(await ensureApiReady())) {
     await refreshFlowStages()
@@ -757,6 +801,9 @@ const handleRunFlow = async () => {
     setFirstRunStepOngoing()
     await runAllFlow({ rerun: isRerun.value })
     await refreshFlowStages()
+    if (flowRunState.value === StateEnum.Imcomplete && flowRunError.value == null) {
+      await markOngoingRunStagesIncomplete()
+    }
   } else {
     setRunStepOngoingByPath(currentStage.value)
     await runFlow({ rerun: isRerun.value })
@@ -1009,6 +1056,10 @@ const handleRunFlow = async () => {
 
 .run-go-btn.running {
   animation: pulse-btn 1.5s ease infinite;
+}
+
+.run-go-btn.stopping {
+  background: #ef4444;
 }
 
 @keyframes pulse-btn {

--- a/ecos/gui/apps/renderer/src/composables/useDesktopRuntime.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesktopRuntime.test.ts
@@ -184,6 +184,13 @@ const desktopBridge = {
     onProgress: () => () => undefined,
   },
   cli: {
+    cancel: async (request) => ({
+      cmd: request.cmd ?? 'rtl2gds',
+      data: { directory: request.directory },
+      message: [],
+      ok: false,
+      response: 'cancelled',
+    }),
     execute: async (request) => ({
       cmd: request.cmd,
       data: {},

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunner.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunner.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { StateEnum, StepEnum } from '@/api/type'
+import { nextTick, ref } from 'vue'
+import { CMDEnum, StateEnum, StepEnum } from '@/api/type'
+
+const testState = vi.hoisted(() => ({
+  runtimeEvents: null as import('vue').Ref<unknown[]> | null,
+}))
 
 const {
   ensureDesktopRuntime,
@@ -8,6 +13,7 @@ const {
   invalidateWorkspaceResources,
   resourceVersions,
   workspaceSession,
+  cancelFlowApi,
   runStepApi,
   rtl2gdsApi,
   currentProject,
@@ -36,6 +42,7 @@ const {
       sessionId: 'session-1',
     },
   },
+  cancelFlowApi: vi.fn(),
   runStepApi: vi.fn(),
   rtl2gdsApi: vi.fn(),
   currentProject: { value: null as { path: string } | null },
@@ -66,11 +73,13 @@ vi.mock('./useWorkspace', () => ({
     showToast,
     invalidateWorkspaceResources,
     resourceVersions,
+    runtimeEvents: testState.runtimeEvents,
     workspaceSession,
   }),
 }))
 
 vi.mock('@/api/flow', () => ({
+  cancelFlowApi,
   runStepApi,
   rtl2gdsApi,
 }))
@@ -82,11 +91,23 @@ vi.mock('./homeRunArtifacts', () => ({
 }))
 
 import {
+  clearFlowCancellationPendingForWorkspace,
   clearFlowExecutionActiveForWorkspace,
   flowExecutionActive,
+  isFlowExecutionActiveForWorkspace,
   markFlowExecutionActiveForWorkspace,
   useFlowRunner,
 } from './useFlowRunner'
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, reject, resolve }
+}
 
 describe('useFlowRunner desktop-only guard', () => {
   beforeEach(() => {
@@ -106,15 +127,23 @@ describe('useFlowRunner desktop-only guard', () => {
       logs: 0,
       all: 0,
     }
+    testState.runtimeEvents = ref([])
     workspaceSession.value = {
       sessionId: 'session-1',
     }
+    cancelFlowApi.mockReset()
     runStepApi.mockReset()
     rtl2gdsApi.mockReset()
     requestHomeRunArtifactReset.mockReset()
     markHomeRunArtifactResetAwaitingBackendStart.mockReset()
     clearHomeRunArtifactResetAwaitingBackendStart.mockReset()
     flowExecutionActive.value = false
+    clearFlowExecutionActiveForWorkspace('/work/a')
+    clearFlowExecutionActiveForWorkspace('/work/b')
+    clearFlowExecutionActiveForWorkspace('/work/demo')
+    clearFlowCancellationPendingForWorkspace('/work/a')
+    clearFlowCancellationPendingForWorkspace('/work/b')
+    clearFlowCancellationPendingForWorkspace('/work/demo')
     currentProject.value = null
   })
 
@@ -210,6 +239,267 @@ describe('useFlowRunner desktop-only guard', () => {
     expect(ensureApiReady).toHaveBeenCalledTimes(1)
     expect(rtl2gdsApi).not.toHaveBeenCalled()
     expect(isRunning.value).toBe(false)
+  })
+
+  it('cancels the active workspace flow through the desktop runtime', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    markFlowExecutionActiveForWorkspace('/work/demo', CMDEnum.rtl2gds)
+    cancelFlowApi.mockResolvedValue({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for rtl2gds.'],
+      ok: false,
+      response: 'cancelled',
+    })
+
+    const { cancelRunningFlow, isCancelling, isRunning, isStopping } = useFlowRunner()
+
+    expect(isRunning.value).toBe(true)
+    expect(isStopping.value).toBe(false)
+
+    await expect(cancelRunningFlow()).resolves.toBe(true)
+    expect(isCancelling.value).toBe(false)
+    expect(isRunning.value).toBe(true)
+    expect(isStopping.value).toBe(true)
+    expect(flowExecutionActive.value).toBe(true)
+    expect(cancelFlowApi).toHaveBeenCalledWith({
+      cmd: 'rtl2gds',
+      data: {
+        directory: '/work/demo',
+      },
+    })
+    expect(showToast).toHaveBeenCalledWith({
+      severity: 'warn',
+      summary: 'Flow Stopped',
+      detail: 'Cancellation requested for rtl2gds.',
+      life: 5000,
+    })
+  })
+
+  it('shows stopping for a cancellation accepted without a local run marker until the runtime exits', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    cancelFlowApi.mockResolvedValue({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for rtl2gds.'],
+      ok: false,
+      response: 'cancelled',
+    })
+
+    const { cancelRunningFlow, isRunning, isStopping } = useFlowRunner()
+
+    expect(isRunning.value).toBe(false)
+    expect(isStopping.value).toBe(false)
+
+    await expect(cancelRunningFlow()).resolves.toBe(true)
+
+    expect(isRunning.value).toBe(false)
+    expect(isStopping.value).toBe(true)
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/work/demo',
+          type: 'cancelled',
+        },
+        message: ['Cancelled rtl2gds.'],
+        response: 'cancelled',
+      },
+    ]
+    await nextTick()
+
+    expect(isStopping.value).toBe(false)
+  })
+
+  it('does not re-enter stopping when the runtime cancelled event arrives before the cancel response', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    const deferredCancel = createDeferred<{
+      cmd: string
+      data: { directory: string }
+      message: string[]
+      ok: boolean
+      response: string
+    }>()
+    cancelFlowApi.mockReturnValue(deferredCancel.promise)
+
+    const { cancelRunningFlow, isStopping } = useFlowRunner()
+    const cancelPromise = cancelRunningFlow()
+
+    await nextTick()
+    expect(isStopping.value).toBe(true)
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/work/demo',
+          type: 'cancelled',
+        },
+        message: ['Cancelled rtl2gds.'],
+        response: 'cancelled',
+      },
+    ]
+    await nextTick()
+    expect(isStopping.value).toBe(false)
+
+    deferredCancel.resolve({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for rtl2gds.'],
+      ok: false,
+      response: 'cancelled',
+    })
+
+    await expect(cancelPromise).resolves.toBe(true)
+    expect(isStopping.value).toBe(false)
+  })
+
+  it('treats a no-active cancellation warning as stale flow UI cleanup', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    cancelFlowApi.mockResolvedValue({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      message: ['No active ECC command is running for /work/demo.'],
+      ok: true,
+      response: 'warning',
+    })
+
+    const { cancelRunningFlow, isStopping } = useFlowRunner()
+
+    await expect(cancelRunningFlow()).resolves.toBe(true)
+
+    expect(isStopping.value).toBe(false)
+    expect(showToast).toHaveBeenCalledWith({
+      severity: 'warn',
+      summary: 'Stop Flow',
+      detail: 'No active ECC command is running for /work/demo.',
+      life: 5000,
+    })
+  })
+
+  it('does not force a fallback command when no local flow command is known', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    cancelFlowApi.mockResolvedValue({
+      cmd: 'run_step',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for run_step.'],
+      ok: false,
+      response: 'cancelled',
+    })
+
+    const { cancelRunningFlow } = useFlowRunner()
+
+    await expect(cancelRunningFlow()).resolves.toBe(true)
+
+    expect(cancelFlowApi).toHaveBeenCalledWith({
+      data: {
+        directory: '/work/demo',
+      },
+    })
+  })
+
+  it('cancels an active single-step run with the run_step command', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    let resolveRunStep:
+      | ((value: {
+          data: { state: StateEnum; step: StepEnum }
+          message: string[]
+          response: string
+        }) => void)
+      | undefined
+    runStepApi.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRunStep = resolve
+      }),
+    )
+    cancelFlowApi.mockResolvedValue({
+      cmd: 'run_step',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for run_step.'],
+      ok: false,
+      response: 'cancelled',
+    })
+
+    const { cancelRunningFlow, runFlow } = useFlowRunner()
+    const runPromise = runFlow()
+
+    await vi.waitFor(() => {
+      expect(runStepApi).toHaveBeenCalledTimes(1)
+    })
+    await expect(cancelRunningFlow()).resolves.toBe(true)
+
+    expect(cancelFlowApi).toHaveBeenCalledWith({
+      cmd: 'run_step',
+      data: {
+        directory: '/work/demo',
+      },
+    })
+
+    resolveRunStep?.({
+      data: { state: StateEnum.Success, step: StepEnum.FLOORPLAN },
+      message: ['done'],
+      response: 'success',
+    })
+    await runPromise
+  })
+
+  it('shows one stopped toast when a cancelled full flow settles after the stop request', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    let resolveRunAll:
+      | ((value: {
+          data: Record<string, unknown>
+          message: string[]
+          response: string
+        }) => void)
+      | undefined
+    rtl2gdsApi.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRunAll = resolve
+      }),
+    )
+    cancelFlowApi.mockResolvedValue({
+      cmd: 'rtl2gds',
+      data: { directory: '/work/demo' },
+      message: ['Cancellation requested for rtl2gds.'],
+      ok: false,
+      response: 'cancelled',
+    })
+
+    const { cancelRunningFlow, isRunning, isStopping, runAllFlow } = useFlowRunner()
+    const runPromise = runAllFlow()
+
+    await vi.waitFor(() => {
+      expect(rtl2gdsApi).toHaveBeenCalledTimes(1)
+    })
+    await expect(cancelRunningFlow()).resolves.toBe(true)
+    expect(isRunning.value).toBe(true)
+    expect(isStopping.value).toBe(true)
+    resolveRunAll?.({
+      data: {},
+      message: ['Cancelled rtl2gds.'],
+      response: 'cancelled',
+    })
+    await runPromise
+    expect(isRunning.value).toBe(false)
+    expect(isStopping.value).toBe(false)
+
+    const stoppedToasts = showToast.mock.calls.filter(([toast]) =>
+      String(toast.summary).includes('Stopped'),
+    )
+    expect(stoppedToasts).toHaveLength(1)
+    expect(stoppedToasts[0]?.[0]).toMatchObject({
+      summary: 'Flow Stopped',
+    })
   })
 
   it('sends the active project directory when running a single step', async () => {
@@ -382,6 +672,22 @@ describe('useFlowRunner desktop-only guard', () => {
 
     clearFlowExecutionActiveForWorkspace('/work/a')
 
+    expect(flowExecutionActive.value).toBe(false)
+  })
+
+  it('does not let an old flow finalizer clear a newer workspace run', () => {
+    const staleToken = markFlowExecutionActiveForWorkspace('/work/demo')
+
+    clearFlowExecutionActiveForWorkspace('/work/demo')
+    const newerToken = markFlowExecutionActiveForWorkspace('/work/demo')
+    clearFlowExecutionActiveForWorkspace('/work/demo', staleToken)
+
+    expect(isFlowExecutionActiveForWorkspace('/work/demo')).toBe(true)
+    expect(flowExecutionActive.value).toBe(true)
+
+    clearFlowExecutionActiveForWorkspace('/work/demo', newerToken)
+
+    expect(isFlowExecutionActiveForWorkspace('/work/demo')).toBe(false)
     expect(flowExecutionActive.value).toBe(false)
   })
 })

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunner.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunner.test.ts
@@ -363,6 +363,7 @@ describe('useFlowRunner desktop-only guard', () => {
   it('treats a no-active cancellation warning as stale flow UI cleanup', async () => {
     ensureDesktopRuntime.mockReturnValue(true)
     currentProject.value = { path: '/work/demo' }
+    markFlowExecutionActiveForWorkspace('/work/demo', CMDEnum.rtl2gds)
     cancelFlowApi.mockResolvedValue({
       cmd: 'rtl2gds',
       data: { directory: '/work/demo' },
@@ -371,11 +372,14 @@ describe('useFlowRunner desktop-only guard', () => {
       response: 'warning',
     })
 
-    const { cancelRunningFlow, isStopping } = useFlowRunner()
+    const { cancelRunningFlow, isRunning, isStopping } = useFlowRunner()
 
+    expect(isRunning.value).toBe(true)
     await expect(cancelRunningFlow()).resolves.toBe(true)
 
+    expect(isRunning.value).toBe(false)
     expect(isStopping.value).toBe(false)
+    expect(flowExecutionActive.value).toBe(false)
     expect(showToast).toHaveBeenCalledWith({
       severity: 'warn',
       summary: 'Stop Flow',

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunner.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunner.test.ts
@@ -506,6 +506,43 @@ describe('useFlowRunner desktop-only guard', () => {
     })
   })
 
+  it('clears a full-flow rerun after a duplicate startup marker is observed', async () => {
+    ensureDesktopRuntime.mockReturnValue(true)
+    currentProject.value = { path: '/work/demo' }
+    let resolveRunAll:
+      | ((value: {
+          data: Record<string, unknown>
+          message: string[]
+          response: string
+        }) => void)
+      | undefined
+    rtl2gdsApi.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRunAll = resolve
+      }),
+    )
+
+    const { isRunning, runAllFlow } = useFlowRunner()
+    const runPromise = runAllFlow({ rerun: true })
+
+    await vi.waitFor(() => {
+      expect(rtl2gdsApi).toHaveBeenCalledTimes(1)
+    })
+    expect(isRunning.value).toBe(true)
+
+    markFlowExecutionActiveForWorkspace('/work/demo', CMDEnum.rtl2gds)
+
+    resolveRunAll?.({
+      data: {},
+      message: ['Cancelled rtl2gds.'],
+      response: 'cancelled',
+    })
+    await runPromise
+
+    expect(isRunning.value).toBe(false)
+    expect(flowExecutionActive.value).toBe(false)
+  })
+
   it('sends the active project directory when running a single step', async () => {
     ensureDesktopRuntime.mockReturnValue(true)
     currentProject.value = { path: '/work/demo' }

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunner.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunner.ts
@@ -1,9 +1,10 @@
-import { computed, ref, shallowReactive } from 'vue'
+import { computed, ref, shallowReactive, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useDesktopRuntime } from './useDesktopRuntime'
 import { useWorkspace } from './useWorkspace'
 import { CMDEnum, StateEnum, StepEnum } from '@/api/type'
-import { runStepApi, rtl2gdsApi, type RunStepResponse } from '@/api/flow'
+import { cancelFlowApi, runStepApi, rtl2gdsApi, type RunStepResponse } from '@/api/flow'
+import type { RuntimeEventResponse } from '@/api/runtimeEvents'
 import type { WorkspaceInvalidationScope } from './useWorkspaceLifecycle'
 import {
   clearHomeRunArtifactResetAwaitingBackendStart,
@@ -15,6 +16,11 @@ import {
 /** 任意流程命令执行中为 true，供 Home flow log 等订阅，避免多实例 composable 状态不一致 */
 export const flowExecutionActive = ref(false)
 const activeFlowWorkspaces = shallowReactive(new Set<string>())
+const stoppingFlowWorkspaces = shallowReactive(new Set<string>())
+type FlowRunCommand = CMDEnum.rtl2gds | CMDEnum.run_step
+type FlowExecutionToken = symbol
+const activeFlowWorkspaceTokens = new Map<string, FlowExecutionToken>()
+const activeFlowWorkspaceCommands = new Map<string, FlowRunCommand>()
 const RUN_STEP_FALLBACK_SCOPES: WorkspaceInvalidationScope[] = ['home', 'parameters']
 
 export interface FlowRunOptions {
@@ -32,16 +38,31 @@ function refreshGlobalFlowExecutionActive() {
   flowExecutionActive.value = activeFlowWorkspaces.size > 0
 }
 
-export function markFlowExecutionActiveForWorkspace(path: string): void {
+export function markFlowExecutionActiveForWorkspace(
+  path: string,
+  command?: FlowRunCommand,
+): FlowExecutionToken | null {
   const workspacePath = normalizeWorkspacePath(path)
-  if (!workspacePath) return
+  if (!workspacePath) return null
+  const token = Symbol(workspacePath)
+  activeFlowWorkspaceTokens.set(workspacePath, token)
+  if (command) {
+    activeFlowWorkspaceCommands.set(workspacePath, command)
+  }
   activeFlowWorkspaces.add(workspacePath)
   refreshGlobalFlowExecutionActive()
+  return token
 }
 
-export function clearFlowExecutionActiveForWorkspace(path: string): void {
+export function clearFlowExecutionActiveForWorkspace(
+  path: string,
+  token?: FlowExecutionToken | null,
+): void {
   const workspacePath = normalizeWorkspacePath(path)
   if (!workspacePath) return
+  if (token && activeFlowWorkspaceTokens.get(workspacePath) !== token) return
+  activeFlowWorkspaceTokens.delete(workspacePath)
+  activeFlowWorkspaceCommands.delete(workspacePath)
   activeFlowWorkspaces.delete(workspacePath)
   refreshGlobalFlowExecutionActive()
 }
@@ -50,6 +71,31 @@ export function isFlowExecutionActiveForWorkspace(
   path: string | undefined | null,
 ): boolean {
   return Boolean(path && activeFlowWorkspaces.has(normalizeWorkspacePath(path)))
+}
+
+function activeFlowCommandForWorkspace(
+  path: string | undefined | null,
+): FlowRunCommand | null {
+  if (!path) return null
+  return activeFlowWorkspaceCommands.get(normalizeWorkspacePath(path)) ?? null
+}
+
+export function markFlowCancellationPendingForWorkspace(path: string): void {
+  const workspacePath = normalizeWorkspacePath(path)
+  if (!workspacePath) return
+  stoppingFlowWorkspaces.add(workspacePath)
+}
+
+export function clearFlowCancellationPendingForWorkspace(path: string): void {
+  const workspacePath = normalizeWorkspacePath(path)
+  if (!workspacePath) return
+  stoppingFlowWorkspaces.delete(workspacePath)
+}
+
+export function isFlowCancellationPendingForWorkspace(
+  path: string | undefined | null,
+): boolean {
+  return Boolean(path && stoppingFlowWorkspaces.has(normalizeWorkspacePath(path)))
 }
 
 /**
@@ -64,6 +110,41 @@ function clearTransientInteractionLocks() {
     'splitter-resizing-vertical',
     'window-resizing',
   )
+}
+
+function workspacePathFromRuntimeEvent(event: RuntimeEventResponse | undefined): string {
+  const data = event?.data
+  const workspacePath =
+    typeof data?.workspaceId === 'string'
+      ? data.workspaceId
+      : typeof data?.directory === 'string'
+        ? data.directory
+        : ''
+  return workspacePath ? normalizeWorkspacePath(workspacePath) : ''
+}
+
+function isTerminalFlowRuntimeEvent(event: RuntimeEventResponse | undefined): boolean {
+  const eventType = event?.data?.type
+  if (
+    eventType !== 'cancelled' &&
+    eventType !== 'task_complete' &&
+    eventType !== 'step_complete' &&
+    eventType !== 'error'
+  ) {
+    return false
+  }
+
+  const command = event?.data?.cmd
+  return command === undefined || command === 'rtl2gds' || command === 'run_step'
+}
+
+function isNoActiveCancellationWarning(result: {
+  message?: string[]
+  response?: string
+}): boolean {
+  if (result.response !== 'warning') return false
+  const message = result.message?.[0] ?? ''
+  return /no active|no running/i.test(message)
 }
 
 // ============ Composable ============
@@ -83,6 +164,7 @@ export function useFlowRunner() {
     showToast,
     invalidateWorkspaceResources,
     resourceVersions,
+    runtimeEvents,
     workspaceSession,
   } = useWorkspace()
   const route = useRoute()
@@ -91,9 +173,24 @@ export function useFlowRunner() {
   const isRunning = computed(() =>
     isFlowExecutionActiveForWorkspace(currentProject.value?.path),
   )
+  const isStopping = computed(() =>
+    isFlowCancellationPendingForWorkspace(currentProject.value?.path),
+  )
   const state = ref<StateEnum>(StateEnum.Invalid)
   const error = ref<string | null>(null)
+  const isCancelling = ref(false)
   const lastRunResult = ref<RunStepResponse | null>(null)
+
+  watch(
+    () => runtimeEvents.value[runtimeEvents.value.length - 1],
+    (event) => {
+      if (!isTerminalFlowRuntimeEvent(event)) return
+      const workspacePath = workspacePathFromRuntimeEvent(event)
+      if (workspacePath) {
+        clearFlowCancellationPendingForWorkspace(workspacePath)
+      }
+    },
+  )
 
   /**
    * 获取当前步骤（从动态路由参数获取）
@@ -161,7 +258,11 @@ export function useFlowRunner() {
     }
 
     clearTransientInteractionLocks()
-    markFlowExecutionActiveForWorkspace(directory)
+    clearFlowCancellationPendingForWorkspace(directory)
+    const executionToken = markFlowExecutionActiveForWorkspace(
+      directory,
+      CMDEnum.run_step,
+    )
     state.value = StateEnum.Ongoing
     error.value = null
     try {
@@ -215,7 +316,8 @@ export function useFlowRunner() {
       })
     } finally {
       clearTransientInteractionLocks()
-      clearFlowExecutionActiveForWorkspace(directory)
+      clearFlowCancellationPendingForWorkspace(directory)
+      clearFlowExecutionActiveForWorkspace(directory, executionToken)
     }
     return null
   }
@@ -257,10 +359,11 @@ export function useFlowRunner() {
     }
 
     clearTransientInteractionLocks()
+    clearFlowCancellationPendingForWorkspace(directory)
     if (options.rerun) {
       markHomeRunArtifactResetAwaitingBackendStart(directory)
     }
-    markFlowExecutionActiveForWorkspace(directory)
+    const executionToken = markFlowExecutionActiveForWorkspace(directory, CMDEnum.rtl2gds)
     state.value = StateEnum.Ongoing
     error.value = null
 
@@ -284,6 +387,9 @@ export function useFlowRunner() {
           detail: 'All flow steps finished successfully',
           life: 5000,
         })
+      } else if (result.response === 'cancelled') {
+        state.value = StateEnum.Imcomplete
+        error.value = null
       } else {
         state.value = StateEnum.Imcomplete
         error.value = result.message?.[0] || 'rtl2gds failed'
@@ -309,14 +415,104 @@ export function useFlowRunner() {
     } finally {
       clearTransientInteractionLocks()
       clearHomeRunArtifactResetAwaitingBackendStart(directory)
-      clearFlowExecutionActiveForWorkspace(directory)
+      clearFlowCancellationPendingForWorkspace(directory)
+      clearFlowExecutionActiveForWorkspace(directory, executionToken)
     }
     return null
+  }
+
+  async function cancelRunningFlow(): Promise<boolean> {
+    if (!ensureDesktopRuntime()) {
+      console.warn(
+        'Not running in desktop runtime environment, cannot cancel ECC CLI flow command',
+      )
+      showDesktopRequiredToast()
+      return false
+    }
+
+    const directory = getCurrentWorkspacePath()
+    if (!directory) {
+      showToast({
+        severity: 'error',
+        summary: 'No Workspace Open',
+        detail: 'Open a workspace before stopping the flow.',
+        life: 5000,
+      })
+      return false
+    }
+
+    if (isCancelling.value) {
+      return false
+    }
+
+    const command = activeFlowCommandForWorkspace(directory)
+
+    markFlowCancellationPendingForWorkspace(directory)
+    isCancelling.value = true
+    try {
+      const result = await cancelFlowApi({
+        ...(command ? { cmd: command } : {}),
+        data: {
+          directory,
+        },
+      })
+
+      if (result.response === 'cancelled') {
+        clearHomeRunArtifactResetAwaitingBackendStart(directory)
+        state.value = StateEnum.Imcomplete
+        error.value = null
+        showToast({
+          severity: 'warn',
+          summary: 'Flow Stopped',
+          detail: result.message?.[0] || 'Cancellation requested.',
+          life: 5000,
+        })
+        return true
+      }
+
+      if (isNoActiveCancellationWarning(result)) {
+        clearHomeRunArtifactResetAwaitingBackendStart(directory)
+        clearFlowCancellationPendingForWorkspace(directory)
+        state.value = StateEnum.Imcomplete
+        error.value = null
+        showToast({
+          severity: 'warn',
+          summary: 'Stop Flow',
+          detail: result.message?.[0] || 'No running flow was found.',
+          life: 5000,
+        })
+        return true
+      }
+
+      showToast({
+        severity: 'warn',
+        summary: 'Stop Flow',
+        detail: result.message?.[0] || 'No running flow was found.',
+        life: 5000,
+      })
+      clearFlowCancellationPendingForWorkspace(directory)
+      return false
+    } catch (err) {
+      console.error('Cancel flow failed:', err)
+      clearFlowCancellationPendingForWorkspace(directory)
+      showToast({
+        severity: 'error',
+        summary: 'Stop Flow Error',
+        detail: err instanceof Error ? err.message : String(err),
+        life: 6000,
+      })
+      return false
+    } finally {
+      isCancelling.value = false
+      clearTransientInteractionLocks()
+    }
   }
 
   return {
     // 状态
     isRunning,
+    isCancelling,
+    isStopping,
     state,
     error,
     lastRunResult,
@@ -324,5 +520,6 @@ export function useFlowRunner() {
     // 方法
     runFlow,
     runAllFlow,
+    cancelRunningFlow,
   }
 }

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunner.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunner.ts
@@ -44,6 +44,14 @@ export function markFlowExecutionActiveForWorkspace(
 ): FlowExecutionToken | null {
   const workspacePath = normalizeWorkspacePath(path)
   if (!workspacePath) return null
+  const existingToken = activeFlowWorkspaceTokens.get(workspacePath)
+  if (existingToken && activeFlowWorkspaces.has(workspacePath)) {
+    if (command) {
+      activeFlowWorkspaceCommands.set(workspacePath, command)
+    }
+    refreshGlobalFlowExecutionActive()
+    return existingToken
+  }
   const token = Symbol(workspacePath)
   activeFlowWorkspaceTokens.set(workspacePath, token)
   if (command) {

--- a/ecos/gui/apps/renderer/src/composables/useFlowRunner.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowRunner.ts
@@ -473,6 +473,7 @@ export function useFlowRunner() {
       if (isNoActiveCancellationWarning(result)) {
         clearHomeRunArtifactResetAwaitingBackendStart(directory)
         clearFlowCancellationPendingForWorkspace(directory)
+        clearFlowExecutionActiveForWorkspace(directory)
         state.value = StateEnum.Imcomplete
         error.value = null
         showToast({

--- a/ecos/gui/apps/renderer/src/composables/useFlowStages.live-watch.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowStages.live-watch.test.ts
@@ -6,6 +6,7 @@ const testState = vi.hoisted(() => ({
   readWorkspaceHomeResourceApi: vi.fn(),
   readWorkspaceFlowResourceApi: vi.fn(),
   readProjectTextFile: vi.fn(),
+  writeProjectTextFile: vi.fn(),
   resolveProjectPathAccess: vi.fn(async (path: string) => path),
   runtimeEvents: null as Ref<unknown[]> | null,
   resourceVersions: null as Ref<{
@@ -52,6 +53,7 @@ vi.mock('./useHomeData', () => ({
 
 vi.mock('@/utils/projectFiles', () => ({
   readProjectTextFile: testState.readProjectTextFile,
+  writeProjectTextFile: testState.writeProjectTextFile,
   watchProjectFile: testState.watchProjectFile,
 }))
 
@@ -108,6 +110,7 @@ describe('useFlowStages live project file watchers', () => {
     testState.readWorkspaceHomeResourceApi.mockReset()
     testState.readWorkspaceFlowResourceApi.mockReset()
     testState.readProjectTextFile.mockReset()
+    testState.writeProjectTextFile.mockReset()
     testState.resolveProjectPathAccess.mockClear()
     testState.watchProjectFile.mockReset()
 
@@ -191,6 +194,95 @@ describe('useFlowStages live project file watchers', () => {
     await vi.waitFor(() => {
       expect(flow.hasOngoingRunStage.value).toBe(true)
     })
+  })
+
+  it('marks stale ongoing run stages incomplete after cancellation cleanup', async () => {
+    const { useFlowStages } = await importFreshFlowStagesModule()
+    await startLifecycleSession('/workspace/a')
+    testState.readProjectTextFile.mockResolvedValue(
+      flowJsonFor({
+        Synthesis: 'Success',
+        Floorplan: 'Ongoing',
+      }),
+    )
+
+    const flow = useFlowStages()
+
+    await vi.waitFor(() => {
+      expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+        'Success',
+        'Ongoing',
+      ])
+    })
+
+    await flow.markOngoingRunStagesIncomplete()
+
+    expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+      'Success',
+      'Incomplete',
+    ])
+    expect(flow.hasOngoingRunStage.value).toBe(false)
+    expect(testState.writeProjectTextFile).toHaveBeenCalledWith(
+      '/workspace/a/home/flow.json',
+      expect.any(String),
+    )
+    const persistedFlow = JSON.parse(testState.writeProjectTextFile.mock.calls[0][1])
+    expect(persistedFlow.steps.map((step: { state: string }) => step.state)).toEqual([
+      'Success',
+      'Incomplete',
+    ])
+
+    await flow.refreshFlowStages()
+
+    expect(flow.dynamicFlowStages.value.map((stage) => stage.state)).toEqual([
+      'Success',
+      'Incomplete',
+    ])
+    expect(flow.hasOngoingRunStage.value).toBe(false)
+  })
+
+  it('persists stale ongoing stages when the cancelled runtime event arrives', async () => {
+    const { useFlowStages } = await importFreshFlowStagesModule()
+    await startLifecycleSession('/workspace/a')
+    testState.readProjectTextFile.mockResolvedValue(
+      flowJsonFor({
+        Synthesis: 'Ongoing',
+        Floorplan: 'Unstart',
+      }),
+    )
+
+    const flow = useFlowStages()
+
+    await vi.waitFor(() => {
+      expect(flow.hasOngoingRunStage.value).toBe(true)
+    })
+    testState.writeProjectTextFile.mockClear()
+
+    testState.runtimeEvents!.value = [
+      {
+        cmd: 'notify',
+        data: {
+          cmd: 'rtl2gds',
+          directory: '/workspace/a',
+          type: 'cancelled',
+        },
+        message: ['Cancelled rtl2gds.'],
+        response: 'cancelled',
+      },
+    ]
+    await nextTick()
+
+    await vi.waitFor(() => {
+      expect(testState.writeProjectTextFile).toHaveBeenCalledWith(
+        '/workspace/a/home/flow.json',
+        expect.any(String),
+      )
+    })
+    const persistedFlow = JSON.parse(testState.writeProjectTextFile.mock.calls[0][1])
+    expect(persistedFlow.steps.map((step: { state: string }) => step.state)).toEqual([
+      'Incomplete',
+      'Unstart',
+    ])
   })
 
   it('does not let a stale flow read from a previous session replace current stages', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useFlowStages.ts
+++ b/ecos/gui/apps/renderer/src/composables/useFlowStages.ts
@@ -3,7 +3,12 @@ import { useWorkspace } from './useWorkspace'
 import { useDesktopRuntime, isDesktopRuntime } from './useDesktopRuntime'
 import { convertRemoteToLocalPath } from './useHomeData'
 import { STEP_METADATA, getStepMetadata } from '@/api/type'
-import { readProjectTextFile, watchProjectFile } from '@/utils/projectFiles'
+import type { RuntimeEventResponse } from '@/api/runtimeEvents'
+import {
+  readProjectTextFile,
+  watchProjectFile,
+  writeProjectTextFile,
+} from '@/utils/projectFiles'
 import { resolveProjectPathAccess } from '@/utils/projectFs'
 import {
   readWorkspaceFlowResourceApi,
@@ -119,6 +124,13 @@ function flowDataHasStartedRun(flowData: FlowData): boolean {
   })
 }
 
+function flowDataHasOngoingRun(flowData: FlowData): boolean {
+  return flowData.steps.some((step) => {
+    const state = (step.state ?? '').trim().toLowerCase()
+    return state === 'ongoing' || state === 'running'
+  })
+}
+
 // ============ Composable ============
 
 /**
@@ -127,7 +139,7 @@ function flowDataHasStartedRun(flowData: FlowData): boolean {
  */
 export function useFlowStages() {
   const { isDesktopRuntimeAvailable } = useDesktopRuntime()
-  const { currentProject, resourceVersions } = useWorkspace()
+  const { currentProject, resourceVersions, runtimeEvents } = useWorkspace()
   const workspaceLifecycle = useWorkspaceLifecycle()
 
   // 动态加载的流程步骤
@@ -138,6 +150,7 @@ export function useFlowStages() {
   let unregisterFlowJsonLifecycleCleanup: (() => void) | null = null
   let unregisterHomeRunArtifactReset: (() => void) | null = null
   let pendingRerunFlowStartProjectPath = ''
+  let cancelledOngoingRunProjectPath = ''
   let watchSession = 0
 
   // 合并后的完整流程步骤
@@ -266,6 +279,7 @@ export function useFlowStages() {
   }
 
   function resetRunStagesForRerun(): void {
+    cancelledOngoingRunProjectPath = ''
     if (dynamicFlowStages.value.length === 0) return
     dynamicFlowStages.value = dynamicFlowStages.value.map((stage) => ({
       ...stage,
@@ -275,10 +289,97 @@ export function useFlowStages() {
     }))
   }
 
+  function normalizedCurrentProjectPath(): string {
+    const projectPath = currentProject.value?.path
+    return projectPath ? normalizeProjectPath(projectPath) : ''
+  }
+
+  function runtimeEventWorkspacePath(event: RuntimeEventResponse | undefined): string {
+    const data = event?.data
+    const workspacePath =
+      typeof data?.workspaceId === 'string'
+        ? data.workspaceId
+        : typeof data?.directory === 'string'
+          ? data.directory
+          : ''
+    return workspacePath ? normalizeProjectPath(workspacePath) : ''
+  }
+
+  function isCancelledFlowRuntimeEvent(event: RuntimeEventResponse | undefined): boolean {
+    if (event?.data?.type !== 'cancelled') return false
+    const command = event.data.cmd
+    return command === undefined || command === 'rtl2gds' || command === 'run_step'
+  }
+
+  function markFlowDataOngoingStepsIncomplete(flowData: FlowData): boolean {
+    let changed = false
+    for (const step of flowData.steps) {
+      const state = (step.state ?? '').trim().toLowerCase()
+      if (state !== 'ongoing' && state !== 'running') continue
+      step.state = 'Incomplete'
+      changed = true
+    }
+    return changed
+  }
+
+  function markDynamicOngoingStagesIncomplete(): boolean {
+    if (dynamicFlowStages.value.length === 0) return false
+    let markedStaleOngoing = false
+    dynamicFlowStages.value = dynamicFlowStages.value.map((stage) => {
+      const state = stage.state.trim().toLowerCase()
+      if (state !== 'ongoing' && state !== 'running') return stage
+      markedStaleOngoing = true
+      return {
+        ...stage,
+        state: 'Incomplete',
+      }
+    })
+    return markedStaleOngoing
+  }
+
+  async function persistOngoingRunStagesIncomplete(): Promise<boolean> {
+    const projectPath = currentProject.value?.path
+    if (!isDesktopRuntimeAvailable || !projectPath) return false
+
+    try {
+      const homeData = (await readWorkspaceHomeResourceApi()) as { flow?: string } | null
+      const flowJsonPath = homeData?.flow
+      if (!flowJsonPath) return false
+
+      const localFlowPath = convertRemoteToLocalPath(flowJsonPath, projectPath)
+      const resolvedFlowPath = await resolveProjectPathAccess(localFlowPath)
+      if (!resolvedFlowPath) return false
+
+      const fileContent = await readProjectTextFile(resolvedFlowPath)
+      const flowData = JSON.parse(fileContent) as FlowData
+      if (!markFlowDataOngoingStepsIncomplete(flowData)) return false
+
+      await writeProjectTextFile(
+        resolvedFlowPath,
+        `${JSON.stringify(flowData, null, 2)}\n`,
+      )
+      dynamicFlowStages.value = transformFlowData(flowData)
+      return true
+    } catch (err) {
+      console.warn('Failed to persist cancelled flow stage states:', err)
+      error.value = err instanceof Error ? err.message : String(err)
+      return false
+    }
+  }
+
   function shouldApplyFlowData(flowData: FlowData): boolean {
     const projectPath = currentProject.value?.path
     if (!projectPath) return true
     const normalizedProjectPath = normalizeProjectPath(projectPath)
+    if (
+      cancelledOngoingRunProjectPath === normalizedProjectPath &&
+      flowDataHasOngoingRun(flowData)
+    ) {
+      return false
+    }
+    if (cancelledOngoingRunProjectPath === normalizedProjectPath) {
+      cancelledOngoingRunProjectPath = ''
+    }
     const resetPending =
       pendingRerunFlowStartProjectPath === normalizedProjectPath ||
       isHomeRunArtifactResetPending(projectPath)
@@ -338,6 +439,7 @@ export function useFlowStages() {
    * 在用户点击 Run RTL2GDS 时调用，立即反映运行状态
    */
   function setFirstRunStepOngoing(): void {
+    cancelledOngoingRunProjectPath = ''
     const idx = dynamicFlowStages.value.findIndex((s) => s.state !== 'Success')
     if (idx !== -1) {
       dynamicFlowStages.value[idx] = {
@@ -353,6 +455,7 @@ export function useFlowStages() {
    */
   function setRunStepOngoingByPath(stepPath: string): void {
     if (!stepPath) return
+    cancelledOngoingRunProjectPath = ''
     const key = stepPath.toLowerCase()
     const idx = dynamicFlowStages.value.findIndex((s) => s.path.toLowerCase() === key)
     if (idx !== -1) {
@@ -360,6 +463,14 @@ export function useFlowStages() {
         ...dynamicFlowStages.value[idx],
         state: 'Ongoing',
       }
+    }
+  }
+
+  async function markOngoingRunStagesIncomplete(): Promise<void> {
+    const markedStaleOngoing = markDynamicOngoingStagesIncomplete()
+    const persistedStaleOngoing = await persistOngoingRunStagesIncomplete()
+    if (markedStaleOngoing || persistedStaleOngoing) {
+      cancelledOngoingRunProjectPath = normalizedCurrentProjectPath()
     }
   }
 
@@ -402,6 +513,18 @@ export function useFlowStages() {
     },
   )
 
+  watch(
+    () => runtimeEvents.value[runtimeEvents.value.length - 1],
+    (event) => {
+      if (!isCancelledFlowRuntimeEvent(event)) return
+      const projectPath = normalizedCurrentProjectPath()
+      if (!projectPath) return
+      const eventWorkspacePath = runtimeEventWorkspacePath(event)
+      if (eventWorkspacePath && eventWorkspacePath !== projectPath) return
+      void markOngoingRunStagesIncomplete()
+    },
+  )
+
   unregisterHomeRunArtifactReset = onHomeRunArtifactReset((projectPath) => {
     const currentProjectPath = currentProject.value?.path
     if (
@@ -439,5 +562,6 @@ export function useFlowStages() {
     clearFlowStages,
     setFirstRunStepOngoing,
     setRunStepOngoingByPath,
+    markOngoingRunStagesIncomplete,
   }
 }

--- a/ecos/gui/apps/renderer/src/composables/usePdkManager.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/usePdkManager.test.ts
@@ -214,6 +214,13 @@ const desktopBridge = {
     onProgress: () => () => undefined,
   },
   cli: {
+    cancel: async (request) => ({
+      cmd: request.cmd ?? 'rtl2gds',
+      data: { directory: request.directory },
+      message: [],
+      ok: false,
+      response: 'cancelled',
+    }),
     execute: async (request) => ({
       cmd: request.cmd,
       data: {},

--- a/ecos/gui/apps/renderer/src/composables/useVersion.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useVersion.test.ts
@@ -158,6 +158,13 @@ function createDesktopBridge(getVersions: DesktopApi['app']['getVersions']) {
       onProgress: () => () => undefined,
     },
     cli: {
+      cancel: async (request) => ({
+        cmd: request.cmd ?? 'rtl2gds',
+        data: { directory: request.directory },
+        message: [],
+        ok: false,
+        response: 'cancelled',
+      }),
       execute: async (request) => ({
         cmd: request.cmd,
         data: {},

--- a/ecos/gui/packages/shared/src/constants/ipcChannels.ts
+++ b/ecos/gui/packages/shared/src/constants/ipcChannels.ts
@@ -56,6 +56,7 @@ export const desktopApiIpcChannels = {
   resourcesRefreshRegistry: 'resources:refresh-registry',
   layoutViewerOpen: 'layout-viewer:open',
   cliExecute: 'cli:execute',
+  cliCancel: 'cli:cancel',
   shellCreateSession: 'shell:create-session',
   shellWrite: 'shell:write',
   shellResize: 'shell:resize',

--- a/ecos/gui/packages/shared/src/contracts/desktopApi.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopApi.ts
@@ -18,6 +18,7 @@ import type {
 } from './resources.ts'
 import type { RemoteContentApi } from './remoteContent.ts'
 import type {
+  DesktopCliCancelRequest,
   DesktopCliCommandEvent,
   DesktopCliCommandRequest,
   DesktopCliCommandResult,
@@ -228,6 +229,7 @@ export interface DesktopApi {
     onProgress(listener: (event: ResourceJob) => void): DesktopEventUnsubscribe
   }
   cli: {
+    cancel(request: DesktopCliCancelRequest): Promise<DesktopCliCommandResult>
     execute(request: DesktopCliCommandRequest): Promise<DesktopCliCommandResult>
     onEvent(listener: (event: DesktopCliCommandEvent) => void): DesktopEventUnsubscribe
   }

--- a/ecos/gui/packages/shared/src/contracts/desktopCli.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopCli.ts
@@ -35,6 +35,11 @@ export interface DesktopCliCommandRequest {
   source: DesktopCliCommandSource
 }
 
+export interface DesktopCliCancelRequest {
+  directory: string
+  cmd?: DesktopCliCommandName
+}
+
 export interface DesktopCliCommandResult {
   ok: boolean
   cmd: DesktopCliCommandName

--- a/ecos/gui/packages/shared/src/index.ts
+++ b/ecos/gui/packages/shared/src/index.ts
@@ -23,6 +23,7 @@ export type {
   VersionInfo,
 } from './contracts/desktopApi.ts'
 export type {
+  DesktopCliCancelRequest,
   DesktopCliCommandEvent,
   DesktopCliCommandEventType,
   DesktopCliCommandName,


### PR DESCRIPTION
## Summary

- Add desktop cancellation support for long-running ECC CLI `rtl2gds` and `run_step` jobs, including process termination and runtime cancellation events.
- Update the renderer flow control to show stop/stopping states, avoid command-mismatch cancellation failures, and restore the run button after cancellation settles.
- Persist cancelled `Ongoing` / `running` flow steps back to `flow.json` as `Incomplete` so refreshed UI state matches the project file.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [x] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other:
  - `cd ecos/gui && pnpm --filter @ecos-studio/renderer exec vitest run src/composables/useFlowStages.live-watch.test.ts src/composables/useFlowRunner.test.ts src/api/flow.desktop-ipc.test.ts`
  - `cd ecos/gui && pnpm --filter @ecos-studio/desktop-electron exec vitest run electron/services/eccCliAdapter.test.ts electron/services/desktopRuntimeManager.test.ts electron/main/registerIpc.test.ts electron/preload/index.test.ts`
  - `cd ecos/gui && pnpm run lint`
  - `cd ecos/gui && pnpm exec oxfmt --check apps/renderer/src/composables/useFlowStages.ts apps/renderer/src/composables/useFlowStages.live-watch.test.ts apps/renderer/src/components/LeftSidebar.vue apps/renderer/src/composables/useFlowRunner.ts apps/renderer/src/composables/useFlowRunner.test.ts apps/renderer/src/api/flow.ts apps/renderer/src/api/flow.desktop-ipc.test.ts apps/desktop-electron/electron/services/eccCliAdapter.ts apps/desktop-electron/electron/services/eccCliAdapter.test.ts apps/desktop-electron/electron/services/desktopRuntimeManager.ts apps/desktop-electron/electron/services/desktopRuntimeManager.test.ts apps/desktop-electron/electron/main/registerIpc.ts apps/desktop-electron/electron/main/registerIpc.test.ts apps/desktop-electron/electron/preload/index.ts apps/desktop-electron/electron/preload/index.test.ts packages/shared/src/contracts/desktopCli.ts packages/shared/src/contracts/desktopApi.ts packages/shared/src/constants/ipcChannels.ts packages/shared/src/index.ts`
  - `git diff --check -- <changed tracked files>`

Skipped checks and reason:

- Full `cd ecos/gui && pnpm run test` not run; targeted renderer and desktop cancellation/runtime suites were run for this scoped change.
- `cd ecos/gui && pnpm run build`, `make build`, `make demo-gcd`, and `make demo-retrosoc` not run; this change is limited to GUI cancellation/runtime behavior and does not change packaging, release artifacts, PDKs, or demo flow inputs.
- Manual GUI smoke not run in this session; behavior is covered by renderer and Electron unit tests.

## Screenshots or Recordings

Required for visible GUI changes.

- Not captured in this session. Visible changes are the stop/stopping control states for active flow runs.

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [x] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Runtime impact is limited to Electron/ECC CLI process cancellation plumbing for `rtl2gds` and `run_step`.
- No dependency, lockfile, version metadata, packaging, or submodule gitlink changes are included.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
