### PR TITLE
feat(gui): add map heatmap navigation to chip viewer

### DIFF
--- a/ecos/chip-viewer/Cargo.lock
+++ b/ecos/chip-viewer/Cargo.lock
@@ -702,8 +702,10 @@ dependencies = [
  "chip-view-db",
  "chipgeom-format",
  "clap",
+ "csv",
  "eframe",
  "egui",
+ "image",
  "serde",
  "serde_json",
 ]
@@ -913,6 +915,27 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2775,6 +2798,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"

--- a/ecos/chip-viewer/Cargo.toml
+++ b/ecos/chip-viewer/Cargo.toml
@@ -19,8 +19,10 @@ version = "0.1.0"
 anyhow = "1.0"
 bytemuck = { version = "1.19", features = ["derive"] }
 clap = { version = "4.5", features = ["derive"] }
+csv = "1.3"
 eframe = "0.31"
 egui = "0.31"
+image = { version = "0.25", default-features = false, features = ["png"] }
 memmap2 = "0.9"
 rstar = "0.13"
 serde = { version = "1.0", features = ["derive"] }

--- a/ecos/chip-viewer/apps/chip-viewer-native/Cargo.toml
+++ b/ecos/chip-viewer/apps/chip-viewer-native/Cargo.toml
@@ -11,7 +11,9 @@ chip-render = { path = "../../crates/chip-render" }
 chip-view-db = { path = "../../crates/chip-view-db" }
 chipgeom-format = { path = "../../crates/chipgeom-format" }
 clap.workspace = true
+csv.workspace = true
 eframe.workspace = true
 egui.workspace = true
+image.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/ecos/chip-viewer/apps/chip-viewer-native/src/app.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/app.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{self, Receiver};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -18,6 +18,8 @@ use chipgeom_format::{
 use eframe::egui;
 use serde::{Deserialize, Serialize};
 
+use crate::map_data::{HeatmapData, MapCatalog, MapItem};
+
 const SNAPSHOT_REFRESH_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 const FOCUS_VIEWPORT_FILL: f32 = 0.45;
 const MIN_SHAPE_SCREEN_SIZE: f32 = 2.0;
@@ -32,6 +34,17 @@ const HOVER_NEAREST_RADIUS_PX: f32 = 8.0;
 const MAX_PARAMETERIZED_GRID_LINES_PER_GRID: usize = 4096;
 const MAX_JAVASCRIPT_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const SIDEBAR_SECTION_RESERVE_HEIGHT: f32 = 34.0;
+const MAP_HEATMAP_WIDTH_FRACTION: f32 = 0.46;
+const MAP_HEATMAP_MAX_WIDTH: f32 = 380.0;
+const MAP_HEATMAP_MIN_WIDTH: f32 = 270.0;
+const MAP_HEATMAP_MAX_GRID_SIZE: f32 = 300.0;
+const MAP_HEATMAP_VERTICAL_OVERHEAD: f32 = 142.0;
+const MAP_FOCUS_ANIMATION_DURATION_SECONDS: f64 = 0.22;
+const MAP_THUMBNAIL_WIDTH: u32 = 128;
+const MAP_THUMBNAIL_HEIGHT: u32 = 96;
+const MAP_THUMBNAIL_MAX_DIMENSION: u32 = 8192;
+const MAP_THUMBNAIL_MAX_DECODE_BYTES: u64 = 128 * 1024 * 1024;
+const REDUCED_MOTION_ENV: &str = "ECOS_REDUCED_MOTION";
 
 pub struct ChipViewerApp {
     state: ViewerState,
@@ -49,6 +62,7 @@ struct LoadingViewer {
     edit_result_dir: Option<PathBuf>,
     drc_data_path: Option<PathBuf>,
     drc_statis_path: Option<PathBuf>,
+    map_root_path: Option<PathBuf>,
 }
 
 struct LoadedViewer {
@@ -82,6 +96,17 @@ struct LoadedViewer {
     next_command_counter: u32,
     drc_overlay: Option<DrcOverlay>,
     selected_drc: Option<usize>,
+    map_catalog: Option<MapCatalog>,
+    map_catalog_error: Option<String>,
+    analysis_tab: AnalysisTab,
+    expanded_map_categories: BTreeSet<String>,
+    selected_map_item: Option<PathBuf>,
+    active_heatmap: Option<ActiveHeatmap>,
+    map_item_error: Option<String>,
+    map_thumbnails: BTreeMap<PathBuf, MapThumbnailState>,
+    map_thumbnail_worker: Option<MapThumbnailWorker>,
+    selected_map_bbox: Option<Rect32>,
+    focus_animation: Option<FocusAnimation>,
     zoom: f32,
     pan: egui::Vec2,
     pan_drag: PanDragState,
@@ -126,6 +151,39 @@ struct DrcOverlay {
     type_states: Vec<DrcTypeState>,
     violations: Vec<DrcViolation>,
     load_error: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AnalysisTab {
+    Drc,
+    Map,
+}
+
+struct ActiveHeatmap {
+    title: String,
+    data: HeatmapData,
+    selected_cell: Option<(usize, usize)>,
+}
+
+enum MapThumbnailState {
+    Loading,
+    Ready(egui::TextureHandle),
+    Failed,
+}
+
+struct MapThumbnailWorker {
+    request_sender: Sender<PathBuf>,
+    result_receiver: Receiver<MapThumbnailResult>,
+}
+
+struct MapThumbnailResult {
+    path: PathBuf,
+    decoded: Result<DecodedMapThumbnail, String>,
+}
+
+struct DecodedMapThumbnail {
+    size: [usize; 2],
+    rgba: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -286,6 +344,29 @@ struct PendingSessionAction {
 struct PendingFocus {
     bbox: Rect32,
     select_shape_id: Option<ShapeId>,
+    transition: FocusTransition,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FocusTransition {
+    Immediate,
+    Animated,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct FocusAnimation {
+    started_at: f64,
+    from_zoom: f32,
+    from_pan: egui::Vec2,
+    to_zoom: f32,
+    to_pan: egui::Vec2,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct FocusAnimationFrame {
+    zoom: f32,
+    pan: egui::Vec2,
+    complete: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -680,6 +761,7 @@ impl ChipViewerApp {
         initial_session_dirty: bool,
         drc_data_path: Option<PathBuf>,
         drc_statis_path: Option<PathBuf>,
+        map_root_path: Option<PathBuf>,
     ) -> Self {
         let edit_enabled = mode == "edit";
         let (sender, receiver) = mpsc::channel();
@@ -699,6 +781,7 @@ impl ChipViewerApp {
                 edit_result_dir,
                 drc_data_path,
                 drc_statis_path,
+                map_root_path,
             }),
             theme_initialized: false,
             startup_focus_requested: false,
@@ -769,6 +852,7 @@ impl ChipViewerApp {
                     loading.edit_result_dir.clone(),
                     loading.drc_data_path.clone(),
                     loading.drc_statis_path.clone(),
+                    loading.map_root_path.clone(),
                 ))),
                 Ok(Err(err)) => Some(ViewerState::Error(err)),
                 Err(mpsc::TryRecvError::Disconnected) => Some(ViewerState::Error(
@@ -1062,11 +1146,32 @@ impl LoadedViewer {
         edit_result_dir: Option<PathBuf>,
         drc_data_path: Option<PathBuf>,
         drc_statis_path: Option<PathBuf>,
+        map_root_path: Option<PathBuf>,
     ) -> Self {
         let stats = db.stats();
         let snapshot_signature = snapshot_signature_for_db(&db);
         let drawing_category_counts = drawing_category_counts(&db);
         let layers = layer_ui_states(&db, &BTreeMap::new());
+        let drc_overlay = DrcOverlay::load(drc_data_path, drc_statis_path);
+        let (map_catalog, map_catalog_error) = match map_root_path.as_deref() {
+            Some(root) => match MapCatalog::discover(root) {
+                Ok(catalog) if !catalog.is_empty() => (Some(catalog), None),
+                Ok(_) => (None, None),
+                Err(err) => (None, Some(err)),
+            },
+            None => (None, None),
+        };
+        let analysis_tab = if drc_overlay.is_some() {
+            AnalysisTab::Drc
+        } else {
+            AnalysisTab::Map
+        };
+        let expanded_map_categories = map_catalog
+            .as_ref()
+            .and_then(|catalog| catalog.categories.first())
+            .map(|category| BTreeSet::from([category.id.clone()]))
+            .unwrap_or_default();
+        let map_thumbnail_worker = map_catalog.as_ref().map(|_| spawn_map_thumbnail_worker());
         Self {
             db,
             stats,
@@ -1096,8 +1201,19 @@ impl LoadedViewer {
             render_cache: RenderPlanCache::default(),
             view_tile_cache: ViewTilePlaneCache::default(),
             next_command_counter: 1,
-            drc_overlay: DrcOverlay::load(drc_data_path, drc_statis_path),
+            drc_overlay,
             selected_drc: None,
+            map_catalog,
+            map_catalog_error,
+            analysis_tab,
+            expanded_map_categories,
+            selected_map_item: None,
+            active_heatmap: None,
+            map_item_error: None,
+            map_thumbnails: BTreeMap::new(),
+            map_thumbnail_worker,
+            selected_map_bbox: None,
+            focus_animation: None,
             zoom: 1.0,
             pan: egui::Vec2::ZERO,
             pan_drag: PanDragState::default(),
@@ -1111,8 +1227,31 @@ impl LoadedViewer {
         self.sidebar_contents(ui);
     }
 
-    fn has_drc_panel(&self) -> bool {
-        self.drc_overlay.is_some()
+    fn has_analysis_panel(&self) -> bool {
+        self.drc_overlay.is_some() || self.map_catalog.is_some() || self.map_catalog_error.is_some()
+    }
+
+    fn analysis_sidebar(&mut self, ui: &mut egui::Ui) {
+        let has_drc = self.drc_overlay.is_some();
+        let has_maps = self.map_catalog.is_some() || self.map_catalog_error.is_some();
+        ui.add_space(8.0);
+        ui.horizontal(|ui| {
+            ui.spacing_mut().item_spacing.x = 2.0;
+            if has_drc && analysis_tab_button(ui, "DRC", self.analysis_tab == AnalysisTab::Drc) {
+                self.analysis_tab = AnalysisTab::Drc;
+            }
+            if has_maps && analysis_tab_button(ui, "MAP", self.analysis_tab == AnalysisTab::Map) {
+                self.analysis_tab = AnalysisTab::Map;
+            }
+        });
+        ui.add_space(4.0);
+        ui.separator();
+        match self.analysis_tab {
+            AnalysisTab::Drc if has_drc => self.drc_sidebar(ui),
+            AnalysisTab::Map if has_maps => self.map_sidebar(ui),
+            AnalysisTab::Drc => self.map_sidebar(ui),
+            AnalysisTab::Map => self.drc_sidebar(ui),
+        }
     }
 
     fn drc_sidebar(&mut self, ui: &mut egui::Ui) {
@@ -1121,9 +1260,8 @@ impl LoadedViewer {
             return;
         };
 
-        ui.add_space(8.0);
         ui.horizontal(|ui| {
-            section_heading(ui, "DRC");
+            section_heading(ui, "VIOLATIONS");
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 ui.label(
                     egui::RichText::new(format!("{visible_count}/{}", overlay.total_count()))
@@ -1189,6 +1327,198 @@ impl LoadedViewer {
                     ui.add_space(8.0);
                 }
             });
+    }
+
+    fn map_sidebar(&mut self, ui: &mut egui::Ui) {
+        self.poll_map_thumbnail_results(ui.ctx());
+        ui.horizontal(|ui| {
+            section_heading(ui, "MAP DATA");
+            if let Some(catalog) = &self.map_catalog {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "{} maps / {} groups",
+                            catalog.item_count(),
+                            catalog.categories.len()
+                        ))
+                        .small()
+                        .color(ecos_text_secondary()),
+                    );
+                });
+            }
+        });
+
+        if let Some(err) = &self.map_catalog_error {
+            ui.add_space(6.0);
+            ui.colored_label(ecos_warning(), err);
+            return;
+        }
+        if let Some(err) = &self.map_item_error {
+            ui.add_space(6.0);
+            ui.colored_label(ecos_warning(), err);
+        }
+
+        let Some(catalog) = self.map_catalog.as_ref() else {
+            ui.add_space(6.0);
+            ui.label(
+                egui::RichText::new("No map data")
+                    .size(13.0)
+                    .color(ecos_text_secondary()),
+            );
+            return;
+        };
+        let categories = catalog.categories.clone();
+        let warnings = catalog.warnings.clone();
+        for warning in warnings {
+            ui.colored_label(ecos_warning(), warning);
+        }
+
+        ui.add_space(4.0);
+        egui::ScrollArea::vertical()
+            .id_salt("chip_viewer_map_catalog_scroll")
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                for category in categories {
+                    let default_open = self.expanded_map_categories.contains(&category.id);
+                    egui::CollapsingHeader::new(format!(
+                        "{}  {}",
+                        category.label,
+                        category.items.len()
+                    ))
+                    .id_salt(("chip_viewer_map_category", &category.id))
+                    .default_open(default_open)
+                    .show(ui, |ui| {
+                        for item in &category.items {
+                            let texture_id = self.map_thumbnail_id(ui.ctx(), &item.png_path);
+                            let available =
+                                item.csv_path.is_some() && category.layout_path.is_some();
+                            let selected = self.selected_map_item.as_ref() == Some(&item.png_path);
+                            ui.horizontal(|ui| {
+                                if let Some(texture_id) = texture_id {
+                                    ui.add(
+                                        egui::Image::new((texture_id, egui::vec2(52.0, 40.0)))
+                                            .fit_to_exact_size(egui::vec2(52.0, 40.0))
+                                            .corner_radius(3.0),
+                                    );
+                                } else {
+                                    let (rect, _) = ui.allocate_exact_size(
+                                        egui::vec2(52.0, 40.0),
+                                        egui::Sense::hover(),
+                                    );
+                                    ui.painter().rect_filled(rect, 3.0, ecos_canvas());
+                                    ui.painter().text(
+                                        rect.center(),
+                                        egui::Align2::CENTER_CENTER,
+                                        "PNG",
+                                        egui::FontId::monospace(10.0),
+                                        ecos_text_secondary(),
+                                    );
+                                }
+
+                                let button_width = ui.available_width().max(80.0);
+                                let response = ui.add_enabled(
+                                    available,
+                                    egui::Button::new(
+                                        egui::RichText::new(&item.label)
+                                            .size(12.5)
+                                            .color(ecos_text_primary()),
+                                    )
+                                    .selected(selected)
+                                    .truncate()
+                                    .min_size(egui::vec2(button_width, 40.0)),
+                                );
+                                let response = if available {
+                                    response
+                                        .on_hover_text(format!("Open {}", item.png_path.display()))
+                                } else if item.csv_path.is_none() {
+                                    response.on_disabled_hover_text("Matching CSV file is missing")
+                                } else {
+                                    response.on_disabled_hover_text("layout.csv is missing")
+                                };
+                                if response.clicked() {
+                                    self.activate_map_item(item, category.layout_path.as_deref());
+                                }
+                            });
+                            ui.add_space(4.0);
+                        }
+                    });
+                    ui.add_space(4.0);
+                }
+            });
+    }
+
+    fn activate_map_item(&mut self, item: &MapItem, layout_path: Option<&Path>) {
+        self.selected_map_item = Some(item.png_path.clone());
+        self.active_heatmap = None;
+        self.map_item_error = None;
+        self.selected_map_bbox = None;
+
+        let Some(csv_path) = item.csv_path.as_deref() else {
+            self.map_item_error = Some(format!("matching CSV is missing for {}", item.label));
+            return;
+        };
+        let Some(layout_path) = layout_path else {
+            self.map_item_error = Some(format!("layout.csv is missing for {}", item.label));
+            return;
+        };
+        match HeatmapData::load(csv_path, layout_path) {
+            Ok(data) => {
+                self.active_heatmap = Some(ActiveHeatmap {
+                    title: item.label.clone(),
+                    data,
+                    selected_cell: None,
+                });
+            }
+            Err(err) => self.map_item_error = Some(err),
+        }
+    }
+
+    fn map_thumbnail_id(&mut self, ctx: &egui::Context, path: &Path) -> Option<egui::TextureId> {
+        if !self.map_thumbnails.contains_key(path) {
+            let state = self
+                .map_thumbnail_worker
+                .as_ref()
+                .filter(|worker| worker.request_sender.send(path.to_path_buf()).is_ok())
+                .map_or(MapThumbnailState::Failed, |_| MapThumbnailState::Loading);
+            self.map_thumbnails.insert(path.to_path_buf(), state);
+            ctx.request_repaint_after(Duration::from_millis(32));
+        }
+        match self.map_thumbnails.get(path) {
+            Some(MapThumbnailState::Ready(texture)) => Some(texture.id()),
+            Some(MapThumbnailState::Loading | MapThumbnailState::Failed) | None => None,
+        }
+    }
+
+    fn poll_map_thumbnail_results(&mut self, ctx: &egui::Context) {
+        let results = self
+            .map_thumbnail_worker
+            .as_ref()
+            .map(|worker| worker.result_receiver.try_iter().collect::<Vec<_>>())
+            .unwrap_or_default();
+        for result in results {
+            let state = match result.decoded {
+                Ok(decoded) => {
+                    let image = egui::ColorImage::from_rgba_unmultiplied(
+                        decoded.size,
+                        decoded.rgba.as_slice(),
+                    );
+                    MapThumbnailState::Ready(ctx.load_texture(
+                        format!("map-preview:{}", result.path.display()),
+                        image,
+                        egui::TextureOptions::LINEAR,
+                    ))
+                }
+                Err(_) => MapThumbnailState::Failed,
+            };
+            self.map_thumbnails.insert(result.path, state);
+        }
+        if self
+            .map_thumbnails
+            .values()
+            .any(|state| matches!(state, MapThumbnailState::Loading))
+        {
+            ctx.request_repaint_after(Duration::from_millis(32));
+        }
     }
 
     fn sidebar_contents(&mut self, ui: &mut egui::Ui) {
@@ -1272,6 +1602,7 @@ impl LoadedViewer {
         });
         ui.horizontal(|ui| {
             if ui.button("⛶").on_hover_text("Fit layout to view").clicked() {
+                self.focus_animation = None;
                 self.zoom = 1.0;
                 self.pan = egui::Vec2::ZERO;
                 self.pan_drag.reset();
@@ -1667,6 +1998,12 @@ impl LoadedViewer {
         let available = ui.available_size();
         let (response, painter) = ui.allocate_painter(available, egui::Sense::click_and_drag());
         let canvas = response.rect;
+        let heatmap_popup_rect = self.map_heatmap_popup_rect(canvas);
+        let pointer_over_heatmap = heatmap_popup_rect.is_some_and(|rect| {
+            ui.ctx()
+                .input(|input| input.pointer.hover_pos())
+                .is_some_and(|pos| rect.contains(pos))
+        });
         painter.rect_filled(canvas, 0.0, ecos_canvas());
 
         let Some(world) = self.stats.bbox else {
@@ -1680,7 +2017,7 @@ impl LoadedViewer {
             return;
         };
 
-        if response.hovered() {
+        if response.hovered() && !pointer_over_heatmap {
             let raw_scroll_delta_y = ui.ctx().input(|input| input.raw_scroll_delta.y);
             let zoom_delta = ui.ctx().input(|input| input.zoom_delta());
             let zoom_factor = if raw_scroll_delta_y.abs() > 0.0 {
@@ -1689,6 +2026,7 @@ impl LoadedViewer {
                 zoom_delta
             };
             if (zoom_factor - 1.0).abs() > f32::EPSILON {
+                self.focus_animation = None;
                 let cursor = ui
                     .ctx()
                     .input(|input| input.pointer.hover_pos())
@@ -1700,7 +2038,7 @@ impl LoadedViewer {
             }
         }
 
-        self.focus_pending_shape(world, canvas);
+        self.focus_pending_shape(ui.ctx(), world, canvas);
 
         let all_layers: BTreeMap<LayerId, LayerStyle> = self
             .layers
@@ -1720,10 +2058,11 @@ impl LoadedViewer {
         let hover_world_point = ui
             .ctx()
             .input(|input| input.pointer.hover_pos())
-            .filter(|pos| response.hovered() && canvas.contains(*pos))
+            .filter(|pos| response.hovered() && !pointer_over_heatmap && canvas.contains(*pos))
             .map(|pos| screen_to_world_point(pos, world, canvas, self.zoom, self.pan));
 
-        if response.drag_started() {
+        if response.drag_started() && !pointer_over_heatmap {
+            self.focus_animation = None;
             self.pan_drag.reset();
             let mode = if response.drag_started_by(egui::PointerButton::Middle)
                 || response.drag_started_by(egui::PointerButton::Secondary)
@@ -1749,7 +2088,7 @@ impl LoadedViewer {
                 self.pan_drag.start(mode);
             }
         }
-        if response.dragged() {
+        if response.dragged() && !pointer_over_heatmap {
             let frame_delta = response.drag_delta();
             match self.pan_drag.mode() {
                 Some(CanvasDragMode::Edit) if self.draft.is_some() => {
@@ -1774,18 +2113,21 @@ impl LoadedViewer {
         }
 
         let drc_double_clicked = response.double_clicked_by(egui::PointerButton::Primary);
-        if drc_double_clicked {
+        if drc_double_clicked && !pointer_over_heatmap {
             self.selected_drc = response
                 .interact_pointer_pos()
                 .and_then(|pos| self.pick_drc_violation_at(pos, world, canvas, viewport));
         }
-        if response.clicked_by(egui::PointerButton::Primary) && !drc_double_clicked {
+        if response.clicked_by(egui::PointerButton::Primary)
+            && !drc_double_clicked
+            && !pointer_over_heatmap
+        {
             self.selected = response
                 .interact_pointer_pos()
                 .and_then(|pos| self.pick_shape_at(pos, world, canvas, &query_layer_ids));
         }
         if let Some(cursor_icon) = canvas_cursor_icon(
-            response.hovered(),
+            response.hovered() && !pointer_over_heatmap,
             self.pan_drag.mode() == Some(CanvasDragMode::Pan)
                 && (response.drag_started() || response.dragged()),
         ) {
@@ -1915,6 +2257,12 @@ impl LoadedViewer {
             }
         }
 
+        if self.analysis_tab == AnalysisTab::Map {
+            if let Some(bbox) = self.selected_map_bbox {
+                paint_map_selection_overlay(&painter, bbox, world, canvas, self.zoom, self.pan);
+            }
+        }
+
         for shape_id in &overlay_shape_ids {
             let Some(shape) = self.db.find_shape(*shape_id) else {
                 continue;
@@ -1997,6 +2345,171 @@ impl LoadedViewer {
         }
         self.canvas_info_overlay(ui, canvas);
         self.drc_detail_overlay(ui, canvas);
+        self.map_heatmap_overlay(ui, canvas);
+    }
+
+    fn map_heatmap_popup_rect(&self, canvas: egui::Rect) -> Option<egui::Rect> {
+        if self.analysis_tab != AnalysisTab::Map {
+            return None;
+        }
+        let heatmap = self.active_heatmap.as_ref()?;
+        let (popup_size, _) =
+            map_heatmap_layout(canvas, heatmap.data.rows(), heatmap.data.columns());
+        let min = egui::pos2(
+            (canvas.right() - popup_size.x - 12.0).max(canvas.left() + 12.0),
+            (canvas.bottom() - popup_size.y - 12.0).max(canvas.top() + 12.0),
+        );
+        Some(egui::Rect::from_min_size(min, popup_size))
+    }
+
+    fn map_heatmap_overlay(&mut self, ui: &mut egui::Ui, canvas: egui::Rect) {
+        let Some(popup_rect) = self.map_heatmap_popup_rect(canvas) else {
+            return;
+        };
+        let Some(heatmap) = self.active_heatmap.as_ref() else {
+            return;
+        };
+        let title = heatmap.title.clone();
+        let rows = heatmap.data.rows();
+        let columns = heatmap.data.columns();
+        let selected_cell = heatmap.selected_cell;
+        let (_, grid_size) = map_heatmap_layout(canvas, rows, columns);
+        let mut close_requested = false;
+        let mut clicked_cell = None;
+        let ctx = ui.ctx().clone();
+
+        egui::Area::new(egui::Id::new("chip_viewer_map_heatmap_popup"))
+            .order(egui::Order::Foreground)
+            .fixed_pos(popup_rect.min)
+            .show(&ctx, |ui| {
+                ui.set_width(popup_rect.width());
+                egui::Frame::NONE
+                    .fill(egui::Color32::from_rgb(29, 30, 34))
+                    .stroke(egui::Stroke::new(1.0, ecos_accent()))
+                    .corner_radius(8)
+                    .inner_margin(egui::Margin::same(10))
+                    .show(ui, |ui| {
+                        ui.set_min_size(popup_rect.size() - egui::vec2(20.0, 20.0));
+                        ui.horizontal(|ui| {
+                            ui.add(
+                                egui::Label::new(
+                                    egui::RichText::new(&title)
+                                        .strong()
+                                        .size(13.0)
+                                        .color(ecos_text_primary()),
+                                )
+                                .truncate(),
+                            );
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if ui
+                                        .small_button("×")
+                                        .on_hover_text("Close heatmap")
+                                        .clicked()
+                                    {
+                                        close_requested = true;
+                                    }
+                                },
+                            );
+                        });
+                        ui.label(
+                            egui::RichText::new(format!("{rows} rows × {columns} columns"))
+                                .small()
+                                .color(ecos_text_secondary()),
+                        );
+                        ui.add_space(2.0);
+
+                        ui.horizontal(|ui| {
+                            let side_padding =
+                                ((ui.available_width() - grid_size.x) * 0.5).max(0.0);
+                            ui.add_space(side_padding);
+                            let (grid_rect, response) =
+                                ui.allocate_exact_size(grid_size, egui::Sense::click());
+                            let painter = ui.painter_at(grid_rect);
+                            paint_heatmap_grid(&painter, grid_rect, &heatmap.data, selected_cell);
+                            let hovered_cell = response.hover_pos().and_then(|pos| {
+                                interactive_heatmap_cell_at(pos, grid_rect, &heatmap.data)
+                            });
+                            if let Some((row, column)) = hovered_cell {
+                                paint_heatmap_cell_outline(
+                                    &painter,
+                                    grid_rect,
+                                    rows,
+                                    columns,
+                                    row,
+                                    column,
+                                    egui::Stroke::new(1.5, egui::Color32::WHITE),
+                                );
+                                if let Some(value) = heatmap.data.value(row, column) {
+                                    response.clone().on_hover_text(format!(
+                                        "row {row}, column {column}\nvalue {}",
+                                        format_map_value(value)
+                                    ));
+                                }
+                            }
+                            if response.clicked() {
+                                clicked_cell = hovered_cell;
+                            }
+                        });
+
+                        if let Some((row, column)) = selected_cell {
+                            let detail = heatmap.data.value(row, column).map_or_else(
+                                || format!("row {row} · column {column}"),
+                                |value| {
+                                    format!(
+                                        "row {row} · column {column} · {}",
+                                        format_map_value(value)
+                                    )
+                                },
+                            );
+                            ui.label(
+                                egui::RichText::new(detail)
+                                    .monospace()
+                                    .size(11.0)
+                                    .color(ecos_info_text()),
+                            );
+                        } else {
+                            ui.label(
+                                egui::RichText::new("Select a cell to focus the layout")
+                                    .size(11.0)
+                                    .color(ecos_text_secondary()),
+                            );
+                        }
+                        paint_heatmap_legend(ui, heatmap.data.min(), heatmap.data.max());
+                    });
+            });
+
+        if close_requested {
+            self.active_heatmap = None;
+            self.selected_map_bbox = None;
+            return;
+        }
+        let Some((row, column)) = clicked_cell else {
+            return;
+        };
+        let bbox = self
+            .active_heatmap
+            .as_ref()
+            .and_then(|heatmap| heatmap.data.bbox(row, column));
+        if let Some(heatmap) = self.active_heatmap.as_mut() {
+            heatmap.selected_cell = Some((row, column));
+        }
+        if let Some(bbox) = bbox {
+            self.selected_map_bbox = Some(bbox);
+            self.pending_focus = Some(PendingFocus {
+                bbox: contextual_map_focus_bbox(bbox),
+                select_shape_id: None,
+                transition: FocusTransition::Animated,
+            });
+            self.selected = None;
+            self.pan_drag.reset();
+            ui.ctx().request_repaint();
+        } else {
+            self.map_item_error = Some(format!(
+                "layout.csv has no coordinate mapping for row {row}, column {column}"
+            ));
+        }
     }
 
     fn canvas_info_overlay(&mut self, ui: &mut egui::Ui, canvas: egui::Rect) {
@@ -2011,9 +2524,14 @@ impl LoadedViewer {
         let popup_height = (canvas.height() * 0.34)
             .clamp(220.0, 310.0)
             .min((canvas.height() - 24.0).max(160.0));
+        let popup_y = if self.analysis_tab == AnalysisTab::Map && self.active_heatmap.is_some() {
+            canvas.top() + 12.0
+        } else {
+            (canvas.bottom() - popup_height - 12.0).max(canvas.top() + 12.0)
+        };
         let popup_pos = egui::pos2(
             (canvas.right() - popup_width - 12.0).max(canvas.left() + 12.0),
-            (canvas.bottom() - popup_height - 12.0).max(canvas.top() + 12.0),
+            popup_y,
         );
 
         egui::Area::new(egui::Id::new("chip_viewer_canvas_info_popup"))
@@ -2074,16 +2592,34 @@ impl LoadedViewer {
         }
     }
 
-    fn focus_pending_shape(&mut self, world: Rect32, canvas: egui::Rect) {
-        let Some(focus) = self.pending_focus.take() else {
+    fn focus_pending_shape(&mut self, ctx: &egui::Context, world: Rect32, canvas: egui::Rect) {
+        let now = ctx.input(|input| input.time);
+        if let Some(focus) = self.pending_focus.take() {
+            let (zoom, pan) = focus_view_on_bbox(world, focus.bbox, canvas);
+            self.pan_drag.reset();
+            self.selected = focus.select_shape_id;
+
+            if focus.transition == FocusTransition::Animated && focus_animation_enabled(ctx) {
+                self.focus_animation =
+                    Some(FocusAnimation::new(now, self.zoom, self.pan, zoom, pan));
+            } else {
+                self.focus_animation = None;
+                self.zoom = zoom;
+                self.pan = pan;
+            }
+        }
+
+        let Some(animation) = self.focus_animation else {
             return;
         };
-
-        let (zoom, pan) = focus_view_on_bbox(world, focus.bbox, canvas);
-        self.zoom = zoom;
-        self.pan = pan;
-        self.pan_drag.reset();
-        self.selected = focus.select_shape_id;
+        let frame = animation.sample(now);
+        self.zoom = frame.zoom;
+        self.pan = frame.pan;
+        if frame.complete {
+            self.focus_animation = None;
+        } else {
+            ctx.request_repaint();
+        }
     }
 
     fn begin_edit_drag(&mut self, pos: egui::Pos2, world: Rect32, canvas: egui::Rect) -> bool {
@@ -2906,13 +3442,13 @@ impl eframe::App for ChipViewerApp {
             ctx.request_repaint_after(Duration::from_millis(50));
         }
         if let ViewerState::Loaded(loaded) = &mut self.state {
-            if loaded.has_drc_panel() {
-                egui::SidePanel::left("chip_viewer_drc")
+            if loaded.has_analysis_panel() {
+                egui::SidePanel::left("chip_viewer_analysis")
                     .resizable(true)
                     .min_width(240.0)
                     .max_width(380.0)
                     .default_width(292.0)
-                    .show(ctx, |ui| loaded.drc_sidebar(ui));
+                    .show(ctx, |ui| loaded.analysis_sidebar(ui));
             }
         }
         egui::SidePanel::right("chip_viewer_operations")
@@ -3026,6 +3562,325 @@ fn section_heading(ui: &mut egui::Ui, label: &str) {
             .small()
             .strong()
             .color(ecos_accent()),
+    );
+}
+
+fn analysis_tab_button(ui: &mut egui::Ui, label: &str, selected: bool) -> bool {
+    let response = ui.add_sized(
+        egui::vec2(52.0, 28.0),
+        egui::Button::new(
+            egui::RichText::new(label)
+                .strong()
+                .size(12.5)
+                .color(if selected {
+                    ecos_text_primary()
+                } else {
+                    ecos_text_secondary()
+                }),
+        )
+        .frame(false),
+    );
+    if selected {
+        ui.painter().line_segment(
+            [
+                egui::pos2(response.rect.left() + 8.0, response.rect.bottom()),
+                egui::pos2(response.rect.right() - 8.0, response.rect.bottom()),
+            ],
+            egui::Stroke::new(2.0, ecos_accent()),
+        );
+    }
+    response.clicked()
+}
+
+fn spawn_map_thumbnail_worker() -> MapThumbnailWorker {
+    let (request_sender, request_receiver) = mpsc::channel::<PathBuf>();
+    let (result_sender, result_receiver) = mpsc::channel::<MapThumbnailResult>();
+    thread::spawn(move || {
+        while let Ok(path) = request_receiver.recv() {
+            let decoded = decode_map_thumbnail(&path);
+            if result_sender
+                .send(MapThumbnailResult { path, decoded })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+    MapThumbnailWorker {
+        request_sender,
+        result_receiver,
+    }
+}
+
+fn decode_map_thumbnail(path: &Path) -> Result<DecodedMapThumbnail, String> {
+    let mut reader = image::ImageReader::open(path)
+        .and_then(image::ImageReader::with_guessed_format)
+        .map_err(|err| format!("failed to open map preview {}: {err}", path.display()))?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAP_THUMBNAIL_MAX_DIMENSION);
+    limits.max_image_height = Some(MAP_THUMBNAIL_MAX_DIMENSION);
+    limits.max_alloc = Some(MAP_THUMBNAIL_MAX_DECODE_BYTES);
+    reader.limits(limits);
+    let image = reader
+        .decode()
+        .map_err(|err| format!("failed to decode map preview {}: {err}", path.display()))?
+        .thumbnail(MAP_THUMBNAIL_WIDTH, MAP_THUMBNAIL_HEIGHT)
+        .to_rgba8();
+    Ok(DecodedMapThumbnail {
+        size: [image.width() as usize, image.height() as usize],
+        rgba: image.into_raw(),
+    })
+}
+
+fn map_heatmap_layout(canvas: egui::Rect, rows: usize, columns: usize) -> (egui::Vec2, egui::Vec2) {
+    let popup_width = (canvas.width() * MAP_HEATMAP_WIDTH_FRACTION)
+        .clamp(MAP_HEATMAP_MIN_WIDTH, MAP_HEATMAP_MAX_WIDTH)
+        .min((canvas.width() - 24.0).max(160.0));
+    let content_width = (popup_width - 20.0).max(120.0);
+    let mut grid_width = content_width.min(MAP_HEATMAP_MAX_GRID_SIZE);
+    let mut grid_height = grid_width * rows.max(1) as f32 / columns.max(1) as f32;
+    let max_grid_height = (canvas.height() - 118.0).clamp(60.0, MAP_HEATMAP_MAX_GRID_SIZE);
+    if grid_height > max_grid_height {
+        let scale = max_grid_height / grid_height;
+        grid_width *= scale;
+        grid_height = max_grid_height;
+    }
+    let popup_height =
+        (grid_height + MAP_HEATMAP_VERTICAL_OVERHEAD).min((canvas.height() - 24.0).max(150.0));
+    (
+        egui::vec2(popup_width, popup_height),
+        egui::vec2(grid_width, grid_height),
+    )
+}
+
+fn paint_heatmap_grid(
+    painter: &egui::Painter,
+    rect: egui::Rect,
+    data: &HeatmapData,
+    selected_cell: Option<(usize, usize)>,
+) {
+    let rows = data.rows().max(1);
+    let columns = data.columns().max(1);
+    let cell_width = rect.width() / columns as f32;
+    let cell_height = rect.height() / rows as f32;
+    painter.rect_filled(rect, 2.0, ecos_canvas());
+    for row in 0..rows {
+        for column in 0..columns {
+            let Some(normalized) = data.normalized_value(row, column) else {
+                continue;
+            };
+            let cell = heatmap_cell_rect(rect, rows, columns, row, column);
+            painter.rect_filled(cell, 0.0, heatmap_color(normalized));
+        }
+    }
+    painter.rect_stroke(
+        rect,
+        2.0,
+        egui::Stroke::new(1.0, ecos_border()),
+        egui::StrokeKind::Inside,
+    );
+    if let Some((row, column)) = selected_cell {
+        if row < rows && column < columns {
+            paint_heatmap_cell_outline(
+                painter,
+                rect,
+                rows,
+                columns,
+                row,
+                column,
+                egui::Stroke::new(2.0, egui::Color32::WHITE),
+            );
+        }
+    }
+
+    if cell_width >= 8.0 && cell_height >= 8.0 {
+        let stroke = egui::Stroke::new(0.5, egui::Color32::from_black_alpha(48));
+        for column in 1..columns {
+            let x = rect.left() + column as f32 * cell_width;
+            painter.line_segment(
+                [egui::pos2(x, rect.top()), egui::pos2(x, rect.bottom())],
+                stroke,
+            );
+        }
+        for row in 1..rows {
+            let y = rect.top() + row as f32 * cell_height;
+            painter.line_segment(
+                [egui::pos2(rect.left(), y), egui::pos2(rect.right(), y)],
+                stroke,
+            );
+        }
+    }
+}
+
+fn paint_heatmap_legend(ui: &mut egui::Ui, min: f64, max: f64) {
+    let (rect, _) =
+        ui.allocate_exact_size(egui::vec2(ui.available_width(), 8.0), egui::Sense::hover());
+    let painter = ui.painter_at(rect);
+    let segments = 64;
+    for segment in 0..segments {
+        let t0 = segment as f32 / segments as f32;
+        let t1 = (segment + 1) as f32 / segments as f32;
+        painter.rect_filled(
+            egui::Rect::from_min_max(
+                egui::pos2(egui::lerp(rect.x_range(), t0), rect.top()),
+                egui::pos2(egui::lerp(rect.x_range(), t1), rect.bottom()),
+            ),
+            0.0,
+            heatmap_color((t0 + t1) * 0.5),
+        );
+    }
+    ui.horizontal(|ui| {
+        ui.label(
+            egui::RichText::new(format_map_value(min))
+                .monospace()
+                .size(10.0)
+                .color(ecos_text_secondary()),
+        );
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            ui.label(
+                egui::RichText::new(format_map_value(max))
+                    .monospace()
+                    .size(10.0)
+                    .color(ecos_text_secondary()),
+            );
+        });
+    });
+}
+
+fn heatmap_cell_at(
+    pos: egui::Pos2,
+    rect: egui::Rect,
+    rows: usize,
+    columns: usize,
+) -> Option<(usize, usize)> {
+    if !rect.contains(pos) || rows == 0 || columns == 0 {
+        return None;
+    }
+    let column = (((pos.x - rect.left()) / rect.width()) * columns as f32)
+        .floor()
+        .clamp(0.0, (columns - 1) as f32) as usize;
+    let row = (((pos.y - rect.top()) / rect.height()) * rows as f32)
+        .floor()
+        .clamp(0.0, (rows - 1) as f32) as usize;
+    Some((row, column))
+}
+
+fn interactive_heatmap_cell_at(
+    pos: egui::Pos2,
+    rect: egui::Rect,
+    data: &HeatmapData,
+) -> Option<(usize, usize)> {
+    heatmap_cell_at(pos, rect, data.rows(), data.columns())
+        .filter(|(row, column)| data.value(*row, *column).is_some())
+}
+
+fn heatmap_cell_rect(
+    rect: egui::Rect,
+    rows: usize,
+    columns: usize,
+    row: usize,
+    column: usize,
+) -> egui::Rect {
+    let cell_width = rect.width() / columns.max(1) as f32;
+    let cell_height = rect.height() / rows.max(1) as f32;
+    egui::Rect::from_min_max(
+        egui::pos2(
+            rect.left() + column as f32 * cell_width,
+            rect.top() + row as f32 * cell_height,
+        ),
+        egui::pos2(
+            rect.left() + (column + 1) as f32 * cell_width,
+            rect.top() + (row + 1) as f32 * cell_height,
+        ),
+    )
+}
+
+fn paint_heatmap_cell_outline(
+    painter: &egui::Painter,
+    rect: egui::Rect,
+    rows: usize,
+    columns: usize,
+    row: usize,
+    column: usize,
+    stroke: egui::Stroke,
+) {
+    painter.rect_stroke(
+        heatmap_cell_rect(rect, rows, columns, row, column).expand(1.0),
+        0.0,
+        stroke,
+        egui::StrokeKind::Inside,
+    );
+}
+
+fn heatmap_color(value: f32) -> egui::Color32 {
+    const STOPS: [[u8; 3]; 5] = [
+        [30, 42, 85],
+        [23, 108, 124],
+        [41, 156, 105],
+        [153, 211, 67],
+        [250, 225, 52],
+    ];
+    let scaled = value.clamp(0.0, 1.0) * (STOPS.len() - 1) as f32;
+    let lower = scaled.floor() as usize;
+    let upper = (lower + 1).min(STOPS.len() - 1);
+    let t = scaled - lower as f32;
+    let channel = |index: usize| {
+        (STOPS[lower][index] as f32 + (STOPS[upper][index] as f32 - STOPS[lower][index] as f32) * t)
+            .round() as u8
+    };
+    egui::Color32::from_rgb(channel(0), channel(1), channel(2))
+}
+
+fn format_map_value(value: f64) -> String {
+    let magnitude = value.abs();
+    if magnitude == 0.0 {
+        "0".to_string()
+    } else if magnitude >= 1000.0 || magnitude < 0.001 {
+        format!("{value:.3e}")
+    } else if magnitude >= 1.0 {
+        format!("{value:.3}")
+    } else {
+        format!("{value:.5}")
+    }
+}
+
+fn contextual_map_focus_bbox(bbox: Rect32) -> Rect32 {
+    let width = i64::from(bbox.hx) - i64::from(bbox.lx);
+    let height = i64::from(bbox.hy) - i64::from(bbox.ly);
+    let half_extent = width.max(height).max(1);
+    let center_x = (i64::from(bbox.lx) + i64::from(bbox.hx)) / 2;
+    let center_y = (i64::from(bbox.ly) + i64::from(bbox.hy)) / 2;
+    Rect32 {
+        lx: clamp_i64_to_i32(center_x - half_extent),
+        ly: clamp_i64_to_i32(center_y - half_extent),
+        hx: clamp_i64_to_i32(center_x + half_extent),
+        hy: clamp_i64_to_i32(center_y + half_extent),
+    }
+}
+
+fn clamp_i64_to_i32(value: i64) -> i32 {
+    value.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
+}
+
+fn paint_map_selection_overlay(
+    painter: &egui::Painter,
+    bbox: Rect32,
+    world: Rect32,
+    canvas: egui::Rect,
+    zoom: f32,
+    pan: egui::Vec2,
+) {
+    let rect = world_to_screen_rect(bbox, world, canvas, zoom, pan);
+    painter.rect_filled(
+        rect,
+        0.0,
+        egui::Color32::from_rgba_unmultiplied(0, 191, 165, 36),
+    );
+    painter.rect_stroke(
+        rect.expand(1.5),
+        0.0,
+        egui::Stroke::new(2.0, ecos_accent()),
+        egui::StrokeKind::Inside,
     );
 }
 
@@ -5142,6 +5997,7 @@ where
     Some(PendingFocus {
         bbox,
         select_shape_id,
+        transition: FocusTransition::Immediate,
     })
 }
 
@@ -5173,6 +6029,7 @@ where
         pending_focus: Some(PendingFocus {
             bbox,
             select_shape_id: Some(shape_id),
+            transition: FocusTransition::Immediate,
         }),
         message: format!("shape {shape_id} selected"),
     }
@@ -5213,6 +6070,57 @@ fn focus_view_on_bbox(world: Rect32, target: Rect32, canvas: egui::Rect) -> (f32
             (target_cy - world_cy) * scale,
         ),
     )
+}
+
+impl FocusAnimation {
+    fn new(
+        started_at: f64,
+        from_zoom: f32,
+        from_pan: egui::Vec2,
+        to_zoom: f32,
+        to_pan: egui::Vec2,
+    ) -> Self {
+        Self {
+            started_at,
+            from_zoom,
+            from_pan,
+            to_zoom,
+            to_pan,
+        }
+    }
+
+    fn sample(self, now: f64) -> FocusAnimationFrame {
+        let progress =
+            ((now - self.started_at) / MAP_FOCUS_ANIMATION_DURATION_SECONDS).clamp(0.0, 1.0) as f32;
+        let eased = ease_out_quint(progress);
+        let zoom = egui::lerp(self.from_zoom..=self.to_zoom, eased);
+        FocusAnimationFrame {
+            zoom: if progress >= 1.0 { self.to_zoom } else { zoom },
+            pan: if progress >= 1.0 {
+                self.to_pan
+            } else {
+                self.from_pan + (self.to_pan - self.from_pan) * eased
+            },
+            complete: progress >= 1.0,
+        }
+    }
+}
+
+fn ease_out_quint(progress: f32) -> f32 {
+    1.0 - (1.0 - progress.clamp(0.0, 1.0)).powi(5)
+}
+
+fn focus_animation_enabled(ctx: &egui::Context) -> bool {
+    ctx.style().animation_time > 0.0
+        && !reduced_motion_requested(std::env::var(REDUCED_MOTION_ENV).ok().as_deref())
+}
+
+fn reduced_motion_requested(value: Option<&str>) -> bool {
+    value.is_some_and(|value| {
+        ["1", "true", "yes", "on"]
+            .iter()
+            .any(|enabled| value.trim().eq_ignore_ascii_case(enabled))
+    })
 }
 
 fn retain_existing_shape_id<F>(shape_id: Option<ShapeId>, mut exists: F) -> Option<ShapeId>
@@ -6446,6 +7354,7 @@ mod tests {
                     hy: 40,
                 },
                 select_shape_id: Some(42),
+                transition: FocusTransition::Immediate,
             })
         );
         assert_eq!(action.message, "shape 42 selected");
@@ -6484,6 +7393,177 @@ mod tests {
         assert!((screen.center().x - canvas.center().x).abs() <= 0.5);
         assert!((screen.center().y - canvas.center().y).abs() <= 0.5);
         assert!(zoom >= 1.0);
+    }
+
+    #[test]
+    fn focus_animation_eases_out_and_finishes_on_the_exact_target() {
+        let animation =
+            FocusAnimation::new(10.0, 1.0, egui::Vec2::ZERO, 16.0, egui::vec2(80.0, -40.0));
+
+        let start = animation.sample(10.0);
+        let middle = animation.sample(10.0 + MAP_FOCUS_ANIMATION_DURATION_SECONDS * 0.5);
+        let end = animation.sample(10.0 + MAP_FOCUS_ANIMATION_DURATION_SECONDS);
+
+        assert_eq!(start.zoom, 1.0);
+        assert_eq!(start.pan, egui::Vec2::ZERO);
+        assert!(!start.complete);
+        assert!(middle.zoom > 4.0 && middle.zoom < 16.0);
+        assert!(middle.pan.x > 40.0 && middle.pan.x < 80.0);
+        assert!(middle.pan.y < -20.0 && middle.pan.y > -40.0);
+        assert!(!middle.complete);
+        assert_eq!(end.zoom, 16.0);
+        assert_eq!(end.pan, egui::vec2(80.0, -40.0));
+        assert!(end.complete);
+    }
+
+    #[test]
+    fn focus_animation_moves_target_monotonically_to_viewport_center() {
+        let target_from_world_center = egui::vec2(10.0, -5.0);
+        let animation = FocusAnimation::new(
+            10.0,
+            1.0,
+            egui::Vec2::ZERO,
+            16.0,
+            -target_from_world_center * 16.0,
+        );
+        let mut previous_distance = f32::INFINITY;
+
+        for progress in [0.0, 0.1, 0.25, 0.5, 0.75, 1.0] {
+            let frame = animation.sample(10.0 + MAP_FOCUS_ANIMATION_DURATION_SECONDS * progress);
+            let target_offset = target_from_world_center * frame.zoom + frame.pan;
+            let distance = target_offset.length();
+            assert!(
+                distance <= previous_distance + f32::EPSILON,
+                "target moved away from center at progress {progress}: {distance} > {previous_distance}"
+            );
+            assert!(target_offset.x >= -f32::EPSILON);
+            assert!(target_offset.y <= f32::EPSILON);
+            previous_distance = distance;
+        }
+        assert!(previous_distance <= f32::EPSILON);
+    }
+
+    #[test]
+    fn reduced_motion_environment_values_disable_focus_animation() {
+        for value in ["1", "true", "TRUE", "yes", "on"] {
+            assert!(reduced_motion_requested(Some(value)));
+        }
+        for value in ["0", "false", "off", ""] {
+            assert!(!reduced_motion_requested(Some(value)));
+        }
+        assert!(!reduced_motion_requested(None));
+    }
+
+    #[test]
+    fn map_focus_keeps_context_around_the_selected_cell() {
+        let target = contextual_map_focus_bbox(Rect32 {
+            lx: 0,
+            ly: 0,
+            hx: 100,
+            hy: 20,
+        });
+
+        assert_eq!(
+            target,
+            Rect32 {
+                lx: -50,
+                ly: -90,
+                hx: 150,
+                hy: 110,
+            }
+        );
+    }
+
+    #[test]
+    fn heatmap_pointer_maps_to_matrix_coordinates() {
+        let rect = egui::Rect::from_min_size(egui::pos2(10.0, 20.0), egui::vec2(100.0, 80.0));
+
+        assert_eq!(
+            heatmap_cell_at(egui::pos2(10.0, 20.0), rect, 4, 5),
+            Some((0, 0))
+        );
+        assert_eq!(
+            heatmap_cell_at(egui::pos2(109.9, 99.9), rect, 4, 5),
+            Some((3, 4))
+        );
+        assert_eq!(heatmap_cell_at(egui::pos2(110.1, 100.1), rect, 4, 5), None);
+    }
+
+    #[test]
+    fn heatmap_pointer_ignores_cells_without_finite_data() {
+        let directory = temp_snapshot_dir("heatmap-interactive-cells");
+        let values_path = directory.join("values.csv");
+        let layout_path = directory.join("layout.csv");
+        fs::write(&values_path, "1,NaN\n3,4\n").unwrap();
+        fs::write(
+            &layout_path,
+            "pixel_row,pixel_col,lx,ly,ux,uy\n0,0,0,0,10,10\n0,1,10,0,20,10\n",
+        )
+        .unwrap();
+        let data = HeatmapData::load(&values_path, &layout_path).unwrap();
+        let rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(100.0, 100.0));
+
+        assert_eq!(
+            interactive_heatmap_cell_at(egui::pos2(25.0, 25.0), rect, &data),
+            Some((0, 0))
+        );
+        assert_eq!(
+            interactive_heatmap_cell_at(egui::pos2(75.0, 25.0), rect, &data),
+            None
+        );
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn map_thumbnail_decoder_downsizes_and_enforces_dimension_limit() {
+        let directory = temp_snapshot_dir("map-thumbnail-limits");
+        let preview_path = directory.join("preview.png");
+        image::RgbaImage::new(256, 192).save(&preview_path).unwrap();
+
+        let preview = decode_map_thumbnail(&preview_path).unwrap();
+        assert_eq!(preview.size, [128, 96]);
+        assert_eq!(preview.rgba.len(), 128 * 96 * 4);
+
+        let oversized_path = directory.join("oversized.png");
+        image::RgbaImage::new(MAP_THUMBNAIL_MAX_DIMENSION + 1, 1)
+            .save(&oversized_path)
+            .unwrap();
+        assert!(decode_map_thumbnail(&oversized_path).is_err());
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn heatmap_palette_has_distinct_low_and_high_colors() {
+        assert_eq!(heatmap_color(0.0), egui::Color32::from_rgb(30, 42, 85));
+        assert_eq!(heatmap_color(1.0), egui::Color32::from_rgb(250, 225, 52));
+        assert_ne!(heatmap_color(0.5), heatmap_color(0.0));
+        assert_ne!(heatmap_color(0.5), heatmap_color(1.0));
+    }
+
+    #[test]
+    fn heatmap_layout_uses_a_larger_contextual_grid() {
+        let canvas = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(674.0, 650.0));
+
+        let (popup, grid) = map_heatmap_layout(canvas, 43, 43);
+
+        assert!((popup.x - 310.04).abs() < 0.1);
+        assert!((grid.x - 290.04).abs() < 0.1);
+        assert_eq!(grid.x, grid.y);
+        assert!((popup.y - (grid.y + MAP_HEATMAP_VERTICAL_OVERHEAD)).abs() < 0.1);
+    }
+
+    #[test]
+    fn heatmap_layout_stays_inside_a_small_canvas() {
+        let canvas = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(220.0, 180.0));
+
+        let (popup, grid) = map_heatmap_layout(canvas, 43, 43);
+
+        assert!(popup.x <= canvas.width() - 24.0);
+        assert!(popup.y <= canvas.height() - 24.0);
+        assert!(grid.x <= popup.x - 20.0);
+        assert!(grid.y <= canvas.height() - 118.0);
     }
 
     #[test]
@@ -7453,7 +8533,7 @@ mod tests {
         let dir = temp_snapshot_dir("external-refresh-new-delta");
         write_empty_snapshot(&dir, false);
         let db = ChipViewDb::open(dir.join("geometry.manifest")).unwrap();
-        let mut loaded = LoadedViewer::new(db, false, false, None, None, None, None);
+        let mut loaded = LoadedViewer::new(db, false, false, None, None, None, None, None);
         let delta_path = dir.join("geometry.delta.bin");
 
         assert!(!loaded.snapshot_signature.files.contains_key(&delta_path));
@@ -7480,7 +8560,7 @@ mod tests {
         let dir = temp_snapshot_dir("restored-edit-session-dirty");
         write_empty_snapshot(&dir, false);
         let db = ChipViewDb::open(dir.join("geometry.manifest")).unwrap();
-        let loaded = LoadedViewer::new(db, true, true, None, None, None, None);
+        let loaded = LoadedViewer::new(db, true, true, None, None, None, None, None);
 
         assert!(loaded.session_dirty);
 

--- a/ecos/chip-viewer/apps/chip-viewer-native/src/main.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod map_data;
 
 use std::path::PathBuf;
 
@@ -28,6 +29,9 @@ struct Args {
 
     #[arg(long)]
     drc_statis: Option<PathBuf>,
+
+    #[arg(long)]
+    map_root: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
@@ -52,6 +56,7 @@ fn main() -> Result<()> {
                 args.edit_dirty,
                 args.drc_data.clone(),
                 args.drc_statis.clone(),
+                args.map_root.clone(),
             )))
         }),
     )

--- a/ecos/chip-viewer/apps/chip-viewer-native/src/map_data.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/map_data.rs
@@ -1,0 +1,371 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chipgeom_format::Rect32;
+use serde::Deserialize;
+
+#[derive(Clone, Debug)]
+pub struct MapCatalog {
+    pub categories: Vec<MapCategory>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MapCategory {
+    pub id: String,
+    pub label: String,
+    pub layout_path: Option<PathBuf>,
+    pub items: Vec<MapItem>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MapItem {
+    pub label: String,
+    pub png_path: PathBuf,
+    pub csv_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
+pub struct HeatmapData {
+    values: Vec<Vec<Option<f64>>>,
+    layout: BTreeMap<(usize, usize), Rect32>,
+    min: f64,
+    max: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct LayoutRecord {
+    pixel_row: usize,
+    pixel_col: usize,
+    lx: i32,
+    ly: i32,
+    ux: i32,
+    uy: i32,
+}
+
+impl MapCatalog {
+    pub fn discover(root: &Path) -> Result<Self, String> {
+        let entries = fs::read_dir(root)
+            .map_err(|err| format!("failed to read map root {}: {err}", root.display()))?;
+        let mut category_directories = entries
+            .filter_map(Result::ok)
+            .filter_map(|entry| {
+                let file_type = entry.file_type().ok()?;
+                let name = entry.file_name().to_string_lossy().into_owned();
+                (file_type.is_dir() && name.to_ascii_lowercase().ends_with("_map"))
+                    .then_some((name, entry.path()))
+            })
+            .collect::<Vec<_>>();
+        category_directories.sort_by_key(|(name, _)| name.to_ascii_lowercase());
+
+        let mut categories = Vec::new();
+        let mut warnings = Vec::new();
+        for (id, directory) in category_directories {
+            match discover_category(&id, &directory) {
+                Ok(category) if !category.items.is_empty() => categories.push(category),
+                Ok(_) => {}
+                Err(err) => warnings.push(err),
+            }
+        }
+        Ok(Self {
+            categories,
+            warnings,
+        })
+    }
+
+    pub fn item_count(&self) -> usize {
+        self.categories
+            .iter()
+            .map(|category| category.items.len())
+            .sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.categories.is_empty()
+    }
+}
+
+impl HeatmapData {
+    pub fn load(csv_path: &Path, layout_path: &Path) -> Result<Self, String> {
+        let values = read_value_matrix(csv_path)?;
+        let layout = read_layout(layout_path)?;
+        let mut finite_values = values.iter().flatten().filter_map(|value| *value);
+        let first = finite_values
+            .next()
+            .ok_or_else(|| format!("map data contains no finite values: {}", csv_path.display()))?;
+        let (min, max) = finite_values.fold((first, first), |(min, max), value| {
+            (min.min(value), max.max(value))
+        });
+        Ok(Self {
+            values,
+            layout,
+            min,
+            max,
+        })
+    }
+
+    pub fn rows(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn columns(&self) -> usize {
+        self.values.first().map_or(0, Vec::len)
+    }
+
+    pub fn value(&self, row: usize, column: usize) -> Option<f64> {
+        self.values
+            .get(row)
+            .and_then(|values| values.get(column))
+            .copied()
+            .flatten()
+    }
+
+    pub fn bbox(&self, row: usize, column: usize) -> Option<Rect32> {
+        self.layout.get(&(row, column)).copied()
+    }
+
+    pub fn min(&self) -> f64 {
+        self.min
+    }
+
+    pub fn max(&self) -> f64 {
+        self.max
+    }
+
+    pub fn normalized_value(&self, row: usize, column: usize) -> Option<f32> {
+        let value = self.value(row, column)?;
+        let range = self.max - self.min;
+        if range.abs() <= f64::EPSILON {
+            return Some(0.5);
+        }
+        Some(((value - self.min) / range).clamp(0.0, 1.0) as f32)
+    }
+}
+
+fn discover_category(id: &str, directory: &Path) -> Result<MapCategory, String> {
+    let entries = fs::read_dir(directory)
+        .map_err(|err| format!("failed to read map category {}: {err}", directory.display()))?;
+    let mut png_paths = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("png"))
+        })
+        .collect::<Vec<_>>();
+    png_paths.sort_by_key(|path| {
+        path.file_name()
+            .map(|name| name.to_string_lossy().to_ascii_lowercase())
+            .unwrap_or_default()
+    });
+
+    let items = png_paths
+        .into_iter()
+        .filter_map(|png_path| {
+            let stem = png_path.file_stem()?.to_string_lossy().into_owned();
+            let csv_path = png_path.with_extension("csv");
+            Some(MapItem {
+                label: humanize_identifier(&stem),
+                png_path,
+                csv_path: csv_path.is_file().then_some(csv_path),
+            })
+        })
+        .collect();
+    let layout_path = directory.join("layout.csv");
+    Ok(MapCategory {
+        id: id.to_string(),
+        label: humanize_category(id),
+        layout_path: layout_path.is_file().then_some(layout_path),
+        items,
+    })
+}
+
+fn read_value_matrix(path: &Path) -> Result<Vec<Vec<Option<f64>>>, String> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .flexible(true)
+        .from_path(path)
+        .map_err(|err| format!("failed to open map CSV {}: {err}", path.display()))?;
+    let mut values = Vec::new();
+    let mut expected_columns = None;
+    for (row_index, record) in reader.records().enumerate() {
+        let record = record.map_err(|err| {
+            format!(
+                "failed to read map CSV {} row {}: {err}",
+                path.display(),
+                row_index + 1
+            )
+        })?;
+        if record.is_empty() {
+            continue;
+        }
+        if let Some(expected) = expected_columns {
+            if record.len() != expected {
+                return Err(format!(
+                    "map CSV {} row {} has {} columns; expected {}",
+                    path.display(),
+                    row_index + 1,
+                    record.len(),
+                    expected
+                ));
+            }
+        } else {
+            expected_columns = Some(record.len());
+        }
+        let mut row = Vec::with_capacity(record.len());
+        for (column_index, field) in record.iter().enumerate() {
+            let field = field.trim();
+            if field.is_empty() || field.eq_ignore_ascii_case("nan") {
+                row.push(None);
+                continue;
+            }
+            let value = field.parse::<f64>().map_err(|err| {
+                format!(
+                    "invalid map value at {} row {}, column {}: {err}",
+                    path.display(),
+                    row_index + 1,
+                    column_index + 1
+                )
+            })?;
+            row.push(value.is_finite().then_some(value));
+        }
+        values.push(row);
+    }
+    if values.is_empty() || expected_columns == Some(0) {
+        return Err(format!("map CSV is empty: {}", path.display()));
+    }
+    Ok(values)
+}
+
+fn read_layout(path: &Path) -> Result<BTreeMap<(usize, usize), Rect32>, String> {
+    let mut reader = csv::Reader::from_path(path)
+        .map_err(|err| format!("failed to open map layout {}: {err}", path.display()))?;
+    let mut layout = BTreeMap::new();
+    for record in reader.deserialize::<LayoutRecord>() {
+        let record =
+            record.map_err(|err| format!("failed to read map layout {}: {err}", path.display()))?;
+        if record.ux <= record.lx || record.uy <= record.ly {
+            return Err(format!(
+                "map layout {} has an invalid rectangle at row {}, column {}",
+                path.display(),
+                record.pixel_row,
+                record.pixel_col
+            ));
+        }
+        layout.insert(
+            (record.pixel_row, record.pixel_col),
+            Rect32 {
+                lx: record.lx,
+                ly: record.ly,
+                hx: record.ux,
+                hy: record.uy,
+            },
+        );
+    }
+    if layout.is_empty() {
+        return Err(format!("map layout is empty: {}", path.display()));
+    }
+    Ok(layout)
+}
+
+fn humanize_category(id: &str) -> String {
+    let base = id
+        .strip_suffix("_map")
+        .or_else(|| id.strip_suffix("_MAP"))
+        .unwrap_or(id);
+    humanize_identifier(base).to_ascii_uppercase()
+}
+
+fn humanize_identifier(value: &str) -> String {
+    value.replace('_', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_directory(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!("chip-viewer-{name}-{unique}"));
+        fs::create_dir_all(&directory).unwrap();
+        directory
+    }
+
+    #[test]
+    fn discovers_map_categories_and_pairs_png_with_csv() {
+        let root = temp_directory("map-catalog");
+        let density = root.join("density_map");
+        fs::create_dir_all(&density).unwrap();
+        fs::write(density.join("place_density.png"), b"preview").unwrap();
+        fs::write(density.join("place_density.csv"), b"0.0,1.0\n").unwrap();
+        fs::write(
+            density.join("layout.csv"),
+            b"pixel_row,pixel_col,lx,ly,ux,uy\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("not_a_category")).unwrap();
+
+        let catalog = MapCatalog::discover(&root).unwrap();
+
+        assert_eq!(catalog.categories.len(), 1);
+        assert_eq!(catalog.categories[0].id, "density_map");
+        assert_eq!(catalog.categories[0].label, "DENSITY");
+        assert_eq!(catalog.categories[0].items.len(), 1);
+        assert!(catalog.categories[0].items[0].csv_path.is_some());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn loads_values_and_pixel_to_layout_coordinates() {
+        let root = temp_directory("map-data");
+        let values = root.join("density.csv");
+        let layout = root.join("layout.csv");
+        fs::write(&values, "0.0,0.5\n1.0,nan\n").unwrap();
+        fs::write(
+            &layout,
+            "pixel_row,pixel_col,grid_x,grid_y,lx,ly,ux,uy\n\
+             0,0,0,1,0,100,10,110\n\
+             0,1,1,1,10,100,20,110\n\
+             1,0,0,0,0,90,10,100\n\
+             1,1,1,0,10,90,20,100\n",
+        )
+        .unwrap();
+
+        let heatmap = HeatmapData::load(&values, &layout).unwrap();
+
+        assert_eq!(heatmap.rows(), 2);
+        assert_eq!(heatmap.columns(), 2);
+        assert_eq!(heatmap.min(), 0.0);
+        assert_eq!(heatmap.max(), 1.0);
+        assert_eq!(heatmap.value(0, 1), Some(0.5));
+        assert_eq!(heatmap.value(1, 1), None);
+        assert_eq!(
+            heatmap.bbox(0, 1),
+            Some(Rect32 {
+                lx: 10,
+                ly: 100,
+                hx: 20,
+                hy: 110,
+            })
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_ragged_value_matrices() {
+        let root = temp_directory("map-ragged");
+        let values = root.join("density.csv");
+        fs::write(&values, "0.0,0.5\n1.0\n").unwrap();
+
+        let error = read_value_matrix(&values).unwrap_err();
+
+        assert!(error.contains("expected 2"));
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/chipViewerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/chipViewerService.test.ts
@@ -30,6 +30,7 @@ const GEOMETRY_SIDMAP = join(GEOMETRY_EPOCH_DIR, 'geometry.sidmap.bin')
 const GEOMETRY_VIEW = join(GEOMETRY_EPOCH_DIR, 'geometry.view.bin')
 const DRC_DATA_PATH = join(STEP_DIRECTORY, 'feature', 'drc.step.json')
 const DRC_STATIS_PATH = join(STEP_DIRECTORY, 'analysis', 'drc_statis.csv')
+const MAP_ROOT_PATH = join(STEP_DIRECTORY, 'feature')
 const EDIT_ROOT_DIR = join(STEP_DIRECTORY, '.chip-viewer', 'layout-edit')
 const EDIT_COMMAND_DIR = join(EDIT_ROOT_DIR, 'commands')
 const EDIT_RESULT_DIR = join(EDIT_ROOT_DIR, 'results')
@@ -519,6 +520,33 @@ describe('ChipViewerService', () => {
         '--drc-statis',
         DRC_STATIS_PATH,
       ],
+      expect.objectContaining({
+        detached: true,
+        stdio: ['ignore', expect.any(Number), expect.any(Number)],
+      }),
+    )
+  })
+
+  it('passes the current step feature directory when map data may be available', async () => {
+    const devBinaries = devChipViewerPaths()
+    const { service, spawnProcess } = createService({
+      existingPaths: [
+        devBinaries.cargoManifest,
+        devBinaries.viewer,
+        GEOMETRY_MANIFEST,
+        MAP_ROOT_PATH,
+      ],
+      files: {},
+    })
+
+    await service.open({
+      projectPath: PROJECT_ROOT,
+      step: STEP_NAME,
+    })
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      devBinaries.viewer,
+      ['--manifest', GEOMETRY_MANIFEST, '--mode', 'view', '--map-root', MAP_ROOT_PATH],
       expect.objectContaining({
         detached: true,
         stdio: ['ignore', expect.any(Number), expect.any(Number)],

--- a/ecos/gui/apps/desktop-electron/electron/services/chipViewerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/chipViewerService.ts
@@ -195,6 +195,7 @@ interface SnapshotInputs {
   gdsPath: string
   imagePath: string
   manifestPath: string
+  mapRootPath?: string
   workspaceStepDirectory: string
 }
 
@@ -611,6 +612,9 @@ export class ChipViewerService {
     if (snapshotInputs.drcStatisPath) {
       viewerArgs.push('--drc-statis', snapshotInputs.drcStatisPath)
     }
+    if (snapshotInputs.mapRootPath) {
+      viewerArgs.push('--map-root', snapshotInputs.mapRootPath)
+    }
     if (mode === 'edit') {
       viewerArgs.push(
         '--edit-command-dir',
@@ -715,6 +719,7 @@ export class ChipViewerService {
     const editDirectory = join(workspaceStepDirectory, '.chip-viewer', 'layout-edit')
     const drcDataPath = join(workspaceStepDirectory, 'feature', 'drc.step.json')
     const drcStatisPath = join(workspaceStepDirectory, 'analysis', 'drc_statis.csv')
+    const mapRootPath = join(workspaceStepDirectory, 'feature')
     const isDrcStep = isDrcWorkspaceStep(step, stepLabel, workspaceStepDirectory)
 
     return {
@@ -728,6 +733,7 @@ export class ChipViewerService {
       gdsPath,
       imagePath,
       manifestPath: join(geometryDir, 'geometry.manifest'),
+      mapRootPath: this.fileExists(mapRootPath) ? mapRootPath : undefined,
       workspaceStepDirectory,
     }
   }


### PR DESCRIPTION
## Summary

- Add a compact DRC/MAP tab switcher and discover categorized `*_map` PNG/CSV data for the active workspace step.
- Render selected CSV data as an interactive heatmap and map clicked cells through `layout.csv` to the corresponding layout coordinates.
- Animate layout focus transitions and decode bounded map thumbnails off the UI thread.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [x] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other:
  - `cd ecos/gui && pnpm install --frozen-lockfile`
  - `cd ecos/gui && pnpm run lint`
  - `cd ecos/gui && pnpm run fmt:check`
  - `python3 .github/scripts/check-version.py`
  - `cd ecos/chip-viewer && cargo fmt --all -- --check`
  - `cd ecos/chip-viewer && cargo test --workspace`
  - Launched `chip-viewer-native` against `ws_0027/place_dreamplace` with its geometry manifest and `feature` map root.

Skipped checks and reason:

- `make build` / Build AppImage was skipped because packaging is excluded from the pre-PR gate and no packaging surface changed.
- `make demo-gcd` and `make demo-retrosoc` are N/A because no ECC flow or demo behavior changed.
- The Electron dev command was not rerun; the native viewer was smoke-tested directly with the real placement workspace and map data.

## Screenshots or Recordings

Required for visible GUI changes.

- Not attached. GNOME denied automated window capture in the development session; the native viewer was manually verified with the real placement workspace.

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Adds desktop runtime behavior only. There are no version, packaging, ECC runtime resource, installer, or submodule changes.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates. (N/A: no submodule changes.)
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
