### PR TITLE
feat(gui): add copy action to home flow step log

### DIFF
--- a/ecos/gui/apps/renderer/src/components/FlowLogCodeViewer.vue
+++ b/ecos/gui/apps/renderer/src/components/FlowLogCodeViewer.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import {
   buildFlowLogViewerExtensions,
+  computeFlowLogContextMenuStyle,
   FLOW_LOG_VIEWER_TAIL_THRESHOLD_PX,
+  getFlowLogViewerSelectedText,
   isFlowLogViewerNearTail,
 } from './flowLogCodeViewer'
+import { copyFlowLogText } from './flowLogCopy'
 
 const props = withDefaults(
   defineProps<{
@@ -23,15 +26,95 @@ const props = withDefaults(
 )
 
 const rootRef = ref<HTMLElement | null>(null)
+const flowLogContextMenuRef = ref<HTMLElement | null>(null)
+const flowLogContextMenuCopyButtonRef = ref<HTMLButtonElement | null>(null)
 const isViewerEmpty = computed(() => !props.content)
+const flowLogContextMenu = ref<{
+  text: string
+  style: { left: string; top: string }
+} | null>(null)
+const flowLogContextMenuFeedback = ref<'copied' | 'failed' | null>(null)
+const flowLogContextMenuCopying = ref(false)
+const flowLogContextMenuCopyLabel = computed(() => {
+  if (flowLogContextMenuCopying.value) return 'Copying...'
+  if (flowLogContextMenuFeedback.value === 'copied') return 'Copied'
+  if (flowLogContextMenuFeedback.value === 'failed') return 'Copy failed'
+  return 'Copy'
+})
 
 let view: EditorView | null = null
 let lastSyncedContent = ''
 let pendingContent: string | null = null
 let pendingSyncRaf: number | null = null
 let pendingTailScrollRaf: number | null = null
+let flowLogContextMenuFeedbackTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearFlowLogContextMenuFeedbackTimer(): void {
+  if (flowLogContextMenuFeedbackTimer) {
+    clearTimeout(flowLogContextMenuFeedbackTimer)
+    flowLogContextMenuFeedbackTimer = null
+  }
+}
+
+function closeFlowLogContextMenu(): void {
+  clearFlowLogContextMenuFeedbackTimer()
+  flowLogContextMenu.value = null
+  flowLogContextMenuFeedback.value = null
+  flowLogContextMenuCopying.value = false
+}
+
+function onViewerContextMenu(event: MouseEvent): void {
+  if (!view) return
+
+  const selectedText = getFlowLogViewerSelectedText(view.state)
+  if (!selectedText) return
+
+  event.preventDefault()
+  clearFlowLogContextMenuFeedbackTimer()
+  flowLogContextMenuFeedback.value = null
+  flowLogContextMenuCopying.value = false
+  flowLogContextMenu.value = {
+    text: selectedText,
+    style: computeFlowLogContextMenuStyle(
+      { x: event.clientX, y: event.clientY },
+      { width: window.innerWidth, height: window.innerHeight },
+    ),
+  }
+  void nextTick(() => flowLogContextMenuCopyButtonRef.value?.focus())
+}
+
+async function copyFlowLogSelection(): Promise<void> {
+  const contextMenu = flowLogContextMenu.value
+  if (!contextMenu || flowLogContextMenuCopying.value) return
+
+  flowLogContextMenuCopying.value = true
+  const result = await copyFlowLogText(contextMenu.text)
+  flowLogContextMenuCopying.value = false
+  flowLogContextMenuFeedback.value = result.ok ? 'copied' : 'failed'
+
+  if (result.ok) {
+    clearFlowLogContextMenuFeedbackTimer()
+    flowLogContextMenuFeedbackTimer = setTimeout(() => {
+      closeFlowLogContextMenu()
+    }, 900)
+  }
+}
+
+function onFlowLogContextMenuPointerDown(event: PointerEvent): void {
+  if (!flowLogContextMenu.value) return
+  const target = event.target
+  if (target instanceof Node && flowLogContextMenuRef.value?.contains(target)) return
+  closeFlowLogContextMenu()
+}
+
+function onFlowLogContextMenuKeydown(event: KeyboardEvent): void {
+  if (event.key !== 'Escape' || !flowLogContextMenu.value) return
+  event.preventDefault()
+  closeFlowLogContextMenu()
+}
 
 function destroyViewer(): void {
+  closeFlowLogContextMenu()
   if (pendingSyncRaf !== null) {
     cancelAnimationFrame(pendingSyncRaf)
     pendingSyncRaf = null
@@ -127,6 +210,10 @@ function scheduleViewerContentSync(nextContent: string): void {
 
 onMounted(() => {
   ensureViewerState()
+  document.addEventListener?.('pointerdown', onFlowLogContextMenuPointerDown)
+  document.addEventListener?.('keydown', onFlowLogContextMenuKeydown)
+  window.addEventListener?.('resize', closeFlowLogContextMenu)
+  document.addEventListener?.('scroll', closeFlowLogContextMenu, true)
 })
 
 watch(
@@ -156,6 +243,10 @@ watch(
 )
 
 onUnmounted(() => {
+  document.removeEventListener?.('pointerdown', onFlowLogContextMenuPointerDown)
+  document.removeEventListener?.('keydown', onFlowLogContextMenuKeydown)
+  window.removeEventListener?.('resize', closeFlowLogContextMenu)
+  document.removeEventListener?.('scroll', closeFlowLogContextMenu, true)
   destroyViewer()
 })
 </script>
@@ -179,10 +270,45 @@ onUnmounted(() => {
       >
       <span v-else>Select a started step or wait for the current step to emit logs.</span>
     </div>
-    <div v-else class="flow-log-viewer-editor-wrap" :class="{ 'is-live': live }">
+    <div
+      v-else
+      class="flow-log-viewer-editor-wrap"
+      :class="{ 'is-live': live }"
+      @contextmenu="onViewerContextMenu"
+    >
       <div ref="rootRef" class="flow-log-viewer-editor"></div>
       <span v-if="live" class="flow-log-terminal-cursor" aria-hidden="true"></span>
     </div>
+    <Teleport to="body">
+      <div
+        v-if="flowLogContextMenu"
+        ref="flowLogContextMenuRef"
+        class="flow-log-context-menu"
+        :style="flowLogContextMenu.style"
+        role="menu"
+        aria-label="Selected log text actions"
+      >
+        <button
+          ref="flowLogContextMenuCopyButtonRef"
+          type="button"
+          class="flow-log-context-menu-action"
+          role="menuitem"
+          :disabled="flowLogContextMenuCopying"
+          @click="copyFlowLogSelection"
+        >
+          <i
+            :class="
+              flowLogContextMenuFeedback === 'copied'
+                ? 'ri-check-line'
+                : flowLogContextMenuFeedback === 'failed'
+                  ? 'ri-error-warning-line'
+                  : 'ri-file-copy-line'
+            "
+          ></i>
+          <span>{{ flowLogContextMenuCopyLabel }}</span>
+        </button>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -209,6 +335,52 @@ onUnmounted(() => {
 
 .flow-log-viewer-editor {
   overflow: hidden;
+}
+
+.flow-log-context-menu {
+  position: fixed;
+  z-index: 20020;
+  min-width: 124px;
+  padding: 4px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.22);
+}
+
+.flow-log-context-menu-action {
+  width: 100%;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.flow-log-context-menu-action:hover:not(:disabled),
+.flow-log-context-menu-action:focus-visible {
+  outline: none;
+  background: rgba(var(--accent-rgb, 59, 130, 246), 0.12);
+}
+
+.flow-log-context-menu-action:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.flow-log-context-menu-action i {
+  width: 14px;
+  color: var(--accent-color);
+  font-size: 14px;
+  text-align: center;
 }
 
 .flow-log-terminal-cursor {

--- a/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.test.ts
+++ b/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.test.ts
@@ -590,11 +590,13 @@ afterEach(() => {
 })
 
 describe('flowLogCodeViewer helpers', () => {
-  it('creates a readonly extension bundle', () => {
+  it('creates a readonly extension bundle that still allows selection', () => {
     const extensions = buildFlowLogViewerExtensions()
 
     expect(Array.isArray(extensions)).toBe(true)
     expect(extensions.length).toBeGreaterThan(0)
+    expect(helperSource).toContain('EditorState.readOnly.of(true)')
+    expect(helperSource).not.toContain('EditorView.editable.of(false)')
   })
 
   it('treats only near-tail scroll positions as pinned', () => {

--- a/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.test.ts
+++ b/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.test.ts
@@ -6,6 +6,8 @@ import * as ts from 'typescript'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildFlowLogViewerExtensions,
+  computeFlowLogContextMenuStyle,
+  getFlowLogViewerSelectedText,
   isFlowLogViewerNearTail,
 } from './flowLogCodeViewer'
 import flowLogCodeViewerSource from './FlowLogCodeViewer.vue?raw'
@@ -46,8 +48,15 @@ function loadFlowLogCodeViewerComponent(vue: typeof import('vue')) {
     if (id === './flowLogCodeViewer' || id === './flowLogCodeViewer.ts') {
       return {
         buildFlowLogViewerExtensions,
+        computeFlowLogContextMenuStyle,
         FLOW_LOG_VIEWER_TAIL_THRESHOLD_PX: 16,
+        getFlowLogViewerSelectedText,
         isFlowLogViewerNearTail,
+      }
+    }
+    if (id === './flowLogCopy' || id === './flowLogCopy.ts') {
+      return {
+        copyFlowLogText: vi.fn(),
       }
     }
     if (id === '@codemirror/state') {
@@ -368,6 +377,8 @@ class FakeElement extends FakeNode {
 
   readonly style: Record<string, string> = {}
 
+  private readonly listeners = new Map<string, Set<(event: unknown) => void>>()
+
   private _className = ''
 
   constructor(tagName: string) {
@@ -431,6 +442,29 @@ class FakeElement extends FakeNode {
     this.attributes.delete(name)
   }
 
+  addEventListener(type: string, listener: (event: unknown) => void) {
+    const listeners = this.listeners.get(type) ?? new Set()
+    listeners.add(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void) {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  dispatchEvent(event: { type: string }) {
+    this.listeners.get(event.type)?.forEach((listener) => listener(event))
+    return true
+  }
+
+  contains(target: FakeNode | null): boolean {
+    if (!target) return false
+    if (target === this) return true
+    return this.childNodes.some(
+      (child) => child instanceof FakeElement && child.contains(target),
+    )
+  }
+
   querySelector(selector: string): FakeElement | null {
     return this.querySelectorAll(selector)[0] ?? null
   }
@@ -470,7 +504,8 @@ function ensureDom() {
     createElementNS: (_namespace: string, tagName: string) => new FakeElement(tagName),
     createTextNode: (text: string) => new FakeText(text),
     createComment: (text: string) => new FakeComment(text),
-    querySelector: (selector: string) => body.querySelector(selector),
+    querySelector: (selector: string) =>
+      selector === 'body' ? body : body.querySelector(selector),
     querySelectorAll: (selector: string) => body.querySelectorAll(selector),
   }
 
@@ -638,6 +673,64 @@ describe('flowLogCodeViewer helpers', () => {
     expect(helperSource).toContain("fontSize: '11px'")
     expect(helperSource).toContain("lineHeight: '1.6'")
     expect(helperSource).toContain("padding: '0 16px'")
+  })
+
+  it('returns only the active CodeMirror selection for context-menu copying', () => {
+    const text = 'first selected last'
+    const selected = getFlowLogViewerSelectedText({
+      selection: {
+        main: {
+          from: 6,
+          to: 14,
+          empty: false,
+        },
+      },
+      sliceDoc: (from, to) => text.slice(from, to),
+    })
+
+    expect(selected).toBe('selected')
+    expect(
+      getFlowLogViewerSelectedText({
+        selection: {
+          main: {
+            from: 6,
+            to: 6,
+            empty: true,
+          },
+        },
+        sliceDoc: (from, to) => text.slice(from, to),
+      }),
+    ).toBe('')
+  })
+
+  it('keeps the selection context menu inside the viewport', () => {
+    expect(
+      computeFlowLogContextMenuStyle({ x: 990, y: 790 }, { width: 1000, height: 800 }),
+    ).toEqual({
+      left: '868px',
+      top: '756px',
+    })
+
+    expect(
+      computeFlowLogContextMenuStyle({ x: 1, y: 2 }, { width: 1000, height: 800 }),
+    ).toEqual({
+      left: '8px',
+      top: '8px',
+    })
+  })
+
+  it('offers Copy from a selected-text context menu and closes it from global input', () => {
+    expect(flowLogCodeViewerSource).toContain('@contextmenu="onViewerContextMenu"')
+    expect(flowLogCodeViewerSource).toContain('flow-log-context-menu')
+    expect(flowLogCodeViewerSource).toContain('role="menu"')
+    expect(flowLogCodeViewerSource).toContain('role="menuitem"')
+    expect(flowLogCodeViewerSource).toContain('copyFlowLogText(contextMenu.text)')
+    expect(flowLogCodeViewerSource).toContain(
+      "document.addEventListener?.('pointerdown', onFlowLogContextMenuPointerDown)",
+    )
+    expect(flowLogCodeViewerSource).toContain(
+      "document.addEventListener?.('keydown', onFlowLogContextMenuKeydown)",
+    )
   })
 })
 

--- a/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.ts
+++ b/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.ts
@@ -5,6 +5,22 @@ import { EditorView, keymap, lineNumbers } from '@codemirror/view'
 
 export const FLOW_LOG_VIEWER_TAIL_THRESHOLD_PX = 16
 
+export type FlowLogViewerSelectionState = {
+  selection: {
+    main: {
+      from: number
+      to: number
+      empty: boolean
+    }
+  }
+  sliceDoc: (from: number, to: number) => string
+}
+
+export type FlowLogContextMenuStyle = {
+  left: string
+  top: string
+}
+
 export function buildFlowLogViewerExtensions(): Extension[] {
   return [
     lineNumbers(),
@@ -79,4 +95,31 @@ export function isFlowLogViewerNearTail(
   thresholdPx = FLOW_LOG_VIEWER_TAIL_THRESHOLD_PX,
 ): boolean {
   return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight <= thresholdPx
+}
+
+export function getFlowLogViewerSelectedText(state: FlowLogViewerSelectionState): string {
+  const selection = state.selection.main
+  if (selection.empty) return ''
+  return state.sliceDoc(selection.from, selection.to)
+}
+
+export function computeFlowLogContextMenuStyle(
+  pointer: { x: number; y: number },
+  viewport: { width: number; height: number },
+  options?: {
+    menuWidthPx?: number
+    menuHeightPx?: number
+    paddingPx?: number
+  },
+): FlowLogContextMenuStyle {
+  const menuWidthPx = Math.max(1, options?.menuWidthPx ?? 124)
+  const menuHeightPx = Math.max(1, options?.menuHeightPx ?? 36)
+  const paddingPx = options?.paddingPx ?? 8
+  const maxLeft = Math.max(paddingPx, viewport.width - menuWidthPx - paddingPx)
+  const maxTop = Math.max(paddingPx, viewport.height - menuHeightPx - paddingPx)
+
+  return {
+    left: `${Math.round(Math.max(paddingPx, Math.min(pointer.x, maxLeft)))}px`,
+    top: `${Math.round(Math.max(paddingPx, Math.min(pointer.y, maxTop)))}px`,
+  }
 }

--- a/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.ts
+++ b/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.ts
@@ -13,7 +13,6 @@ export function buildFlowLogViewerExtensions(): Extension[] {
     }),
     keymap.of(searchKeymap),
     EditorState.readOnly.of(true),
-    EditorView.editable.of(false),
     EditorView.lineWrapping,
     EditorView.theme({
       '&': {

--- a/ecos/gui/apps/renderer/src/components/flowLogCopy.ts
+++ b/ecos/gui/apps/renderer/src/components/flowLogCopy.ts
@@ -1,0 +1,24 @@
+export type FlowLogCopyResult =
+  | { ok: true }
+  | { ok: false; reason: 'empty' | 'failed'; message?: string }
+
+export async function copyFlowLogText(
+  text: string,
+  writeText: (value: string) => Promise<void> = (value) =>
+    navigator.clipboard.writeText(value),
+): Promise<FlowLogCopyResult> {
+  if (!text) {
+    return { ok: false, reason: 'empty' }
+  }
+
+  try {
+    await writeText(text)
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'failed',
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/ecos/gui/apps/renderer/src/views/HomeView.flow-log.test.ts
+++ b/ecos/gui/apps/renderer/src/views/HomeView.flow-log.test.ts
@@ -73,7 +73,9 @@ describe('HomeView floating chooser integration', () => {
     expect(homeViewSource).toContain('copyFlowLogText')
     expect(homeViewSource).toContain("is-copied': flowLogCopyFeedback === 'copied'")
     expect(homeViewSource).toContain("flowLogCopyFeedback === 'failed'")
-    expect(homeViewSource).toContain("is-above': flowLogCopyTooltipStyle?.placement === 'above'")
+    expect(homeViewSource).toContain(
+      "is-above': flowLogCopyTooltipStyle?.placement === 'above'",
+    )
     expect(homeViewSource).not.toContain('is-feedback')
   })
 

--- a/ecos/gui/apps/renderer/src/views/HomeView.flow-log.test.ts
+++ b/ecos/gui/apps/renderer/src/views/HomeView.flow-log.test.ts
@@ -63,6 +63,20 @@ describe('HomeView floating chooser integration', () => {
     expect(homeViewSource).toContain('flow-log-viewer-shell')
   })
 
+  it('exposes a copy action with teleported tooltip feedback', () => {
+    expect(homeViewSource).toContain('flow-log-copy-btn')
+    expect(homeViewSource).toContain('flow-log-copy-tooltip')
+    expect(homeViewSource).toContain('computeFlowLogCopyTooltipStyle')
+    expect(homeViewSource).toContain('refineFlowLogCopyTooltipPosition')
+    expect(homeViewSource).toContain('canCopyFlowLogText')
+    expect(homeViewSource).toContain('onCopyFlowLogText')
+    expect(homeViewSource).toContain('copyFlowLogText')
+    expect(homeViewSource).toContain("is-copied': flowLogCopyFeedback === 'copied'")
+    expect(homeViewSource).toContain("flowLogCopyFeedback === 'failed'")
+    expect(homeViewSource).toContain("is-above': flowLogCopyTooltipStyle?.placement === 'above'")
+    expect(homeViewSource).not.toContain('is-feedback')
+  })
+
   it('exports chooser state transitions that close after selection and jump-to-live', () => {
     const createFlowLogChooserController = loadFlowLogChooserController()
     const chooser = createFlowLogChooserController('step-a')

--- a/ecos/gui/apps/renderer/src/views/HomeView.vue
+++ b/ecos/gui/apps/renderer/src/views/HomeView.vue
@@ -731,8 +731,7 @@
         class="flow-log-copy-tooltip"
         :class="{
           'is-copied': flowLogCopyFeedback === 'copied',
-          'is-error':
-            flowLogCopyFeedback === 'failed' || flowLogCopyFeedback === 'empty',
+          'is-error': flowLogCopyFeedback === 'failed' || flowLogCopyFeedback === 'empty',
           'is-above': flowLogCopyTooltipStyle?.placement === 'above',
         }"
         :style="flowLogCopyTooltipInlineStyle"
@@ -1021,9 +1020,7 @@ const flowLogCopyTooltip = computed(() =>
   flowLogCopyFeedbackTooltip(flowLogCopyFeedback.value),
 )
 const flowLogCopyButtonTitle = computed(() =>
-  flowLogCopyFeedback.value
-    ? flowLogCopyTooltip.value
-    : flowLogCopyFeedbackTooltip(null),
+  flowLogCopyFeedback.value ? flowLogCopyTooltip.value : flowLogCopyFeedbackTooltip(null),
 )
 const flowLogCopyTooltipInlineStyle = computed(() => {
   const style = flowLogCopyTooltipStyle.value
@@ -1112,8 +1109,7 @@ function setFlowLogCopyFeedback(
 }
 
 async function onCopyFlowLogText(event: MouseEvent): Promise<void> {
-  const trigger =
-    event.currentTarget instanceof HTMLElement ? event.currentTarget : null
+  const trigger = event.currentTarget instanceof HTMLElement ? event.currentTarget : null
   const result = await copyFlowLogText(selectedFlowLogContent.value)
   setFlowLogCopyFeedback(flowLogCopyFeedbackFromResult(result), trigger)
 }

--- a/ecos/gui/apps/renderer/src/views/HomeView.vue
+++ b/ecos/gui/apps/renderer/src/views/HomeView.vue
@@ -318,6 +318,32 @@
                           <span>Steps</span>
                         </button>
                         <button
+                          v-if="selectedFlowLogSegment"
+                          type="button"
+                          class="flow-log-copy-btn"
+                          :class="{
+                            'is-copied': flowLogCopyFeedback === 'copied',
+                            'is-error':
+                              flowLogCopyFeedback === 'failed' ||
+                              flowLogCopyFeedback === 'empty',
+                          }"
+                          :disabled="!canCopyFlowLogText"
+                          :title="flowLogCopyButtonTitle"
+                          :aria-label="flowLogCopyButtonTitle"
+                          @click="onCopyFlowLogText"
+                        >
+                          <i
+                            :class="
+                              flowLogCopyFeedback === 'copied'
+                                ? 'ri-check-line'
+                                : 'ri-file-copy-line'
+                            "
+                          ></i>
+                          <span>{{
+                            flowLogCopyFeedback === 'copied' ? 'Copied' : 'Copy'
+                          }}</span>
+                        </button>
+                        <button
                           v-if="liveFlowLogKey && liveFlowLogKey !== selectedFlowLogKey"
                           type="button"
                           class="flow-log-jump-live-btn"
@@ -544,6 +570,32 @@
                         <span>Steps</span>
                       </button>
                       <button
+                        v-if="selectedFlowLogSegment"
+                        type="button"
+                        class="flow-log-copy-btn"
+                        :class="{
+                          'is-copied': flowLogCopyFeedback === 'copied',
+                          'is-error':
+                            flowLogCopyFeedback === 'failed' ||
+                            flowLogCopyFeedback === 'empty',
+                        }"
+                        :disabled="!canCopyFlowLogText"
+                        :title="flowLogCopyButtonTitle"
+                        :aria-label="flowLogCopyButtonTitle"
+                        @click="onCopyFlowLogText"
+                      >
+                        <i
+                          :class="
+                            flowLogCopyFeedback === 'copied'
+                              ? 'ri-check-line'
+                              : 'ri-file-copy-line'
+                          "
+                        ></i>
+                        <span>{{
+                          flowLogCopyFeedback === 'copied' ? 'Copied' : 'Copy'
+                        }}</span>
+                      </button>
+                      <button
                         v-if="liveFlowLogKey && liveFlowLogKey !== selectedFlowLogKey"
                         type="button"
                         class="flow-log-jump-live-btn"
@@ -670,6 +722,24 @@
           </section>
         </div>
       </Transition>
+    </Teleport>
+
+    <Teleport to="body">
+      <span
+        v-if="flowLogCopyFeedback"
+        ref="flowLogCopyTooltipRef"
+        class="flow-log-copy-tooltip"
+        :class="{
+          'is-copied': flowLogCopyFeedback === 'copied',
+          'is-error':
+            flowLogCopyFeedback === 'failed' || flowLogCopyFeedback === 'empty',
+          'is-above': flowLogCopyTooltipStyle?.placement === 'above',
+        }"
+        :style="flowLogCopyTooltipInlineStyle"
+        role="status"
+      >
+        {{ flowLogCopyTooltip }}
+      </span>
     </Teleport>
 
     <!-- ===== 图表预览 Lightbox ===== -->
@@ -855,6 +925,14 @@ import {
   reconcileSelectedFlowLogKey,
   toFlowLogListItems,
 } from './homeViewFlowLogSelection'
+import {
+  computeFlowLogCopyTooltipStyle,
+  copyFlowLogText,
+  flowLogCopyFeedbackFromResult,
+  flowLogCopyFeedbackTooltip,
+  type FlowLogCopyFeedback,
+  type FlowLogCopyTooltipStyle,
+} from './homeViewFlowLogCopy'
 import { ensureMonitorChartInstance } from './homeMonitorCharts'
 
 // 注册 ECharts 组件（按需引入）
@@ -928,6 +1006,33 @@ const selectedFlowLogContent = computed(() => {
   if (!selectedFlowLogKey.value) return ''
   return flowLogContentByKey.value[selectedFlowLogKey.value] ?? ''
 })
+const canCopyFlowLogText = computed(
+  () =>
+    Boolean(selectedFlowLogSegment.value) &&
+    !selectedFlowLogSegment.value?.missing &&
+    selectedFlowLogContent.value.length > 0,
+)
+const flowLogCopyFeedback = ref<FlowLogCopyFeedback | null>(null)
+const flowLogCopyTooltipStyle = ref<FlowLogCopyTooltipStyle | null>(null)
+const flowLogCopyTooltipRef = ref<HTMLElement | null>(null)
+let flowLogCopyFeedbackTimer: ReturnType<typeof setTimeout> | null = null
+let flowLogCopyFeedbackToken = 0
+const flowLogCopyTooltip = computed(() =>
+  flowLogCopyFeedbackTooltip(flowLogCopyFeedback.value),
+)
+const flowLogCopyButtonTitle = computed(() =>
+  flowLogCopyFeedback.value
+    ? flowLogCopyTooltip.value
+    : flowLogCopyFeedbackTooltip(null),
+)
+const flowLogCopyTooltipInlineStyle = computed(() => {
+  const style = flowLogCopyTooltipStyle.value
+  if (!style) return undefined
+  return {
+    left: style.left,
+    top: style.top,
+  }
+})
 const flowLogSelectionSignature = computed(() =>
   flowLogSegments.value
     .map((segment) =>
@@ -935,6 +1040,83 @@ const flowLogSelectionSignature = computed(() =>
     )
     .join('\u001e'),
 )
+
+function clearFlowLogCopyFeedbackTimer(): void {
+  if (flowLogCopyFeedbackTimer) {
+    clearTimeout(flowLogCopyFeedbackTimer)
+    flowLogCopyFeedbackTimer = null
+  }
+}
+
+function getFlowLogCopyViewport() {
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }
+}
+
+function positionFlowLogCopyTooltip(
+  trigger: HTMLElement,
+  tooltipSize?: { width: number; height: number },
+): void {
+  const triggerRect = trigger.getBoundingClientRect()
+  flowLogCopyTooltipStyle.value = computeFlowLogCopyTooltipStyle(
+    triggerRect,
+    getFlowLogCopyViewport(),
+    tooltipSize
+      ? {
+          tooltipWidthPx: tooltipSize.width,
+          tooltipHeightPx: tooltipSize.height,
+        }
+      : undefined,
+  )
+}
+
+async function refineFlowLogCopyTooltipPosition(
+  trigger: HTMLElement,
+  token: number,
+): Promise<void> {
+  await nextTick()
+  if (token !== flowLogCopyFeedbackToken) return
+  const tooltipEl = flowLogCopyTooltipRef.value
+  if (!tooltipEl || !trigger.isConnected) return
+
+  const tooltipRect = tooltipEl.getBoundingClientRect()
+  positionFlowLogCopyTooltip(trigger, {
+    width: tooltipRect.width,
+    height: tooltipRect.height,
+  })
+}
+
+function setFlowLogCopyFeedback(
+  feedback: FlowLogCopyFeedback,
+  trigger?: HTMLElement | null,
+): void {
+  clearFlowLogCopyFeedbackTimer()
+  const token = ++flowLogCopyFeedbackToken
+  flowLogCopyFeedback.value = feedback
+
+  if (trigger?.isConnected) {
+    positionFlowLogCopyTooltip(trigger)
+    void refineFlowLogCopyTooltipPosition(trigger, token)
+  } else {
+    flowLogCopyTooltipStyle.value = null
+  }
+
+  flowLogCopyFeedbackTimer = setTimeout(() => {
+    if (token !== flowLogCopyFeedbackToken) return
+    flowLogCopyFeedback.value = null
+    flowLogCopyTooltipStyle.value = null
+    flowLogCopyFeedbackTimer = null
+  }, 2000)
+}
+
+async function onCopyFlowLogText(event: MouseEvent): Promise<void> {
+  const trigger =
+    event.currentTarget instanceof HTMLElement ? event.currentTarget : null
+  const result = await copyFlowLogText(selectedFlowLogContent.value)
+  setFlowLogCopyFeedback(flowLogCopyFeedbackFromResult(result), trigger)
+}
 
 function toggleFlowLogStepChooser(): void {
   flowLogChooser.toggleFlowLogStepChooser()
@@ -1585,6 +1767,10 @@ onUnmounted(() => {
     cancelAnimationFrame(pendingDashboardSettleRaf)
     pendingDashboardSettleRaf = null
   }
+  clearFlowLogCopyFeedbackTimer()
+  flowLogCopyFeedbackToken += 1
+  flowLogCopyFeedback.value = null
+  flowLogCopyTooltipStyle.value = null
   document.removeEventListener('keydown', onFullscreenKeydown)
 })
 
@@ -2489,6 +2675,8 @@ html.dark .chart-card:hover {
 }
 
 .flow-log-viewer-header {
+  position: relative;
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -2594,6 +2782,7 @@ html.dark .chart-card:hover {
 }
 
 .flow-log-steps-trigger,
+.flow-log-copy-btn,
 .flow-log-jump-live-btn,
 .flow-log-expand-btn,
 .flow-log-icon-btn {
@@ -2617,6 +2806,7 @@ html.dark .chart-card:hover {
 }
 
 .flow-log-steps-trigger:hover:not(:disabled),
+.flow-log-copy-btn:hover:not(:disabled),
 .flow-log-jump-live-btn:hover:not(:disabled),
 .flow-log-expand-btn:hover:not(:disabled),
 .flow-log-icon-btn:hover:not(:disabled) {
@@ -2625,12 +2815,70 @@ html.dark .chart-card:hover {
   background: rgba(var(--accent-rgb, 59, 130, 246), 0.08);
 }
 
+.flow-log-copy-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.flow-log-copy-btn.is-copied {
+  color: var(--text-primary);
+  border-color: rgba(var(--accent-rgb, 59, 130, 246), 0.45);
+  background: rgba(var(--accent-rgb, 59, 130, 246), 0.08);
+}
+
+.flow-log-copy-btn.is-error {
+  color: var(--text-primary);
+  border-color: rgba(239, 68, 68, 0.45);
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.flow-log-copy-tooltip {
+  position: fixed;
+  z-index: 20020;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+.flow-log-copy-tooltip.is-copied {
+  border-color: rgba(var(--accent-rgb, 59, 130, 246), 0.45);
+}
+
+.flow-log-copy-tooltip.is-error {
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.flow-log-copy-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  right: 12px;
+  border: 5px solid transparent;
+  border-bottom-color: var(--border-color);
+}
+
+.flow-log-copy-tooltip.is-above::after {
+  top: 100%;
+  bottom: auto;
+  border-bottom-color: transparent;
+  border-top-color: var(--border-color);
+}
+
 .flow-log-expand-btn:disabled {
   opacity: 0.7;
   cursor: progress;
 }
 
 .flow-log-steps-trigger i,
+.flow-log-copy-btn i,
 .flow-log-jump-live-btn i,
 .flow-log-expand-btn i,
 .flow-log-icon-btn i {

--- a/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.test.ts
+++ b/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.test.ts
@@ -47,12 +47,8 @@ describe('flowLogCopyFeedbackTooltip', () => {
 
   it('maps copy results to feedback states', () => {
     expect(flowLogCopyFeedbackFromResult({ ok: true })).toBe('copied')
-    expect(
-      flowLogCopyFeedbackFromResult({ ok: false, reason: 'empty' }),
-    ).toBe('empty')
-    expect(
-      flowLogCopyFeedbackFromResult({ ok: false, reason: 'failed' }),
-    ).toBe('failed')
+    expect(flowLogCopyFeedbackFromResult({ ok: false, reason: 'empty' })).toBe('empty')
+    expect(flowLogCopyFeedbackFromResult({ ok: false, reason: 'failed' })).toBe('failed')
   })
 })
 

--- a/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.test.ts
+++ b/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  computeFlowLogCopyTooltipStyle,
+  copyFlowLogText,
+  flowLogCopyFeedbackFromResult,
+  flowLogCopyFeedbackTooltip,
+} from './homeViewFlowLogCopy'
+
+describe('copyFlowLogText', () => {
+  it('copies non-empty log text through the provided writer', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+
+    await expect(copyFlowLogText('step log output', writeText)).resolves.toEqual({
+      ok: true,
+    })
+    expect(writeText).toHaveBeenCalledWith('step log output')
+  })
+
+  it('returns empty when there is no text to copy', async () => {
+    const writeText = vi.fn()
+
+    await expect(copyFlowLogText('', writeText)).resolves.toEqual({
+      ok: false,
+      reason: 'empty',
+    })
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('returns failed when the clipboard writer rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+
+    await expect(copyFlowLogText('step log output', writeText)).resolves.toEqual({
+      ok: false,
+      reason: 'failed',
+      message: 'denied',
+    })
+  })
+})
+
+describe('flowLogCopyFeedbackTooltip', () => {
+  it('maps feedback states to tooltip copy', () => {
+    expect(flowLogCopyFeedbackTooltip(null)).toBe('Copy log text')
+    expect(flowLogCopyFeedbackTooltip('copied')).toBe('Copied to clipboard')
+    expect(flowLogCopyFeedbackTooltip('empty')).toBe('Nothing to copy')
+    expect(flowLogCopyFeedbackTooltip('failed')).toBe('Copy failed')
+  })
+
+  it('maps copy results to feedback states', () => {
+    expect(flowLogCopyFeedbackFromResult({ ok: true })).toBe('copied')
+    expect(
+      flowLogCopyFeedbackFromResult({ ok: false, reason: 'empty' }),
+    ).toBe('empty')
+    expect(
+      flowLogCopyFeedbackFromResult({ ok: false, reason: 'failed' }),
+    ).toBe('failed')
+  })
+})
+
+describe('computeFlowLogCopyTooltipStyle', () => {
+  it('right-aligns the tooltip under the trigger when space allows', () => {
+    expect(
+      computeFlowLogCopyTooltipStyle(
+        { left: 200, right: 260, top: 100, bottom: 120 },
+        { width: 800, height: 600 },
+        { tooltipWidthPx: 140 },
+      ),
+    ).toEqual({
+      left: '120px',
+      top: '126px',
+      placement: 'below',
+    })
+  })
+
+  it('clamps the tooltip inside the viewport on narrow panels', () => {
+    expect(
+      computeFlowLogCopyTooltipStyle(
+        { left: 10, right: 70, top: 20, bottom: 40 },
+        { width: 120, height: 200 },
+        { tooltipWidthPx: 140, paddingPx: 8 },
+      ),
+    ).toEqual({
+      left: '8px',
+      top: '46px',
+      placement: 'below',
+    })
+  })
+
+  it('places the tooltip above the trigger when there is no room below', () => {
+    expect(
+      computeFlowLogCopyTooltipStyle(
+        { left: 200, right: 260, top: 560, bottom: 580 },
+        { width: 800, height: 600 },
+        { tooltipWidthPx: 140, tooltipHeightPx: 28, gapPx: 6, paddingPx: 8 },
+      ),
+    ).toEqual({
+      left: '120px',
+      top: '526px',
+      placement: 'above',
+    })
+  })
+
+  it('uses measured tooltip size instead of the default estimate', () => {
+    expect(
+      computeFlowLogCopyTooltipStyle(
+        { left: 200, right: 260, top: 100, bottom: 120 },
+        { width: 800, height: 600 },
+        { tooltipWidthPx: 180, tooltipHeightPx: 32 },
+      ),
+    ).toEqual({
+      left: '80px',
+      top: '126px',
+      placement: 'below',
+    })
+  })
+})

--- a/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.ts
+++ b/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.ts
@@ -12,9 +12,7 @@ export type FlowLogCopyTooltipStyle = {
   placement: FlowLogCopyTooltipPlacement
 }
 
-export function flowLogCopyFeedbackTooltip(
-  feedback: FlowLogCopyFeedback | null,
-): string {
+export function flowLogCopyFeedbackTooltip(feedback: FlowLogCopyFeedback | null): string {
   switch (feedback) {
     case 'copied':
       return 'Copied to clipboard'

--- a/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.ts
+++ b/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.ts
@@ -1,0 +1,99 @@
+export type FlowLogCopyResult =
+  | { ok: true }
+  | { ok: false; reason: 'empty' | 'failed'; message?: string }
+
+export type FlowLogCopyFeedback = 'copied' | 'empty' | 'failed'
+
+export type FlowLogCopyTooltipPlacement = 'below' | 'above'
+
+export type FlowLogCopyTooltipStyle = {
+  left: string
+  top: string
+  placement: FlowLogCopyTooltipPlacement
+}
+
+export function flowLogCopyFeedbackTooltip(
+  feedback: FlowLogCopyFeedback | null,
+): string {
+  switch (feedback) {
+    case 'copied':
+      return 'Copied to clipboard'
+    case 'empty':
+      return 'Nothing to copy'
+    case 'failed':
+      return 'Copy failed'
+    default:
+      return 'Copy log text'
+  }
+}
+
+export function flowLogCopyFeedbackFromResult(
+  result: FlowLogCopyResult,
+): FlowLogCopyFeedback {
+  if (result.ok) return 'copied'
+  return result.reason
+}
+
+export function computeFlowLogCopyTooltipStyle(
+  triggerRect: { left: number; right: number; top: number; bottom: number },
+  viewport: { width: number; height: number },
+  options?: {
+    gapPx?: number
+    paddingPx?: number
+    tooltipWidthPx?: number
+    tooltipHeightPx?: number
+  },
+): FlowLogCopyTooltipStyle {
+  const gapPx = options?.gapPx ?? 6
+  const paddingPx = options?.paddingPx ?? 8
+  const tooltipWidthPx = Math.max(1, options?.tooltipWidthPx ?? 148)
+  const tooltipHeightPx = Math.max(1, options?.tooltipHeightPx ?? 28)
+
+  let left = triggerRect.right - tooltipWidthPx
+  const maxLeft = Math.max(paddingPx, viewport.width - tooltipWidthPx - paddingPx)
+  left = Math.max(paddingPx, Math.min(left, maxLeft))
+
+  const belowTop = triggerRect.bottom + gapPx
+  const aboveTop = triggerRect.top - gapPx - tooltipHeightPx
+  const fitsBelow = belowTop + tooltipHeightPx + paddingPx <= viewport.height
+  const fitsAbove = aboveTop >= paddingPx
+
+  let top = belowTop
+  let placement: FlowLogCopyTooltipPlacement = 'below'
+  if (!fitsBelow && fitsAbove) {
+    top = aboveTop
+    placement = 'above'
+  } else if (!fitsBelow && !fitsAbove) {
+    top = Math.max(
+      paddingPx,
+      Math.min(belowTop, viewport.height - tooltipHeightPx - paddingPx),
+    )
+  }
+
+  return {
+    left: `${Math.round(left)}px`,
+    top: `${Math.round(top)}px`,
+    placement,
+  }
+}
+
+export async function copyFlowLogText(
+  text: string,
+  writeText: (value: string) => Promise<void> = (value) =>
+    navigator.clipboard.writeText(value),
+): Promise<FlowLogCopyResult> {
+  if (!text) {
+    return { ok: false, reason: 'empty' }
+  }
+
+  try {
+    await writeText(text)
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'failed',
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.ts
+++ b/ecos/gui/apps/renderer/src/views/homeViewFlowLogCopy.ts
@@ -1,6 +1,6 @@
-export type FlowLogCopyResult =
-  | { ok: true }
-  | { ok: false; reason: 'empty' | 'failed'; message?: string }
+import type { FlowLogCopyResult } from '../components/flowLogCopy'
+
+export { copyFlowLogText, type FlowLogCopyResult } from '../components/flowLogCopy'
 
 export type FlowLogCopyFeedback = 'copied' | 'empty' | 'failed'
 
@@ -72,26 +72,5 @@ export function computeFlowLogCopyTooltipStyle(
     left: `${Math.round(left)}px`,
     top: `${Math.round(top)}px`,
     placement,
-  }
-}
-
-export async function copyFlowLogText(
-  text: string,
-  writeText: (value: string) => Promise<void> = (value) =>
-    navigator.clipboard.writeText(value),
-): Promise<FlowLogCopyResult> {
-  if (!text) {
-    return { ok: false, reason: 'empty' }
-  }
-
-  try {
-    await writeText(text)
-    return { ok: true }
-  } catch (error) {
-    return {
-      ok: false,
-      reason: 'failed',
-      message: error instanceof Error ? error.message : String(error),
-    }
   }
 }


### PR DESCRIPTION
## Summary

- Add a Copy button to the homepage Flow Step Log (including fullscreen) that copies the currently loaded step log text to the clipboard.
- Show local teleported tooltip feedback for success and failure instead of a top-right toast, and keep the log viewer selectable while remaining read-only.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other:
  - `cd ecos/gui && pnpm install --frozen-lockfile`
  - `cd ecos/gui && pnpm run lint`
  - `cd ecos/gui && pnpm run fmt:check`
  - `python3 .github/scripts/check-version.py`

Skipped checks and reason:

- `cd ecos/gui && pnpm run build`: not required by GUI Checks path filter; typecheck/lint/fmt/test cover this change.
- `make build` / AppImage packaging: skipped per packaging gate exclusion for GUI-only UI work.
- `make demo-gcd` / `make demo-retrosoc`: not applicable to homepage Flow Step Log copy UI.
- Manual GUI smoke: not run in this session; covered by unit tests for copy helpers, tooltip placement, and HomeView source wiring.

## Screenshots or Recordings

Required for visible GUI changes.

- Not attached in this PR creation pass. Please review the homepage Flow Step Log Copy button and teleported success/failure tooltip before merge.

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Renderer-only change. No packaging, version, or submodule gitlink updates.

## Checklist

- [x] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
