### PR TITLE
fix(gui): pin ics55 routing layers

### DIFF
--- a/ecos/gui/apps/renderer/src/components/step-config/stepConfigLayouts.css
+++ b/ecos/gui/apps/renderer/src/components/step-config/stepConfigLayouts.css
@@ -426,6 +426,20 @@
   font-size: 11px;
 }
 
+.step-config-root .sc-pro-fixed-value {
+  display: flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-secondary) 75%, var(--bg-primary));
+  color: var(--text-primary);
+  font-family: 'Fira Code', ui-monospace, monospace;
+  font-size: 11px;
+  box-sizing: border-box;
+}
+
 /* Label chips (CTS toggles) */
 .step-config-root .sc-pro-pill {
   display: inline-flex;

--- a/ecos/gui/apps/renderer/src/components/step-config/views/RtStepConfigView.vue
+++ b/ecos/gui/apps/renderer/src/components/step-config/views/RtStepConfigView.vue
@@ -14,7 +14,12 @@ const rtEntries = computed(() => {
   return Object.entries(block).sort(([a], [b]) => a.localeCompare(b))
 })
 
+function isFixedRoutingLayerKey(k: string): boolean {
+  return k === '-bottom_routing_layer' || k === '-top_routing_layer'
+}
+
 function setRtKey(k: string, val: string | undefined): void {
+  if (isFixedRoutingLayerKey(k)) return
   const s = val ?? ''
   if (isObj(draft.value.RT)) {
     ;(draft.value.RT as Record<string, unknown>)[k] = s
@@ -40,7 +45,11 @@ function setRtKey(k: string, val: string | undefined): void {
         <div v-for="[k, v] in rtEntries" :key="k" class="sc-pro-flag">
           <div class="sc-pro-flag__key">{{ k }}</div>
           <div class="sc-pro-flag__val min-w-0">
+            <div v-if="isFixedRoutingLayerKey(k)" class="sc-pro-fixed-value">
+              {{ v === null || v === undefined ? '' : String(v) }}
+            </div>
             <InputText
+              v-else
               :model-value="v === null || v === undefined ? '' : String(v)"
               size="small"
               fluid

--- a/ecos/gui/apps/renderer/src/composables/useParameters.runtime.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useParameters.runtime.test.ts
@@ -175,35 +175,30 @@ describe('useParameters desktop bridge integration', () => {
     clearFlowExecutionActiveForWorkspace('/workspace/demo')
   })
 
+  it('exposes the ics55 routing layers supported by the route config', () => {
+    fetchSharedHomeData.mockResolvedValue({
+      parameters: '/workspace/demo/home/parameters.json',
+    })
+    readProjectTextFile.mockResolvedValue(parametersJson())
+
+    const parameters = useParameters()
+
+    expect(parameters.layerOptions.value.map((layer) => layer.value)).toEqual([
+      'MET2',
+      'MET3',
+      'MET4',
+      'MET5',
+    ])
+  })
+
   it('loads and saves parameters through the bridge-backed file helpers', async () => {
     fetchSharedHomeData.mockResolvedValue({
       parameters: '/workspace/demo/home/parameters.json',
     })
     readProjectTextFile.mockResolvedValue(
-      JSON.stringify({
-        PDK: 'ics55',
-        Design: 'demo',
-        'Top module': 'chip_top',
-        Die: { Size: [100, 100], Area: 10000 },
-        Core: {
-          Size: [80, 80],
-          Area: 6400,
-          'Bounding box': '(0,0) (80,80)',
-          Utilitization: 0.5,
-          Margin: [4, 4],
-          'Aspect ratio': 1,
-        },
-        'Max fanout': 20,
-        'Target density': 0.3,
-        'Target overflow': 0.1,
-        'Global right padding': 0,
-        'Cell padding x': 600,
-        'Routability opt flag': 1,
-        Clock: 'clk',
-        'Frequency max [MHz]': 100,
-        'Bottom layer': 'MET2',
-        'Top layer': 'MET5',
-        'PDK Root': '/pdks/ics55',
+      parametersJson({
+        'Bottom layer': 'MET3',
+        'Top layer': 'MET6',
       }),
     )
 
@@ -217,6 +212,8 @@ describe('useParameters desktop bridge integration', () => {
 
     expect(parameters.config.design).toBe('demo')
     expect(parameters.config.topModule).toBe('chip_top')
+    expect(parameters.config.bottomLayer).toBe('MET2')
+    expect(parameters.config.topLayer).toBe('MET5')
 
     parameters.config.design = 'updated_demo'
 
@@ -225,10 +222,12 @@ describe('useParameters desktop bridge integration', () => {
     expect(resolveProjectPathAccess).toHaveBeenCalledWith(
       '/workspace/demo/home/parameters.json',
     )
-    expect(writeProjectTextFile).toHaveBeenCalledWith(
-      '/workspace/demo/home/parameters.json',
-      expect.stringContaining('"Design": "updated_demo"'),
-    )
+    const savedContent = writeProjectTextFile.mock.calls[0][1] as string
+    expect(JSON.parse(savedContent)).toMatchObject({
+      Design: 'updated_demo',
+      'Bottom layer': 'MET2',
+      'Top layer': 'MET5',
+    })
     expect(refreshConfigApi).toHaveBeenCalledWith({
       cmd: 'refresh_config',
       data: {

--- a/ecos/gui/apps/renderer/src/composables/useParameters.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useParameters.test.ts
@@ -87,11 +87,55 @@ describe('useParameters helpers', () => {
       clock: 'clk',
       frequencyMax: 500,
       bottomLayer: 'MET2',
-      topLayer: 'MET7',
+      topLayer: 'MET5',
     }
 
     expect(transformParametersToConfig(transformConfigToParameters(config))).toEqual(
       config,
     )
+  })
+
+  it('pins routing layer fields to the ics55 MET2-MET5 route window', () => {
+    const config = transformParametersToConfig(
+      parseParametersData(
+        JSON.stringify({
+          PDK: 'ics55',
+          Design: 'demo',
+          'Top module': 'top',
+          Die: { Size: [100, 200], Area: 300 },
+          Core: {
+            Size: [80, 120],
+            Area: 9600,
+            'Bounding box': '(0,0) (10,10)',
+            Utilitization: 0.55,
+            Margin: [3, 4],
+            'Aspect ratio': 1.2,
+          },
+          'Max fanout': 42,
+          'Target density': 0.61,
+          'Target overflow': 0.09,
+          'Global right padding': 7,
+          'Cell padding x': 900,
+          'Routability opt flag': 0,
+          Clock: 'clk',
+          'Frequency max [MHz]': 250,
+          'Bottom layer': 'MET3',
+          'Top layer': 'MET6',
+          'PDK Root': '/pdks/ics55',
+        }),
+      ),
+    )
+
+    expect(config.bottomLayer).toBe('MET2')
+    expect(config.topLayer).toBe('MET5')
+
+    const parameters = transformConfigToParameters({
+      ...config,
+      bottomLayer: 'MET3',
+      topLayer: 'MET6',
+    })
+
+    expect(parameters['Bottom layer']).toBe('MET2')
+    expect(parameters['Top layer']).toBe('MET5')
   })
 })

--- a/ecos/gui/apps/renderer/src/composables/useParameters.ts
+++ b/ecos/gui/apps/renderer/src/composables/useParameters.ts
@@ -71,18 +71,10 @@ export interface ConfigData {
 
 // ============ 工具函数 ============
 
-/** 用于 Bottom/Top 金属层下拉的常见顺序（与 PDK 文档一致即可） */
-const ROUTING_LAYER_ORDER = [
-  'LI1',
-  'MET1',
-  'MET2',
-  'MET3',
-  'MET4',
-  'MET5',
-  'MET6',
-  'MET7',
-  'MET8',
-]
+/** ICS55 routing is pinned to the MET2 through MET5 route window. */
+const FIXED_BOTTOM_LAYER = 'MET2'
+const FIXED_TOP_LAYER = 'MET5'
+const ROUTING_LAYER_ORDER = [FIXED_BOTTOM_LAYER, 'MET3', 'MET4', FIXED_TOP_LAYER]
 const FLOW_RUNNING_SAVE_BLOCKED_MESSAGE =
   'Flow is running. Configuration is read-only until the current run finishes.'
 const RUNNING_FLOW_PARAMETERS_POLL_MS = 1600
@@ -110,8 +102,8 @@ function getDefaultConfig(): ConfigData {
     routabilityOptFlag: true,
     clock: '',
     frequencyMax: 100,
-    bottomLayer: 'MET2',
-    topLayer: 'MET5',
+    bottomLayer: FIXED_BOTTOM_LAYER,
+    topLayer: FIXED_TOP_LAYER,
   }
 }
 
@@ -178,8 +170,8 @@ export function parseParametersData(fileContent: string): ParametersData {
     'Routability opt flag': Number(raw['Routability opt flag'] ?? 1),
     Clock: String(raw.Clock ?? ''),
     'Frequency max [MHz]': Number(raw['Frequency max [MHz]'] ?? 100),
-    'Bottom layer': String(raw['Bottom layer'] ?? 'MET2'),
-    'Top layer': String(raw['Top layer'] ?? 'MET5'),
+    'Bottom layer': String(raw['Bottom layer'] ?? FIXED_BOTTOM_LAYER),
+    'Top layer': String(raw['Top layer'] ?? FIXED_TOP_LAYER),
     'PDK Root': raw['PDK Root'] != null ? String(raw['PDK Root']) : undefined,
   }
 }
@@ -210,8 +202,8 @@ export function transformParametersToConfig(data: ParametersData): ConfigData {
     routabilityOptFlag: !!data['Routability opt flag'],
     clock: data.Clock || '',
     frequencyMax: data['Frequency max [MHz]'] ?? 100,
-    bottomLayer: data['Bottom layer'] || 'MET2',
-    topLayer: data['Top layer'] || 'MET5',
+    bottomLayer: FIXED_BOTTOM_LAYER,
+    topLayer: FIXED_TOP_LAYER,
   }
 }
 
@@ -240,8 +232,8 @@ export function transformConfigToParameters(config: ConfigData): ParametersData 
     'Routability opt flag': config.routabilityOptFlag ? 1 : 0,
     Clock: config.clock,
     'Frequency max [MHz]': config.frequencyMax,
-    'Bottom layer': config.bottomLayer,
-    'Top layer': config.topLayer,
+    'Bottom layer': FIXED_BOTTOM_LAYER,
+    'Top layer': FIXED_TOP_LAYER,
   }
   out['PDK Root'] = config.pdkRoot ?? ''
   return out
@@ -725,21 +717,11 @@ export function useParameters() {
   })
 
   const layersList = computed(() => {
-    const opts = layerOptions.value.map((o) => o.value)
-    const lo = opts.indexOf(config.bottomLayer)
-    const hi = opts.indexOf(config.topLayer)
-    if (lo === -1 || hi === -1) return opts
-    const a = Math.min(lo, hi)
-    const b = Math.max(lo, hi)
-    return opts.slice(a, b + 1)
+    return layerOptions.value.map((o) => o.value)
   })
 
   const isLayerInRange = (layer: string): boolean => {
-    const layers = layersList.value
-    const bottomIndex = layers.indexOf(config.bottomLayer)
-    const topIndex = layers.indexOf(config.topLayer)
-    const currentIndex = layers.indexOf(layer)
-    return currentIndex >= bottomIndex && currentIndex <= topIndex
+    return layersList.value.includes(layer)
   }
 
   return {

--- a/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.test.ts
@@ -377,6 +377,56 @@ describe('useStepConfigInfo', () => {
     })
   })
 
+  it('pins route step config routing layers when loading and saving', async () => {
+    testState.resolveWorkspaceStepInfoApi.mockResolvedValue({
+      response: 'available',
+      info: {
+        config: '/workspace/demo/config/rt_default_config.json',
+      },
+      missing: [],
+      message: [],
+      id: 'config',
+      step: 'route',
+    })
+    testState.readProjectTextFile.mockResolvedValue(
+      JSON.stringify({
+        RT: {
+          '-bottom_routing_layer': 'MET1',
+          '-top_routing_layer': 'MET6',
+          '-thread_number': '50',
+        },
+      }),
+    )
+    testState.route.path = '/workspace/route'
+
+    const result = scope.run(() => useStepConfigInfo())!
+
+    await vi.waitFor(() => {
+      expect(result.stepConfigDraft.value).toEqual({
+        RT: {
+          '-bottom_routing_layer': 'MET2',
+          '-top_routing_layer': 'MET5',
+          '-thread_number': '50',
+        },
+      })
+    })
+    expect(result.hasStepConfigChanges.value).toBe(true)
+
+    await expect(result.saveStepConfig()).resolves.toBe(true)
+
+    const savedContent = testState.writeProjectTextFile.mock.calls[0][1] as string
+    expect(JSON.parse(savedContent)).toEqual({
+      RT: {
+        '-bottom_routing_layer': 'MET2',
+        '-top_routing_layer': 'MET5',
+        '-thread_number': '50',
+      },
+    })
+    await vi.waitFor(() => {
+      expect(result.hasStepConfigChanges.value).toBe(false)
+    })
+  })
+
   it('rejects step config saves while the workspace flow is running', async () => {
     testState.resolveWorkspaceStepInfoApi.mockResolvedValue({
       response: 'available',
@@ -417,7 +467,9 @@ describe('useStepConfigInfo', () => {
       step: 'route',
     })
     testState.readProjectTextFile
-      .mockResolvedValueOnce('{"RT":{"-bottom_routing_layer":"MET2"}}')
+      .mockResolvedValueOnce(
+        '{"RT":{"-bottom_routing_layer":"MET2","-top_routing_layer":"MET5","-thread_number":"50"}}',
+      )
       .mockResolvedValue(
         '{\n    "RT": {\n        "-bottom_routing_layer": "MET4"\n    }\n}',
       )
@@ -438,13 +490,23 @@ describe('useStepConfigInfo', () => {
 
     await vi.waitFor(() => {
       expect(result.stepConfigDraft.value).toEqual({
-        RT: { '-bottom_routing_layer': 'MET2' },
+        RT: {
+          '-bottom_routing_layer': 'MET2',
+          '-top_routing_layer': 'MET5',
+          '-thread_number': '50',
+        },
       })
     })
 
     const lifecycle = useWorkspaceLifecycle()
     const initialVersions = { ...lifecycle.resourceVersions.value }
-    result.stepConfigDraft.value = { RT: { '-bottom_routing_layer': 'MET4' } }
+    result.stepConfigDraft.value = {
+      RT: {
+        '-bottom_routing_layer': 'MET2',
+        '-top_routing_layer': 'MET5',
+        '-thread_number': '64',
+      },
+    }
 
     await expect(result.saveStepConfig()).resolves.toBe(true)
 

--- a/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.ts
+++ b/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.ts
@@ -14,6 +14,12 @@ import { isFlowExecutionActiveForWorkspace } from './useFlowRunner'
 const stepEnumValues = Object.values(StepEnum)
 const FLOW_RUNNING_SAVE_BLOCKED_MESSAGE =
   'Flow is running. Configuration is read-only until the current run finishes.'
+const ROUTE_STEP_BOTTOM_LAYER = 'MET2'
+const ROUTE_STEP_TOP_LAYER = 'MET5'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
 
 function getStepEnumFromPath(path: string): StepEnum | undefined {
   return stepEnumValues.find((step) => step.toLowerCase() === path.toLowerCase())
@@ -49,6 +55,18 @@ function stableJsonSig(v: unknown): string {
   } catch {
     return ''
   }
+}
+
+function pinRouteStepConfigRoutingLayers(
+  value: unknown,
+  step: StepEnum | undefined,
+): unknown {
+  if (step !== StepEnum.ROUTING || !isRecord(value)) return value
+
+  const routeBlock = isRecord(value.RT) ? value.RT : value
+  routeBlock['-bottom_routing_layer'] = ROUTE_STEP_BOTTOM_LAYER
+  routeBlock['-top_routing_layer'] = ROUTE_STEP_TOP_LAYER
+  return value
 }
 
 function pickStepConfigPathFromInfo(data: Record<string, unknown>): string | undefined {
@@ -227,7 +245,10 @@ export function useStepConfigInfo() {
     }
     try {
       const parsed = JSON.parse(raw) as unknown
-      stepConfigDraft.value = deepClone(parsed)
+      stepConfigDraft.value = pinRouteStepConfigRoutingLayers(
+        deepClone(parsed),
+        currentStep.value,
+      )
       stepConfigBaselineSig.value = stableJsonSig(parsed)
       stepConfigTextDraft.value = ''
       stepConfigTextBaseline.value = ''
@@ -473,14 +494,15 @@ export function useStepConfigInfo() {
         stepConfigSaveError.value = 'Nothing to save'
         return false
       }
-      text = JSON.stringify(draftBeforeSave, null, 4)
+      const normalizedDraft = pinRouteStepConfigRoutingLayers(draftBeforeSave, step)
+      text = JSON.stringify(normalizedDraft, null, 4)
       const writeResult = await workspaceLifecycle.runForSession(sessionId, async () => {
         await writeProjectTextFile(resolvedPath, text)
         return true
       })
       if (!canApply() || writeResult !== true) return false
       stepConfigRaw.value = text
-      stepConfigBaselineSig.value = stableJsonSig(draftBeforeSave)
+      stepConfigBaselineSig.value = stableJsonSig(normalizedDraft)
       return await syncWorkspaceConfig()
     } catch (e) {
       if (!canApply()) return false

--- a/ecos/gui/apps/renderer/src/views/ConfigureView.vue
+++ b/ecos/gui/apps/renderer/src/views/ConfigureView.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue'
 import InputText from 'primevue/inputtext'
 import InputNumber from 'primevue/inputnumber'
 import Checkbox from 'primevue/checkbox'
-import Select from 'primevue/select'
 import { useParameters } from '@/composables/useParameters'
 
 const {
@@ -297,23 +296,11 @@ const resetConfig = () => {
             <div class="field-row" style="margin-top: 12px">
               <div class="field">
                 <label>Bottom</label>
-                <Select
-                  v-model="config.bottomLayer"
-                  :options="layerOptions"
-                  optionLabel="label"
-                  optionValue="value"
-                  size="small"
-                />
+                <div class="fixed-layer-value">{{ config.bottomLayer }}</div>
               </div>
               <div class="field">
                 <label>Top</label>
-                <Select
-                  v-model="config.topLayer"
-                  :options="layerOptions"
-                  optionLabel="label"
-                  optionValue="value"
-                  size="small"
-                />
+                <div class="fixed-layer-value">{{ config.topLayer }}</div>
               </div>
             </div>
           </div>
@@ -627,17 +614,28 @@ input[type='range'].orange::-webkit-slider-thumb {
   color: #06b6d4;
 }
 
+.fixed-layer-value {
+  display: flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: 'Fira Code', monospace;
+  font-size: 12px;
+}
+
 :deep(.p-inputtext),
-:deep(.p-inputnumber-input),
-:deep(.p-select) {
+:deep(.p-inputnumber-input) {
   background: var(--bg-primary);
   border-color: var(--border-color);
   font-size: 12px;
 }
 
 .field :deep(.p-inputtext),
-.field :deep(.p-inputnumber),
-.field :deep(.p-select) {
+.field :deep(.p-inputnumber) {
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary

- Pin Configuration routing layer values and saved `parameters.json` fields to `MET2` and `MET5`.
- Replace Configuration Bottom/Top routing layer dropdowns and Route step `-bottom_routing_layer` / `-top_routing_layer` inputs with fixed read-only values.
- Normalize loaded and saved `rt_default_config.json` route step config data so existing stale workspaces write `MET2` / `MET5` on Save.
- Closes #129

## Touched Area

- GUI renderer configuration page
- GUI renderer Route step configuration panel
- Renderer composables and tests for parameters and step config data

## Validation

Run:

- `cd ecos/gui && pnpm --filter @ecos-studio/renderer exec vitest run src/composables/useParameters.test.ts src/composables/useParameters.runtime.test.ts src/composables/useStepConfigInfo.test.ts`
- `cd ecos/gui && pnpm --filter @ecos-studio/renderer run build`
- Pre-commit hook: `cd ecos/gui && oxlint -c .oxlintrc.json apps packages --deny-warnings` and `oxfmt --check` on staged files

Not run:

- Full GUI workspace `pnpm run typecheck`, `pnpm run test`, and `pnpm run build`; this change is scoped to renderer configuration/step-config behavior and targeted renderer tests/build were run instead.
- `make build`, `make demo-gcd`, and `make demo-retrosoc`; no release packaging, ECC integration, or demo-flow files changed.
- Manual GUI smoke/screenshots; visible change is fixed read-only `MET2` / `MET5` routing-layer fields and is covered by renderer tests/build.

## Notes

- No dependency, lockfile, release, packaging, PDK, or submodule gitlink changes are included.
- Existing local `rt_default_config.json` files with stale route layer values are normalized in the UI draft and written as `MET2` / `MET5` when saved.