### PR TITLE
feat(gui): polish workspace interactions

### DIFF
--- a/ecos/gui/apps/renderer/src/components/AIChatPanel.vue
+++ b/ecos/gui/apps/renderer/src/components/AIChatPanel.vue
@@ -247,28 +247,6 @@ const handleKeyDown = (e: KeyboardEvent) => {
 </script>
 
 <style scoped>
-.custom-scrollbar {
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-color) transparent;
-}
-
-.custom-scrollbar::-webkit-scrollbar {
-  width: 6px;
-}
-
-.custom-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.custom-scrollbar::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 3px;
-}
-
-.custom-scrollbar::-webkit-scrollbar-thumb:hover {
-  background: var(--text-secondary);
-}
-
 /* 消息容器约束 - 防止内容撑开父容器 */
 .messages-container {
   contain: layout style;

--- a/ecos/gui/apps/renderer/src/components/DesignFileTransfer.vue
+++ b/ecos/gui/apps/renderer/src/components/DesignFileTransfer.vue
@@ -266,13 +266,4 @@ export default {
   opacity: 0.4;
   cursor: not-allowed;
 }
-
-.custom-scrollbar::-webkit-scrollbar {
-  width: 6px;
-}
-
-.custom-scrollbar::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 9999px;
-}
 </style>

--- a/ecos/gui/apps/renderer/src/components/DesignFilesManageDialog.vue
+++ b/ecos/gui/apps/renderer/src/components/DesignFilesManageDialog.vue
@@ -719,13 +719,4 @@ onUnmounted(() => {
   gap: 12px;
   margin-top: 20px;
 }
-
-.custom-scrollbar::-webkit-scrollbar {
-  width: 6px;
-}
-
-.custom-scrollbar::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 9999px;
-}
 </style>

--- a/ecos/gui/apps/renderer/src/components/FlowLogCodeViewer.vue
+++ b/ecos/gui/apps/renderer/src/components/FlowLogCodeViewer.vue
@@ -488,9 +488,8 @@ onUnmounted(() => {
   top: 0;
   right: 0;
   bottom: 0;
-  width: 20px;
-  border-left: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
-  background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+  width: 8px;
+  background: transparent;
   cursor: grab;
   pointer-events: auto;
   touch-action: none;
@@ -504,18 +503,29 @@ onUnmounted(() => {
 .flow-log-vertical-scrollbar-thumb {
   position: absolute;
   top: 0;
-  right: 4px;
-  left: 4px;
-  min-height: 32px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 8px;
-  background: rgba(166, 166, 176, 0.66);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.36);
+  right: 2px;
+  left: 2px;
+  min-height: 24px;
+  border: 0 solid transparent;
+  border-radius: var(--scrollbar-radius);
+  background-color: transparent;
+  background-clip: padding-box;
 }
 
-.flow-log-vertical-scrollbar:hover .flow-log-vertical-scrollbar-thumb,
+.flow-log-viewer-editor-wrap:hover .flow-log-vertical-scrollbar-thumb,
+.flow-log-viewer-editor-wrap:has(.is-scrolling) .flow-log-vertical-scrollbar-thumb,
 .flow-log-vertical-scrollbar.is-dragging .flow-log-vertical-scrollbar-thumb {
-  background: rgba(196, 196, 208, 0.88);
+  background-color: var(--scrollbar-thumb);
+}
+
+.flow-log-viewer-editor-wrap:hover
+  .flow-log-vertical-scrollbar:hover
+  .flow-log-vertical-scrollbar-thumb,
+.flow-log-viewer-editor-wrap:has(.is-scrolling)
+  .flow-log-vertical-scrollbar:hover
+  .flow-log-vertical-scrollbar-thumb,
+.flow-log-vertical-scrollbar.is-dragging .flow-log-vertical-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb-hover);
 }
 
 :deep(.cm-scroller) {
@@ -524,10 +534,8 @@ onUnmounted(() => {
   overflow-x: hidden;
   overflow-y: scroll;
   overscroll-behavior: contain;
-  /* Keep the log position discoverable even when Chromium uses overlay scrollbars. */
-  scrollbar-color: rgba(190, 196, 207, 0.86) var(--bg-secondary);
-  scrollbar-gutter: stable;
-  scrollbar-width: auto;
+  /* Custom overlay scrollbar matches the app-wide tokens; hide the native bar. */
+  scrollbar-width: none;
 }
 
 :deep(.cm-editor) {
@@ -536,28 +544,8 @@ onUnmounted(() => {
 }
 
 :deep(.cm-scroller::-webkit-scrollbar) {
-  width: 12px;
-}
-
-:deep(.cm-scroller::-webkit-scrollbar-track) {
-  background: var(--bg-secondary);
-  border-left: 1px solid var(--border-color);
-}
-
-:deep(.cm-scroller::-webkit-scrollbar-thumb) {
-  min-height: 32px;
-  background-color: rgba(190, 196, 207, 0.86);
-  border: 2px solid var(--bg-secondary);
-  border-radius: 6px;
-  background-clip: padding-box;
-}
-
-:deep(.cm-scroller::-webkit-scrollbar-thumb:hover) {
-  background-color: var(--accent-color);
-}
-
-:deep(.cm-scroller::-webkit-scrollbar-corner) {
-  background: var(--bg-secondary);
+  width: 0;
+  height: 0;
 }
 
 .flow-log-context-menu {

--- a/ecos/gui/apps/renderer/src/components/LeftSidebar.test.ts
+++ b/ecos/gui/apps/renderer/src/components/LeftSidebar.test.ts
@@ -15,4 +15,13 @@ describe('LeftSidebar workspace navigation', () => {
     expect(source).not.toContain('RTL to GDS Pipeline')
     expect(source).not.toContain('w-[240px]')
   })
+
+  it('keeps sidebar items within the fixed width so labels do not force horizontal scroll', () => {
+    expect(source).toContain('overflow-y-auto')
+    expect(source).not.toContain('overflow-x-hidden')
+    expect(source).toContain('w-full min-w-0')
+    expect(source).toContain('w-full max-w-full')
+    expect(source).toContain('break-words')
+    expect(source).not.toContain('scale-90')
+  })
 })

--- a/ecos/gui/apps/renderer/src/components/LeftSidebar.vue
+++ b/ecos/gui/apps/renderer/src/components/LeftSidebar.vue
@@ -7,7 +7,7 @@
       v-for="stage in flowStages"
       :key="stage.path"
       :to="workspaceStageLink(stage.path)"
-      class="group relative mb-1 flex flex-col items-center justify-center py-4 transition-all"
+      class="group relative mb-1 flex w-full min-w-0 flex-col items-center justify-center px-1 py-4 transition-all"
       :class="[
         currentStage === stage.path ? 'text-(--accent-color)' : 'text-(--text-secondary)',
       ]"
@@ -22,32 +22,34 @@
         <i :class="stage.icon" class="mb-1.5 inline-block text-xl" aria-hidden="true" />
         <i
           v-if="stage.state === 'Success'"
-          class="ri-checkbox-circle-fill absolute -top-1 -right-1 rounded-full bg-(--bg-sidebar) text-[10px] text-green-500"
+          class="ri-checkbox-circle-fill absolute -top-0.5 right-0 rounded-full bg-(--bg-sidebar) text-[10px] text-green-500"
           aria-label="Completed"
         />
         <i
           v-else-if="stage.state === 'Ongoing'"
-          class="ri-loader-4-line absolute -top-1 -right-1 animate-spin rounded-full bg-(--bg-sidebar) text-[10px] text-blue-400"
+          class="ri-loader-4-line absolute -top-0.5 right-0 animate-spin rounded-full bg-(--bg-sidebar) text-[10px] text-blue-400"
           aria-label="Running"
         />
         <i
           v-else-if="stage.state === 'Pending'"
-          class="ri-time-line absolute -top-1 -right-1 rounded-full bg-(--bg-sidebar) text-[10px] text-(--text-secondary)"
+          class="ri-time-line absolute -top-0.5 right-0 rounded-full bg-(--bg-sidebar) text-[10px] text-(--text-secondary)"
           aria-label="Pending"
         />
         <i
           v-else-if="stage.state === 'Invalid'"
-          class="ri-error-warning-fill absolute -top-1 -right-1 rounded-full bg-(--bg-sidebar) text-[10px] text-red-500"
+          class="ri-error-warning-fill absolute -top-0.5 right-0 rounded-full bg-(--bg-sidebar) text-[10px] text-red-500"
           aria-label="Failed"
         />
         <i
           v-else-if="stage.state === 'Incomplete'"
-          class="ri-indeterminate-circle-fill absolute -top-1 -right-1 rounded-full bg-(--bg-sidebar) text-[10px] text-amber-500"
+          class="ri-indeterminate-circle-fill absolute -top-0.5 right-0 rounded-full bg-(--bg-sidebar) text-[10px] text-amber-500"
           aria-label="Incomplete"
         />
       </span>
 
-      <span class="scale-90 text-center text-[9px] leading-tight font-bold uppercase">
+      <span
+        class="w-full max-w-full text-center text-[8px] leading-tight font-bold break-words uppercase"
+      >
         {{ stage.label }}
       </span>
     </router-link>

--- a/ecos/gui/apps/renderer/src/components/NewProjectWizard.test.ts
+++ b/ecos/gui/apps/renderer/src/components/NewProjectWizard.test.ts
@@ -342,8 +342,9 @@ describe('NewProjectWizard workspace wizard redesign', () => {
   })
 
   it('keeps selected PDK resource files in an internal scroll list', () => {
+    expect(source).toContain('pdk-resource-selected-list custom-scrollbar')
     const styleStart = source.indexOf('.pdk-resource-selected-list')
-    const styleEnd = source.indexOf('.custom-scrollbar::-webkit-scrollbar', styleStart)
+    const styleEnd = source.indexOf('.flow-step-connector', styleStart)
     const styleSource = source.slice(styleStart, styleEnd)
 
     expect(styleStart).toBeGreaterThan(-1)

--- a/ecos/gui/apps/renderer/src/components/NewProjectWizard.vue
+++ b/ecos/gui/apps/renderer/src/components/NewProjectWizard.vue
@@ -3087,22 +3087,4 @@ async function createWorkspace() {
     display: flex;
   }
 }
-
-.custom-scrollbar::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-.custom-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.custom-scrollbar::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 10px;
-}
-
-.custom-scrollbar::-webkit-scrollbar-thumb:hover {
-  background: var(--text-secondary);
-}
 </style>

--- a/ecos/gui/apps/renderer/src/components/StepDashboard.test.ts
+++ b/ecos/gui/apps/renderer/src/components/StepDashboard.test.ts
@@ -92,6 +92,9 @@ describe('StepDashboard', () => {
     expect(componentSource).toContain('.data-body.harden-data-body')
     expect(componentSource).toContain('.harden-output-table {')
     expect(componentSource).toContain('.harden-output-table table {')
+    expect(componentSource).toContain(
+      '.harden-output-table th,\n.harden-output-table td {\n  font-size: 11px;',
+    )
     expect(componentSource).toContain('is-sta-report-card')
     expect(componentSource).toContain('grid-auto-rows: minmax(54px, auto)')
     expect(componentSource).toContain('white-space: normal')
@@ -118,10 +121,12 @@ describe('StepDashboard', () => {
       'grid-template-columns: minmax(0, 2fr) minmax(0, 3fr)',
     )
     expect(componentSource).toContain('grid-template-columns: repeat(2, minmax(0, 1fr))')
-    expect(componentSource).toContain('grid-template-rows: repeat(3, minmax(0, 1fr))')
+    expect(componentSource).toContain(
+      'grid-template-rows: repeat(3, minmax(min-content, 1fr))',
+    )
     expect(componentSource).toContain('.basic-info-list > div:last-child')
     expect(componentSource).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))')
-    expect(componentSource).toContain('grid-template-rows: repeat(3, minmax(0, 1fr))')
+    expect(componentSource).toContain('min-height: min-content')
     expect(componentSource).toContain('if (entries.length >= 9) return')
     expect(componentSource).toContain('<span>N/A</span>')
     expect(componentSource).not.toContain('No configuration data')
@@ -161,9 +166,12 @@ describe('StepDashboard', () => {
       'grid-template-columns: minmax(0, 3fr) minmax(0, 1fr)',
     )
     expect(componentSource).toContain('overflow-wrap: anywhere')
-    expect(componentSource).toContain('grid-template-rows: repeat(6, minmax(0, 1fr))')
+    expect(componentSource).toContain(
+      'grid-template-rows: repeat(6, minmax(min-content, 1fr))',
+    )
     expect(componentSource).toContain('.qor-step-list')
-    expect(componentSource).toContain('overflow: hidden')
+    expect(componentSource).toContain('overflow-y: auto')
+    expect(componentSource).toContain('grid-auto-rows: minmax(min-content, 1fr)')
     expect(componentSource).toContain('.qor-metric-current.is-neutral')
     expect(componentSource).toContain('grid-template-columns: repeat(2, minmax(0, 1fr))')
     expect(componentSource).not.toContain('<dt>Baseline</dt>')

--- a/ecos/gui/apps/renderer/src/components/StepDashboard.vue
+++ b/ecos/gui/apps/renderer/src/components/StepDashboard.vue
@@ -1525,64 +1525,6 @@ function fileName(path: string): string {
   position: relative;
 }
 
-.step-dashboard-card::before {
-  background:
-    linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      top left / 23px 2px no-repeat,
-    linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      top left / 2px 23px no-repeat,
-    linear-gradient(
-        270deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      top right / 23px 2px no-repeat,
-    linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      top right / 2px 23px no-repeat,
-    linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      bottom left / 23px 2px no-repeat,
-    linear-gradient(
-        0deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      bottom left / 2px 23px no-repeat,
-    linear-gradient(
-        270deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      bottom right / 23px 2px no-repeat,
-    linear-gradient(
-        0deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      bottom right / 2px 23px no-repeat;
-  content: '';
-  filter: drop-shadow(0 0 3px color-mix(in srgb, var(--success-color) 48%, transparent));
-  inset: -1px;
-  pointer-events: none;
-  position: absolute;
-  z-index: 2;
-}
-
 .step-dashboard-header {
   align-items: center;
   border-bottom: 1px solid var(--border-color);
@@ -1734,14 +1676,16 @@ function fileName(path: string): string {
 }
 
 .basic-info-list {
+  align-content: start;
   display: grid;
   flex: 1;
   gap: 4px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-template-rows: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(min-content, 1fr));
   margin: 0;
   min-height: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 6px;
 }
 
@@ -1752,6 +1696,7 @@ function fileName(path: string): string {
   flex-direction: column;
   gap: 3px;
   justify-content: center;
+  min-height: min-content;
   min-width: 0;
   padding: 5px 7px;
 }
@@ -1798,14 +1743,16 @@ function fileName(path: string): string {
 }
 
 .config-preview-grid {
+  align-content: start;
   display: grid;
   flex: 1;
   gap: 4px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  grid-template-rows: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(min-content, 1fr));
   margin: 0;
   min-height: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 6px;
 }
 
@@ -1814,13 +1761,14 @@ function fileName(path: string): string {
   border: 1px solid color-mix(in srgb, var(--border-color) 75%, transparent);
   display: flex;
   flex-direction: column;
+  gap: 3px;
   justify-content: center;
+  min-height: min-content;
   min-width: 0;
   padding: 5px 7px;
 }
 
 .config-preview-grid dd {
-  margin-top: 3px;
   text-align: left;
 }
 
@@ -1979,21 +1927,24 @@ function fileName(path: string): string {
   border-right: 1px solid var(--border-color);
 }
 .qor-step-list {
+  align-content: start;
   display: grid;
   gap: 4px 6px;
-  grid-auto-rows: minmax(0, 1fr);
+  grid-auto-rows: minmax(min-content, 1fr);
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-template-rows: repeat(6, minmax(0, 1fr));
+  grid-template-rows: repeat(6, minmax(min-content, 1fr));
   min-width: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 5px 6px;
 }
 .qor-step-row {
   border: 1px solid color-mix(in srgb, var(--border-color) 75%, transparent);
   display: flex;
   flex-direction: column;
+  gap: 4px;
   justify-content: center;
-  min-height: 0;
+  min-height: min-content;
   min-width: 0;
   overflow: hidden;
   padding: 2px 4px;
@@ -2001,10 +1952,11 @@ function fileName(path: string): string {
 .qor-step-link {
   align-items: center;
   display: grid;
+  flex: 0 0 auto;
   gap: 4px;
   grid-template-columns: auto minmax(0, 1fr);
-  min-height: 0;
   min-width: 0;
+  overflow: hidden;
 }
 .qor-step-link strong {
   color: var(--text-primary);
@@ -2060,9 +2012,9 @@ function fileName(path: string): string {
 .qor-step-trend {
   align-items: center;
   display: grid;
+  flex: 0 0 auto;
   gap: 6px;
   grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
-  margin: 6px 0 0;
   min-width: 0;
 }
 .qor-step-trend-bar {
@@ -2211,12 +2163,15 @@ function fileName(path: string): string {
   margin: 0;
 }
 .synthesis-value-grid {
+  align-content: start;
   display: grid;
   flex: 1;
   gap: 4px;
-  grid-auto-rows: minmax(0, 1fr);
+  grid-auto-rows: minmax(min-content, 1fr);
   grid-template-columns: repeat(2, minmax(0, 1fr));
   min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 6px;
 }
 .synthesis-value-grid > div,
@@ -2232,6 +2187,7 @@ function fileName(path: string): string {
   flex-direction: column;
   gap: 3px;
   justify-content: center;
+  min-height: min-content;
   padding: 5px 7px;
 }
 .synthesis-value-grid dt,
@@ -2309,12 +2265,13 @@ function fileName(path: string): string {
   padding-top: 5px;
 }
 .floorplan-metrics-grid {
-  grid-auto-rows: minmax(0, 1fr);
+  grid-auto-rows: minmax(min-content, 1fr);
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 .floorplan-metrics-grid > div {
   gap: 4px;
   justify-content: flex-start;
+  min-height: min-content;
   padding: 6px 7px;
 }
 .floorplan-metric-label {
@@ -2415,7 +2372,7 @@ function fileName(path: string): string {
   flex: 1;
   min-height: 0;
   min-width: 0;
-  overflow: hidden;
+  overflow: auto;
   padding: 5px 6px 6px;
 }
 .insight-table-wrap table {
@@ -2475,21 +2432,33 @@ function fileName(path: string): string {
 }
 .harden-output-table th:first-child,
 .harden-output-table td:first-child {
-  width: 52px;
+  width: 56px;
 }
 .harden-output-table {
-  padding: 0;
+  overflow: auto;
+  padding: 6px;
   width: 100%;
 }
 .harden-output-table table {
   width: 100%;
 }
+.harden-output-table th,
+.harden-output-table td {
+  font-size: 11px;
+  line-height: 1.35;
+  padding: 7px 8px;
+}
+.harden-output-table thead th {
+  font-size: 10px;
+}
 .harden-output-table th:last-child,
 .harden-output-table td:last-child {
-  width: 92px;
+  width: 104px;
 }
 .harden-output-table td:nth-child(2) {
-  line-height: 1.35;
+  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  font-size: 10px;
+  line-height: 1.4;
   overflow-wrap: anywhere;
   text-align: left;
   text-overflow: clip;
@@ -2498,9 +2467,13 @@ function fileName(path: string): string {
 .harden-output-state {
   align-items: center;
   display: inline-flex;
-  gap: 3px;
+  font-size: 11px;
+  gap: 4px;
   justify-content: flex-end;
   white-space: nowrap;
+}
+.harden-output-state > i {
+  font-size: 12px;
 }
 .harden-output-table tr.is-available .harden-output-state {
   color: var(--success-color);

--- a/ecos/gui/apps/renderer/src/components/TopBar.test.ts
+++ b/ecos/gui/apps/renderer/src/components/TopBar.test.ts
@@ -67,6 +67,18 @@ describe('TopBar drag region layout', () => {
     expect(topBarSource).toContain("path: '/projects'")
   })
 
+  it('returns to Project Management with the current workspace focus query', () => {
+    const goStart = topBarSource.indexOf('const goToProjectManagement')
+    const goEnd = topBarSource.indexOf('const handleClickOutside', goStart)
+    const goSource = topBarSource.slice(goStart, goEnd)
+
+    expect(goSource).toContain('workspaceId')
+    expect(goSource).toContain('projectRoot')
+    expect(goSource).toContain("path: '/projects'")
+    expect(goSource).toContain('query')
+    expect(topBarSource).toContain('route.query.workspaceId')
+  })
+
   it('teleports the workspace quick menu outside the app container clipping area', () => {
     expect(topBarSource).toContain('<Teleport to="body">')
     expect(topBarSource).toContain(':style="quickMenuStyle"')

--- a/ecos/gui/apps/renderer/src/components/TopBar.vue
+++ b/ecos/gui/apps/renderer/src/components/TopBar.vue
@@ -218,6 +218,11 @@ const emit = defineEmits<{
   (e: 'menu-action', action: AppMenuAction): void
 }>()
 
+const workspaceFocusId = computed(
+  () =>
+    queryString(route.query.workspaceId) || workspaceIdFromProjectName(props.projectName),
+)
+
 const themeStore = useThemeStore()
 const isDark = computed(() => themeStore.themeName === 'dark')
 const desktopApi = ref<DesktopApi | null>(getOptionalDesktopApi())
@@ -296,6 +301,11 @@ function queryString(value: unknown): string {
   return typeof value === 'string' ? value : ''
 }
 
+function workspaceIdFromProjectName(projectName?: string | null): string {
+  if (!projectName) return ''
+  return projectName.split(/[/\\]/).filter(Boolean).pop() ?? ''
+}
+
 /** 切换菜单展开/收起 */
 const toggleMenu = (action: string) => {
   quickMenuOpen.value = false
@@ -338,12 +348,12 @@ const toggleQuickMenu = async () => {
 
 const goToProjectManagement = () => {
   quickMenuOpen.value = false
-  const query = workspaceProjectRoot.value
-    ? {
-        projectRoot: workspaceProjectRoot.value,
-        projectName: workspaceProjectName.value || undefined,
-      }
-    : {}
+  const query: Record<string, string> = {}
+  if (workspaceProjectRoot.value) {
+    query.projectRoot = workspaceProjectRoot.value
+    if (workspaceProjectName.value) query.projectName = workspaceProjectName.value
+  }
+  if (workspaceFocusId.value) query.workspaceId = workspaceFocusId.value
   router.push({
     path: '/projects',
     query,

--- a/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.test.ts
+++ b/ecos/gui/apps/renderer/src/components/flowLogCodeViewer.test.ts
@@ -715,18 +715,22 @@ describe('flowLogCodeViewer helpers', () => {
     expect(flowLogCodeViewerSource).toContain(
       "window.removeEventListener?.('pointermove', onFlowLogScrollbarPointerMove)",
     )
-    expect(flowLogCodeViewerSource).toContain('width: 20px')
-    expect(flowLogCodeViewerSource).toContain('background: rgba(166, 166, 176, 0.66)')
+    expect(flowLogCodeViewerSource).toContain('width: 8px')
+    expect(flowLogCodeViewerSource).toContain('background-color: var(--scrollbar-thumb)')
+    expect(flowLogCodeViewerSource).toContain(
+      'background-color: var(--scrollbar-thumb-hover)',
+    )
+    expect(flowLogCodeViewerSource).toContain(
+      '.flow-log-viewer-editor-wrap:hover .flow-log-vertical-scrollbar-thumb',
+    )
+    expect(flowLogCodeViewerSource).toContain(
+      '.flow-log-viewer-editor-wrap:has(.is-scrolling)',
+    )
+    expect(flowLogCodeViewerSource).toContain('border-radius: var(--scrollbar-radius)')
     expect(flowLogCodeViewerSource).toContain(':deep(.cm-scroller)')
     expect(flowLogCodeViewerSource).toContain('overflow-y: scroll')
-    expect(flowLogCodeViewerSource).toContain('scrollbar-gutter: stable')
-    expect(flowLogCodeViewerSource).toContain('scrollbar-width: auto')
+    expect(flowLogCodeViewerSource).toContain('scrollbar-width: none')
     expect(flowLogCodeViewerSource).toContain('overscroll-behavior: contain')
-    expect(flowLogCodeViewerSource).toContain('width: 12px')
-    expect(flowLogCodeViewerSource).toContain('background: var(--bg-secondary)')
-    expect(flowLogCodeViewerSource).toContain(
-      'background-color: rgba(190, 196, 207, 0.86)',
-    )
   })
 
   it('renders a blinking terminal cursor while live log content is visible', () => {

--- a/ecos/gui/apps/renderer/src/components/home/StatusPieChart.test.ts
+++ b/ecos/gui/apps/renderer/src/components/home/StatusPieChart.test.ts
@@ -2,15 +2,27 @@ import { describe, expect, it } from 'vitest'
 import statusPieChartSource from './StatusPieChart.vue?raw'
 
 describe('StatusPieChart', () => {
-  it('supports opt-in external slice labels with colored leader lines', () => {
+  it('uses an HTML legend instead of clipped ECharts callout labels', () => {
     expect(statusPieChartSource).toContain('showLabels?: boolean')
-    expect(statusPieChartSource).toContain("radius: props.showLabels ? ['42%', '66%']")
-    expect(statusPieChartSource).toContain("formatter: '{b} {c}'")
-    expect(statusPieChartSource).toContain('show: props.showLabels ?? false')
-    expect(statusPieChartSource).toContain('length: 7')
-    expect(statusPieChartSource).toContain('length2: 8')
-    expect(statusPieChartSource).toContain('label: { color }')
-    expect(statusPieChartSource).toContain('labelLine: { lineStyle: { color } }')
+    expect(statusPieChartSource).toContain('class="status-pie-legend"')
+    expect(statusPieChartSource).toContain('v-if="showLabels && slices.length"')
+    expect(statusPieChartSource).toContain("radius: props.showLabels ? ['48%', '70%']")
+    expect(statusPieChartSource).toContain('label: { show: false }')
+    expect(statusPieChartSource).toContain('labelLine: { show: false }')
     expect(statusPieChartSource).toContain('slice.color ?? colorForTone(slice.tone)')
+  })
+
+  it('keeps unlabeled chart wrappers filling their parent height for snapshot tiles', () => {
+    expect(statusPieChartSource).toContain(
+      '.status-pie,\n.status-pie-chart-wrap,\n.status-pie-empty {\n  height: 100%;',
+    )
+    expect(statusPieChartSource).toContain(
+      '.status-pie.has-legend .status-pie-chart-wrap {\n  flex: 1 1 auto;\n  height: auto;',
+    )
+  })
+
+  it('renders tooltips outside overflow-clipped chart containers', () => {
+    expect(statusPieChartSource).toContain("appendTo: 'body'")
+    expect(statusPieChartSource).toContain('confine: false')
   })
 })

--- a/ecos/gui/apps/renderer/src/components/home/StatusPieChart.vue
+++ b/ecos/gui/apps/renderer/src/components/home/StatusPieChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="status-pie" :aria-label="label" role="img">
+  <div
+    class="status-pie"
+    :class="{ 'has-legend': showLabels && slices.length }"
+    :aria-label="label"
+    role="img"
+  >
     <div v-if="slices.length" class="status-pie-chart-wrap">
       <div ref="chartElement" class="status-pie-chart" />
       <div v-if="centerPrimary" class="status-pie-center" aria-hidden="true">
@@ -7,7 +12,14 @@
         <span v-if="centerSecondary">{{ centerSecondary }}</span>
       </div>
     </div>
-    <div v-else class="status-pie-empty">No data</div>
+    <ul v-if="showLabels && slices.length" class="status-pie-legend">
+      <li v-for="slice in slices" :key="slice.id">
+        <i aria-hidden="true" :style="{ backgroundColor: colorForSlice(slice) }" />
+        <span :title="slice.label">{{ slice.label }}</span>
+        <strong>{{ slice.value }}</strong>
+      </li>
+    </ul>
+    <div v-else-if="!slices.length" class="status-pie-empty">No data</div>
   </div>
 </template>
 
@@ -57,40 +69,35 @@ async function renderChart(): Promise<void> {
   chart ??= echarts.init(target)
   resizeObserver ??= new ResizeObserver(() => chart?.resize())
   resizeObserver.observe(target)
-  chart.setOption({
-    animationDuration: 180,
-    color: props.slices.map(colorForSlice),
-    series: [
-      {
-        type: 'pie',
-        radius: props.showLabels ? ['42%', '66%'] : ['54%', '78%'],
-        avoidLabelOverlap: true,
-        label: {
-          color: 'inherit',
-          fontSize: 10,
-          fontWeight: 600,
-          formatter: '{b} {c}',
-          show: props.showLabels ?? false,
-        },
-        labelLine: {
-          length: 7,
-          length2: 8,
-          lineStyle: { width: 1 },
-          show: props.showLabels ?? false,
-        },
-        data: props.slices.map((slice) => {
-          const color = colorForSlice(slice)
-          return {
+  chart.setOption(
+    {
+      animationDuration: 180,
+      color: props.slices.map(colorForSlice),
+      series: [
+        {
+          type: 'pie',
+          // Keep the ring compact so it stays clear above the HTML legend.
+          radius: props.showLabels ? ['48%', '70%'] : ['54%', '78%'],
+          center: ['50%', '50%'],
+          avoidLabelOverlap: true,
+          label: { show: false },
+          labelLine: { show: false },
+          data: props.slices.map((slice) => ({
             name: slice.label,
             value: slice.value,
-            label: { color },
-            labelLine: { lineStyle: { color } },
-          }
-        }),
+            itemStyle: { color: colorForSlice(slice) },
+          })),
+        },
+      ],
+      tooltip: {
+        appendTo: 'body',
+        confine: false,
+        trigger: 'item',
+        valueFormatter: (value: number) => String(value),
       },
-    ],
-    tooltip: { trigger: 'item', valueFormatter: (value: number) => String(value) },
-  })
+    },
+    { notMerge: true },
+  )
 }
 
 watch(
@@ -115,9 +122,21 @@ onBeforeUnmount(() => {
   width: 100%;
 }
 
+.status-pie.has-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .status-pie-chart-wrap {
   min-height: 92px;
   position: relative;
+}
+
+.status-pie.has-legend .status-pie-chart-wrap {
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 96px;
 }
 
 .status-pie-chart {
@@ -152,11 +171,57 @@ onBeforeUnmount(() => {
   margin-top: 2px;
 }
 
+.status-pie-legend {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 3px 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  list-style: none;
+  margin: 0;
+  min-width: 0;
+  padding: 0 2px;
+}
+
+.status-pie-legend li {
+  align-items: center;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: 6px minmax(0, 1fr) auto;
+  min-width: 0;
+}
+
+.status-pie-legend i {
+  border-radius: 50%;
+  flex: 0 0 auto;
+  height: 6px;
+  width: 6px;
+}
+
+.status-pie-legend span {
+  color: var(--text-secondary);
+  font-size: 9px;
+  line-height: 1.2;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-pie-legend strong {
+  color: var(--text-primary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
 .status-pie-empty {
   align-items: center;
   color: var(--text-secondary);
   display: flex;
+  flex: 1;
   font-size: 10px;
+  height: 100%;
   justify-content: center;
 }
 </style>

--- a/ecos/gui/apps/renderer/src/components/projectStepAnalysisPanel.css
+++ b/ecos/gui/apps/renderer/src/components/projectStepAnalysisPanel.css
@@ -19,7 +19,6 @@
   border-bottom: 1px solid var(--border-color);
   background: color-mix(in srgb, var(--bg-secondary) 60%, var(--bg-primary));
   overflow-x: auto;
-  scrollbar-width: thin;
 }
 
 .step-rail-item {
@@ -247,7 +246,6 @@
   margin: 0;
   padding: 0;
   overflow: auto;
-  scrollbar-width: thin;
   list-style: none;
 }
 
@@ -1682,7 +1680,6 @@
     width: 100%;
     padding-bottom: 2px;
     overflow-x: auto;
-    scrollbar-width: thin;
   }
 
   .severity-filters button {

--- a/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.test.ts
+++ b/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.test.ts
@@ -26,4 +26,14 @@ describe('FlowLogPanel embedded controls', () => {
   it('keeps the embedded viewer constrained so its log text can scroll', () => {
     expect(source).toContain('.flow-log-viewer {\n  display: flex;')
   })
+
+  it('lets the open-log dialog fill the viewport when maximized', () => {
+    expect(source).toContain('class="flow-log-dialog"')
+    expect(source).toContain('maximizable')
+    expect(source).toContain(
+      '.flow-log-dialog.p-dialog-maximized .flow-log-dialog-content',
+    )
+    expect(source).toContain('max-height: none')
+    expect(source).toContain('height: 100vh')
+  })
 })

--- a/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.vue
+++ b/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.vue
@@ -64,6 +64,7 @@
 
   <Dialog
     v-model:visible="dialogVisible"
+    class="flow-log-dialog"
     modal
     maximizable
     :header="logTitle"
@@ -294,10 +295,36 @@ onBeforeUnmount(() => {
   line-height: 1.5;
   margin: 0;
   max-height: min(70vh, 760px);
+  min-height: 0;
   overflow: auto;
   padding: 12px;
   user-select: text;
   white-space: pre-wrap;
   word-break: break-word;
+}
+</style>
+
+<!-- Dialog teleports to body; keep maximize layout rules unscoped. -->
+<style>
+.flow-log-dialog.p-dialog-maximized {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-height: 100vh;
+  width: 100vw;
+}
+
+.flow-log-dialog.p-dialog-maximized .p-dialog-content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.flow-log-dialog.p-dialog-maximized .flow-log-dialog-content {
+  flex: 1 1 auto;
+  height: 100%;
+  max-height: none;
 }
 </style>

--- a/ecos/gui/apps/renderer/src/main.ts
+++ b/ecos/gui/apps/renderer/src/main.ts
@@ -11,7 +11,10 @@ import '@fontsource/noto-sans-sc/500.css'
 import '@fontsource/noto-sans-sc/600.css'
 import '@fontsource/noto-sans-sc/700.css'
 import './styles/index.css'
+import { installScrollbarReveal } from './styles/scrollbarReveal'
 import 'remixicon/fonts/remixicon.css'
+
+installScrollbarReveal()
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/ecos/gui/apps/renderer/src/styles/index.css
+++ b/ecos/gui/apps/renderer/src/styles/index.css
@@ -31,6 +31,14 @@
   --warn-color: #d97706;
   --warn-bg: rgba(217, 119, 6, 0.12);
 
+  /* Match Flow Log overlay: ~4px thumb inside an 8px transparent gutter */
+  --scrollbar-size: 8px;
+  --scrollbar-thumb-inset: 2px;
+  --scrollbar-radius: 9999px;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: color-mix(in srgb, var(--text-secondary) 18%, transparent);
+  --scrollbar-thumb-hover: color-mix(in srgb, var(--text-secondary) 36%, transparent);
+
   color-scheme: light dark;
 
   /* 禁用浏览器的自动缩放 */
@@ -143,23 +151,49 @@ body.window-maximized #app {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* 优化滚动性能 */
+/*
+ * Unified app scrollbars — visual match for Flow Log's custom overlay.
+ * Only ::-webkit-scrollbar* is used. Chromium's standard scrollbar-width /
+ * scrollbar-color properties switch to the thicker platform scrollbar and
+ * must not be set here.
+ *
+ * Thumb stays invisible until the scrollable area is hovered or receives
+ * the .is-scrolling class (see scrollbarReveal.ts).
+ */
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
+  background: transparent;
 }
 
-::-webkit-scrollbar-track {
-  background: var(--bg-secondary);
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-track-piece {
+  background: var(--scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 4px;
+  background-color: transparent;
+  background-clip: padding-box;
+  border: var(--scrollbar-thumb-inset) solid transparent;
+  border-radius: var(--scrollbar-radius);
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: var(--text-secondary);
+*:hover::-webkit-scrollbar-thumb,
+*.is-scrolling::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+}
+
+*:hover::-webkit-scrollbar-thumb:hover,
+*.is-scrolling::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}
+
+::-webkit-scrollbar-button,
+::-webkit-scrollbar-corner {
+  display: none;
+  width: 0;
+  height: 0;
+  background: transparent;
 }
 
 /* 优化过渡和动画性能 */

--- a/ecos/gui/apps/renderer/src/styles/index.scrollbar.test.ts
+++ b/ecos/gui/apps/renderer/src/styles/index.scrollbar.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const styleSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'index.css'),
+  'utf8',
+)
+const revealSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'scrollbarReveal.ts'),
+  'utf8',
+)
+const mainSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '../main.ts'),
+  'utf8',
+)
+
+describe('global scrollbar styles', () => {
+  it('defines shared scrollbar tokens and WebKit-only app-wide styling', () => {
+    expect(styleSource).toContain('--scrollbar-size: 8px')
+    expect(styleSource).toContain('--scrollbar-thumb-inset: 2px')
+    expect(styleSource).toContain('--scrollbar-thumb:')
+    expect(styleSource).toContain('--scrollbar-thumb-hover:')
+    expect(styleSource).toContain('--scrollbar-track:')
+    expect(styleSource).toContain('::-webkit-scrollbar {')
+    expect(styleSource).toContain('width: var(--scrollbar-size)')
+    expect(styleSource).toContain(
+      'border: var(--scrollbar-thumb-inset) solid transparent',
+    )
+    expect(styleSource).toContain('background-color: transparent')
+    expect(styleSource).toContain('*:hover::-webkit-scrollbar-thumb')
+    expect(styleSource).toContain('*.is-scrolling::-webkit-scrollbar-thumb')
+    expect(styleSource).toContain('background-color: var(--scrollbar-thumb)')
+    expect(styleSource).toContain('background-color: var(--scrollbar-thumb-hover)')
+    expect(styleSource).not.toContain('scrollbar-width:')
+    expect(styleSource).not.toContain('scrollbar-color:')
+  })
+
+  it('reveals scrollbars while scrolling via a document-level listener', () => {
+    expect(revealSource).toContain("const SCROLLING_CLASS = 'is-scrolling'")
+    expect(revealSource).toContain('classList.add(SCROLLING_CLASS)')
+    expect(revealSource).toContain("'scroll'")
+    expect(revealSource).toContain("'wheel'")
+    expect(mainSource).toContain('installScrollbarReveal()')
+  })
+})

--- a/ecos/gui/apps/renderer/src/styles/scrollbarReveal.ts
+++ b/ecos/gui/apps/renderer/src/styles/scrollbarReveal.ts
@@ -1,0 +1,58 @@
+const SCROLLING_CLASS = 'is-scrolling'
+const HIDE_DELAY_MS = 900
+
+const hideTimers = new WeakMap<Element, ReturnType<typeof setTimeout>>()
+
+function markScrolling(target: Element): void {
+  target.classList.add(SCROLLING_CLASS)
+  const previous = hideTimers.get(target)
+  if (previous !== undefined) clearTimeout(previous)
+  hideTimers.set(
+    target,
+    setTimeout(() => {
+      target.classList.remove(SCROLLING_CLASS)
+      hideTimers.delete(target)
+    }, HIDE_DELAY_MS),
+  )
+}
+
+function findScrollableAncestor(start: Element | null): Element | null {
+  let element = start
+  while (element) {
+    const style = window.getComputedStyle(element)
+    const canScrollY =
+      (style.overflowY === 'auto' ||
+        style.overflowY === 'scroll' ||
+        style.overflowY === 'overlay') &&
+      element.scrollHeight > element.clientHeight
+    const canScrollX =
+      (style.overflowX === 'auto' ||
+        style.overflowX === 'scroll' ||
+        style.overflowX === 'overlay') &&
+      element.scrollWidth > element.clientWidth
+    if (canScrollY || canScrollX) return element
+    element = element.parentElement
+  }
+  return null
+}
+
+/** Show overlay scrollbars while the user scrolls; CSS hides them again afterward. */
+export function installScrollbarReveal(): void {
+  document.addEventListener(
+    'scroll',
+    (event) => {
+      if (event.target instanceof Element) markScrolling(event.target)
+    },
+    true,
+  )
+
+  document.addEventListener(
+    'wheel',
+    (event) => {
+      const scrollable =
+        event.target instanceof Element ? findScrollableAncestor(event.target) : null
+      if (scrollable) markScrolling(scrollable)
+    },
+    { capture: true, passive: true },
+  )
+}

--- a/ecos/gui/apps/renderer/src/utils/projectManifestRegistration.test.ts
+++ b/ecos/gui/apps/renderer/src/utils/projectManifestRegistration.test.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WorkspaceConfig } from '@/types'
 import {
+  createProjectManifestDraft,
+  registerWorkspaceInManifest,
+} from '@/utils/projectManagement'
+import {
   projectContextFromWorkspaceConfig,
   registerProjectManagedWorkspace,
+  resolveProjectRouteContextForWorkspace,
 } from './projectManifestRegistration'
 
 const registerProjectRoot = vi.fn()
 const mutateProjectManifest = vi.fn()
+const readOptionalProjectTextFile = vi.fn()
 
 vi.mock('@/platform/desktop', () => ({
   waitForDesktopApi: vi.fn(async () => ({
@@ -20,10 +26,16 @@ vi.mock('@/api/projectManifest', () => ({
   mutateProjectManifest: (...args: unknown[]) => mutateProjectManifest(...args),
 }))
 
+vi.mock('@/utils/projectFiles', () => ({
+  readOptionalProjectTextFile: (...args: unknown[]) =>
+    readOptionalProjectTextFile(...args),
+}))
+
 describe('projectManifestRegistration', () => {
   beforeEach(() => {
     registerProjectRoot.mockReset()
     mutateProjectManifest.mockReset()
+    readOptionalProjectTextFile.mockReset()
     registerProjectRoot.mockImplementation(async (path: string) => path)
     mutateProjectManifest.mockResolvedValue(undefined)
   })
@@ -98,5 +110,43 @@ describe('projectManifestRegistration', () => {
     })
 
     expect(mutateProjectManifest).not.toHaveBeenCalled()
+  })
+
+  it('resolves project route context from a parent project.json that lists the workspace', async () => {
+    const manifest = registerWorkspaceInManifest(
+      createProjectManifestDraft({
+        rootPath: '/projects/gcd',
+        name: 'gcd',
+        now: '2026-08-04T00:00:00.000Z',
+      }),
+      {
+        projectRoot: '/projects/gcd',
+        workspacePath: '/projects/gcd/ws_0036',
+        now: '2026-08-04T00:00:00.000Z',
+      },
+    )
+    readOptionalProjectTextFile.mockResolvedValue(JSON.stringify(manifest))
+
+    await expect(
+      resolveProjectRouteContextForWorkspace('/projects/gcd/ws_0036'),
+    ).resolves.toEqual({
+      projectRoot: '/projects/gcd',
+      projectName: 'gcd',
+    })
+
+    expect(registerProjectRoot).toHaveBeenCalledWith('/projects/gcd')
+    expect(registerProjectRoot).toHaveBeenCalledWith('/projects/gcd/ws_0036')
+    expect(readOptionalProjectTextFile).toHaveBeenCalledWith('project.json', {
+      projectPath: '/projects/gcd',
+    })
+  })
+
+  it('returns null when the parent directory is not a managed project for the workspace', async () => {
+    readOptionalProjectTextFile.mockResolvedValue(null)
+
+    await expect(
+      resolveProjectRouteContextForWorkspace('/workspaces/orphan/ws_0001'),
+    ).resolves.toBeNull()
+    expect(registerProjectRoot).toHaveBeenCalledWith('/workspaces/orphan/ws_0001')
   })
 })

--- a/ecos/gui/apps/renderer/src/utils/projectManifestRegistration.ts
+++ b/ecos/gui/apps/renderer/src/utils/projectManifestRegistration.ts
@@ -1,6 +1,8 @@
 import type { WorkspaceConfig } from '@/types'
 import { waitForDesktopApi } from '@/platform/desktop'
 import { mutateProjectManifest } from '@/api/projectManifest'
+import { readOptionalProjectTextFile } from '@/utils/projectFiles'
+import { parseProjectManifest } from '@/utils/projectManagement'
 
 export interface ProjectRouteContext {
   projectRoot: string
@@ -33,6 +35,47 @@ export function projectContextFromWorkspaceConfig(
       typeof projectContext.project_name === 'string'
         ? projectContext.project_name
         : undefined,
+  }
+}
+
+/**
+ * Infers the parent project for a workspace opened outside Project Management
+ * (for example Backend Design recent workspaces) when the parent directory has a
+ * project.json that already lists that workspace.
+ */
+export async function resolveProjectRouteContextForWorkspace(
+  workspacePath: string,
+): Promise<ProjectRouteContext | null> {
+  const normalizedWorkspace = normalizePath(workspacePath)
+  if (!normalizedWorkspace) return null
+
+  const projectRoot = parentPath(normalizedWorkspace)
+  if (!projectRoot || projectRoot === normalizedWorkspace) return null
+
+  try {
+    const registeredProjectRoot = await registerLocalProjectRoot(projectRoot)
+    if (!registeredProjectRoot) return null
+
+    const manifestText = await readOptionalProjectTextFile('project.json', {
+      projectPath: registeredProjectRoot,
+    })
+    if (!manifestText) return null
+
+    const manifest = parseProjectManifest(manifestText)
+    const listed = manifest.workspaces.some(
+      (workspace) => normalizePath(workspace.workspace_path) === normalizedWorkspace,
+    )
+    if (!listed) return null
+
+    return {
+      projectRoot: registeredProjectRoot,
+      projectName: manifest.name || basenamePath(registeredProjectRoot) || undefined,
+    }
+  } catch (error) {
+    console.warn('Failed to resolve project context for workspace.', error)
+    return null
+  } finally {
+    await registerLocalProjectRoot(normalizedWorkspace)
   }
 }
 
@@ -121,4 +164,12 @@ function normalizePath(path: string): string {
   const normalized = path.replace(/\\/g, '/')
   if (normalized.endsWith('/') && normalized.length > 1) return normalized.slice(0, -1)
   return normalized
+}
+
+function parentPath(path: string): string {
+  const normalized = normalizePath(path)
+  const parts = normalized.split('/').filter(Boolean)
+  if (parts.length <= 1) return normalized.startsWith('/') ? '/' : ''
+  const parent = parts.slice(0, -1).join('/')
+  return normalized.startsWith('/') ? `/${parent}` : parent
 }

--- a/ecos/gui/apps/renderer/src/views/ECCView.project-prefill.test.ts
+++ b/ecos/gui/apps/renderer/src/views/ECCView.project-prefill.test.ts
@@ -143,6 +143,37 @@ describe('ECCView project management handoff', () => {
     expect(openSource).toContain('workspacePath: currentProject.value.path')
   })
 
+  it('resolves project route context when Backend Design opens an existing workspace', () => {
+    expect(source).toContain('resolveProjectRouteContextForWorkspace')
+    expect(source).toContain('resolveOpenProjectContext')
+
+    const openStart = source.indexOf('const handleOpenProject')
+    const openEnd = source.indexOf('const handleOpenRecent', openStart)
+    const openSource = source.slice(openStart, openEnd)
+    expect(openSource).toContain(
+      'await resolveOpenProjectContext(currentProject.value.path)',
+    )
+    expect(openSource).toContain('projectContext,')
+    expect(openSource).toContain(
+      'query: workspaceRouteQuery(currentProject.value.path, projectContext)',
+    )
+
+    const recentStart = source.indexOf('const handleOpenRecent')
+    const recentEnd = source.indexOf('const handleRemoveRecent', recentStart)
+    const recentSource = source.slice(recentStart, recentEnd)
+    expect(recentSource).toContain('await resolveOpenProjectContext(workspacePath)')
+    expect(recentSource).toContain('projectContext,')
+    expect(recentSource).toContain('workspaceRouteQuery(workspacePath, projectContext)')
+
+    const resolveStart = source.indexOf('async function resolveOpenProjectContext')
+    const resolveEnd = source.indexOf('function workspaceRouteQuery', resolveStart)
+    const resolveSource = source.slice(resolveStart, resolveEnd)
+    expect(resolveSource).toContain(
+      'await resolveProjectRouteContextForWorkspace(workspacePath)',
+    )
+    expect(resolveSource).toContain('queryString(route.query.projectRoot)')
+  })
+
   it('registers the project root before updating project.json from ECC', () => {
     expect(source).toContain('@/utils/projectManifestRegistration')
     expect(source).toContain('await registerProjectManagedWorkspace({')

--- a/ecos/gui/apps/renderer/src/views/ECCView.vue
+++ b/ecos/gui/apps/renderer/src/views/ECCView.vue
@@ -213,6 +213,7 @@ import { readOptionalProjectTextFile } from '@/utils/projectFiles'
 import {
   projectContextFromWorkspaceConfig,
   registerProjectManagedWorkspace,
+  resolveProjectRouteContextForWorkspace,
   type ProjectRouteContext,
 } from '@/utils/projectManifestRegistration'
 
@@ -254,27 +255,33 @@ const handleOpenProject = async () => {
   const success = await openProject()
   if (!success || !currentProject.value?.path) return
 
+  const projectContext = await resolveOpenProjectContext(currentProject.value.path)
   await registerProjectManagedWorkspace({
     workspacePath: currentProject.value.path,
+    projectContext,
     routeQuery: route.query,
   })
   router.push({
     path: '/workspace/home',
-    query: workspaceRouteQuery(currentProject.value.path),
+    query: workspaceRouteQuery(currentProject.value.path, projectContext),
   })
 }
 
 const handleOpenRecent = async (project: Project) => {
   const success = await openProject(project)
-  if (success) {
-    await registerProjectManagedWorkspace({
-      workspacePath: currentProject.value?.path ?? project.path,
-    })
-    router.push({
-      path: '/workspace/home',
-      query: workspaceRouteQuery(currentProject.value?.path ?? project.path),
-    })
-  }
+  if (!success) return
+
+  const workspacePath = currentProject.value?.path ?? project.path
+  const projectContext = await resolveOpenProjectContext(workspacePath)
+  await registerProjectManagedWorkspace({
+    workspacePath,
+    projectContext,
+    routeQuery: route.query,
+  })
+  router.push({
+    path: '/workspace/home',
+    query: workspaceRouteQuery(workspacePath, projectContext),
+  })
 }
 
 const handleRemoveRecent = async (projectId: string) => {
@@ -584,6 +591,21 @@ const handleWizardCreate = async (config: WorkspaceConfig) => {
     path: '/workspace/home',
     query: workspaceRouteQuery(workspacePath, projectContext),
   })
+}
+
+async function resolveOpenProjectContext(
+  workspacePath: string,
+): Promise<ProjectRouteContext | null> {
+  const resolved = await resolveProjectRouteContextForWorkspace(workspacePath)
+  if (resolved) return resolved
+
+  const projectRoot = queryString(route.query.projectRoot)
+  if (!projectRoot) return null
+
+  return {
+    projectRoot,
+    projectName: queryString(route.query.projectName) || undefined,
+  }
 }
 
 function workspaceRouteQuery(

--- a/ecos/gui/apps/renderer/src/views/HomeView.layout-fullscreen.test.ts
+++ b/ecos/gui/apps/renderer/src/views/HomeView.layout-fullscreen.test.ts
@@ -93,16 +93,20 @@ describe('HomeView workspace dashboard layout', () => {
     expect(homeViewSource).toContain('class="home-snapshot-detail"')
   })
 
-  it('uses the legacy green bracket corners around each dashboard card', () => {
-    expect(homeViewSource).toContain('.dashboard-section::before')
-    expect(homeViewSource).toContain('top left / 23px 2px no-repeat')
-    expect(homeViewSource).toContain('bottom right / 2px 23px no-repeat')
-    expect(homeViewSource).toContain('filter: drop-shadow')
-    expect(homeViewSource).not.toContain('radial-gradient(\n        circle at 0 0')
+  it('keeps dashboard cards free of decorative corner brackets', () => {
+    expect(homeViewSource).not.toContain('.dashboard-section::before')
+    expect(homeViewSource).not.toContain('top left / 23px 2px no-repeat')
+    expect(homeViewSource).not.toContain('bottom right / 2px 23px no-repeat')
   })
 
   it('uses grid cells for dashboard parameters and compact QoR comparison entry points', () => {
     expect(homeViewSource).toContain('class="dashboard-parameter-grid chip-info-grid"')
+    expect(homeViewSource).toContain(
+      '.chip-info-grid {\n  align-content: start;\n  flex: 1 1 auto;\n  grid-auto-rows: minmax(min-content, auto);',
+    )
+    expect(homeViewSource).toContain(
+      '.chip-info-grid dd {\n  overflow-wrap: anywhere;\n  white-space: normal;',
+    )
     expect(homeViewSource).toContain('class="dashboard-parameter-grid constraint-list"')
     expect(homeViewSource).toContain('class="dashboard-parameter-grid key-metrics-grid"')
     expect(homeViewSource).toContain('.dashboard-parameter-grid > div')
@@ -157,6 +161,9 @@ describe('HomeView workspace dashboard layout', () => {
     expect(homeViewSource).toContain(':style="{ flexGrow: step.improvedCount }"')
     expect(homeViewSource).toContain(':style="{ flexGrow: step.regressedCount }"')
     expect(homeViewSource).toContain(':style="{ flexGrow: step.unchangedCount }"')
+    expect(homeViewSource).toContain('grid-auto-rows: minmax(min-content, 1fr)')
+    expect(homeViewSource).toContain('overflow-y: auto')
+    expect(homeViewSource).toContain('min-height: min-content')
     expect(homeViewSource).toContain('overflow: hidden')
     expect(homeViewSource).toContain('border-right: 1px solid var(--border-color)')
   })
@@ -256,11 +263,11 @@ describe('HomeView workspace dashboard layout', () => {
     expect(homeViewSource).toContain('.qor-step-trend-bar > .is-improved')
     expect(homeViewSource).toContain('.qor-step-trend-bar > .is-regressed')
     expect(homeViewSource).toContain('.qor-step-trend-bar > .is-neutral')
-    expect(homeViewSource).toContain(
-      '.key-metrics-grid {\n  grid-auto-rows: minmax(0, 1fr);',
-    )
+    expect(homeViewSource).toContain('grid-auto-rows: minmax(min-content, 1fr)')
     expect(homeViewSource).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))')
-    expect(homeViewSource).toContain('.key-metrics-grid > div {\n  min-height: 0;')
+    expect(homeViewSource).toContain(
+      '.key-metrics-grid > div {\n  gap: 3px;\n  min-height: min-content;',
+    )
   })
 
   it('preserves fixed-size checklist, QoR, and snapshot pie chart regions', () => {

--- a/ecos/gui/apps/renderer/src/views/HomeView.vue
+++ b/ecos/gui/apps/renderer/src/views/HomeView.vue
@@ -13,43 +13,57 @@
             <dl class="dashboard-parameter-grid chip-info-grid">
               <div>
                 <dt>Project</dt>
-                <dd>{{ valueOrNA(qorComparisonState.projectName) }}</dd>
+                <dd :title="valueOrNA(qorComparisonState.projectName)">
+                  {{ valueOrNA(qorComparisonState.projectName) }}
+                </dd>
               </div>
               <div>
                 <dt>SoC Template</dt>
-                <dd>{{ valueOrNA(mpcDisplayName) }}</dd>
+                <dd :title="valueOrNA(mpcDisplayName)">
+                  {{ valueOrNA(mpcDisplayName) }}
+                </dd>
               </div>
               <div>
                 <dt>Baseline workspace</dt>
-                <dd>{{ valueOrNA(qorComparisonState.baselineWorkspaceName) }}</dd>
+                <dd :title="valueOrNA(qorComparisonState.baselineWorkspaceName)">
+                  {{ valueOrNA(qorComparisonState.baselineWorkspaceName) }}
+                </dd>
               </div>
               <div>
                 <dt>Workspace</dt>
-                <dd>{{ valueOrNA(currentProject?.name) }}</dd>
+                <dd :title="valueOrNA(currentProject?.name)">
+                  {{ valueOrNA(currentProject?.name) }}
+                </dd>
               </div>
               <div>
                 <dt>PDK</dt>
-                <dd>{{ valueOrNA(config.pdk) }}</dd>
+                <dd :title="valueOrNA(config.pdk)">{{ valueOrNA(config.pdk) }}</dd>
               </div>
               <div>
                 <dt>Design</dt>
-                <dd>{{ valueOrNA(config.design) }}</dd>
+                <dd :title="valueOrNA(config.design)">{{ valueOrNA(config.design) }}</dd>
               </div>
               <div>
                 <dt>Top Module</dt>
-                <dd>{{ valueOrNA(config.topModule) }}</dd>
+                <dd :title="valueOrNA(config.topModule)">
+                  {{ valueOrNA(config.topModule) }}
+                </dd>
               </div>
               <div>
                 <dt>Target Die Area</dt>
-                <dd>{{ positiveNumberOrNA(config.die.area) }}</dd>
+                <dd :title="positiveNumberOrNA(config.die.area)">
+                  {{ positiveNumberOrNA(config.die.area) }}
+                </dd>
               </div>
               <div>
                 <dt>Target Frequency</dt>
-                <dd>{{ frequencyOrNA(config.frequencyMax) }}</dd>
+                <dd :title="frequencyOrNA(config.frequencyMax)">
+                  {{ frequencyOrNA(config.frequencyMax) }}
+                </dd>
               </div>
               <div>
                 <dt>Clock</dt>
-                <dd>{{ valueOrNA(config.clock) }}</dd>
+                <dd :title="valueOrNA(config.clock)">{{ valueOrNA(config.clock) }}</dd>
               </div>
             </dl>
           </section>
@@ -1145,64 +1159,6 @@ async function openLayoutChipViewer(): Promise<void> {
   position: relative;
 }
 
-.dashboard-section::before {
-  background:
-    linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      top left / 23px 2px no-repeat,
-    linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      top left / 2px 23px no-repeat,
-    linear-gradient(
-        270deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      top right / 23px 2px no-repeat,
-    linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      top right / 2px 23px no-repeat,
-    linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      bottom left / 23px 2px no-repeat,
-    linear-gradient(
-        0deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      bottom left / 2px 23px no-repeat,
-    linear-gradient(
-        270deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      bottom right / 23px 2px no-repeat,
-    linear-gradient(
-        0deg,
-        color-mix(in srgb, var(--success-color) 90%, transparent) 0 16px,
-        transparent 16px
-      )
-      bottom right / 2px 23px no-repeat;
-  content: '';
-  filter: drop-shadow(0 0 3px color-mix(in srgb, var(--success-color) 48%, transparent));
-  inset: -1px;
-  pointer-events: none;
-  position: absolute;
-  z-index: 2;
-}
-
 .dashboard-section-header {
   align-items: center;
   border-bottom: 1px solid var(--border-color);
@@ -1287,10 +1243,11 @@ async function openLayoutChipViewer(): Promise<void> {
   border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  min-height: 43px;
+  gap: 4px;
+  justify-content: flex-start;
+  min-height: min-content;
   min-width: 0;
-  padding: 7px 9px;
+  padding: 8px 9px;
 }
 
 .chip-info-grid,
@@ -1299,14 +1256,23 @@ async function openLayoutChipViewer(): Promise<void> {
 }
 
 .chip-info-grid {
+  align-content: start;
   flex: 1 1 auto;
+  grid-auto-rows: minmax(min-content, auto);
+  overflow-x: hidden;
   overflow-y: auto;
 }
 
+.chip-info-grid > div {
+  justify-content: flex-start;
+}
+
 .key-metrics-grid {
-  grid-auto-rows: minmax(0, 1fr);
+  align-content: start;
+  grid-auto-rows: minmax(min-content, 1fr);
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .constraint-list {
@@ -1317,20 +1283,33 @@ async function openLayoutChipViewer(): Promise<void> {
 .key-metrics-grid dt,
 .constraint-list dt {
   color: var(--text-secondary);
+  flex: 0 0 auto;
   font-size: 10px;
   line-height: 1.2;
-  margin: 0 0 3px;
+  margin: 0;
 }
 
 .chip-info-grid dd,
 .key-metrics-grid dd,
 .constraint-list dd {
   color: var(--text-primary);
+  flex: 0 0 auto;
   font-size: 13px;
   font-variant-numeric: tabular-nums;
   font-weight: 700;
-  line-height: 1.25;
+  line-height: 1.3;
   margin: 0;
+  min-width: 0;
+}
+
+.chip-info-grid dd {
+  overflow-wrap: anywhere;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.key-metrics-grid dd,
+.constraint-list dd {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1342,7 +1321,8 @@ async function openLayoutChipViewer(): Promise<void> {
 }
 
 .key-metrics-grid > div {
-  min-height: 0;
+  gap: 3px;
+  min-height: min-content;
   padding: 5px 7px;
 }
 
@@ -1503,17 +1483,17 @@ async function openLayoutChipViewer(): Promise<void> {
 }
 
 .qor-comparison-pie {
-  align-content: center;
-  display: grid;
+  display: flex;
   flex: 1 1 auto;
-  min-height: 140px;
+  flex-direction: column;
+  min-height: 148px;
   min-width: 0;
   overflow: hidden;
   padding: 2px 0;
 }
 
 .qor-comparison-pie :deep(.status-pie-chart-wrap) {
-  min-height: 140px;
+  min-height: 104px;
 }
 
 .status-summary-content,
@@ -1641,21 +1621,24 @@ async function openLayoutChipViewer(): Promise<void> {
 }
 
 .qor-step-list {
+  align-content: start;
   display: grid;
   flex: 1;
   gap: 4px 6px;
-  grid-auto-rows: minmax(0, 1fr);
+  grid-auto-rows: minmax(min-content, 1fr);
   grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
   min-width: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 7px 8px;
 }
 .qor-step-row {
   border: 1px solid color-mix(in srgb, var(--border-color) 75%, transparent);
   display: flex;
   flex-direction: column;
+  gap: 4px;
   justify-content: center;
-  min-height: 0;
+  min-height: min-content;
   min-width: 0;
   padding: 4px 6px;
 }
@@ -1666,10 +1649,11 @@ async function openLayoutChipViewer(): Promise<void> {
   color: var(--text-primary);
   cursor: pointer;
   display: grid;
+  flex: 0 0 auto;
   gap: 4px;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  min-height: 0;
   min-width: 0;
+  overflow: hidden;
   padding: 0;
   text-align: left;
 }
@@ -1698,9 +1682,9 @@ async function openLayoutChipViewer(): Promise<void> {
 .qor-step-trend {
   align-items: center;
   display: grid;
+  flex: 0 0 auto;
   gap: 6px;
   grid-template-columns: minmax(0, 1fr) auto;
-  margin: 6px 0 0;
   min-width: 0;
 }
 
@@ -1914,8 +1898,6 @@ async function openLayoutChipViewer(): Promise<void> {
   overflow-x: hidden;
   overflow-y: auto;
   padding: 0 5px 8px 0;
-  scrollbar-color: color-mix(in srgb, var(--text-secondary) 52%, transparent) transparent;
-  scrollbar-width: thin;
 }
 
 :deep(.qor-detail-dialog.p-dialog-maximized .p-dialog-content) {
@@ -2340,13 +2322,19 @@ async function openLayoutChipViewer(): Promise<void> {
     padding-right: 8px;
   }
   .qor-step-row {
-    gap: 3px;
+    align-items: center;
+    display: grid;
+    gap: 6px;
+    grid-template-columns: minmax(0, 1fr) minmax(52px, 0.9fr);
+    min-height: min-content;
+    padding: 4px 6px;
   }
   .qor-step-list {
-    grid-template-columns: repeat(auto-fit, minmax(114px, 1fr));
+    grid-auto-rows: minmax(min-content, auto);
+    grid-template-columns: repeat(auto-fit, minmax(148px, 1fr));
   }
   .qor-step-total {
-    font-size: 7px;
+    font-size: 9px;
   }
 }
 </style>

--- a/ecos/gui/apps/renderer/src/views/ProjectsView.project-management.test.ts
+++ b/ecos/gui/apps/renderer/src/views/ProjectsView.project-management.test.ts
@@ -18,6 +18,17 @@ const projectSurfaceSource = `${source}\n${projectStyles}`
 const analysisSurfaceSource = `${analysisSource}\n${analysisStyles}`
 
 describe('ProjectsView project management surface', () => {
+  it('applies route focus so Back to Project Management selects the current workspace', () => {
+    expect(source).toContain('resolveProjectManagementRouteFocus')
+    expect(source).toContain('applyRouteProjectFocus')
+    expect(source).toContain('useRoute')
+    expect(source).toContain('route.query.projectRoot')
+    expect(source).toContain('route.query.workspaceId')
+    expect(source).toContain('data-workspace-id')
+    expect(source).toContain('scrollIntoView')
+    expect(source).toContain('selectWorkspace(')
+  })
+
   it('renders the project tree and project analysis surface instead of the old flow matrix', () => {
     expect(source).toContain('ProjectAnalysisPanel')
     expect(analysisSource).toContain('aria-label="Analysis"')

--- a/ecos/gui/apps/renderer/src/views/ProjectsView.vue
+++ b/ecos/gui/apps/renderer/src/views/ProjectsView.vue
@@ -215,7 +215,10 @@
                     :class="flowStatusHintClass(workspace.flowStatusHint.state)"
                     :style="workspaceDepthStyle(workspace)"
                   >
-                    <div class="workspace-tree-row-shell">
+                    <div
+                      class="workspace-tree-row-shell"
+                      :data-workspace-id="workspace.id"
+                    >
                       <button
                         type="button"
                         class="workspace-tree-row"
@@ -753,12 +756,13 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import type { Project, ProjectStatus } from '../types'
 import { useWorkspace } from '../composables/useWorkspace'
 import ProjectAnalysisPanel from './project-management/ProjectAnalysisPanel.vue'
 import MpcTemplatePreview from '@/components/MpcTemplatePreview.vue'
 import { previewList } from './project-management/projectListPreview'
+import { resolveProjectManagementRouteFocus } from './project-management/projectRouteFocus'
 import {
   readProjectWorkspaceAnalysisInputs,
   readProjectWorkspaceFlowStates,
@@ -807,6 +811,7 @@ type ProjectCard = { source: Project; model: ProjectManagementProject }
 const PROJECT_PREVIEW_LIMIT = 20
 const WORKSPACE_PREVIEW_LIMIT = 20
 
+const route = useRoute()
 const router = useRouter()
 const { openProject, showToast } = useWorkspace()
 
@@ -860,14 +865,23 @@ onMounted(async () => {
   document.addEventListener('keydown', handleWorkspacePopoverKeydown)
   projectHistory.value = await loadProjectHistory()
   await refreshProjectManifests()
-  if (!selectedProjectId.value)
+  const focused = await applyRouteProjectFocus()
+  if (!focused && !selectedProjectId.value) {
     selectedProjectId.value = projectCards.value[0]?.model.id ?? selectedProject.value.id
+  }
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('pointerdown', handleWorkspacePopoverPointerDown)
   document.removeEventListener('keydown', handleWorkspacePopoverKeydown)
 })
+
+watch(
+  () => [route.query.projectRoot, route.query.workspaceId] as const,
+  () => {
+    void applyRouteProjectFocus()
+  },
+)
 
 const projectSources = computed<Project[]>(() => projectHistory.value)
 
@@ -1142,6 +1156,43 @@ function selectWorkspace(workspaceId: string) {
   selectedIssueMetric.value = null
   branchDraft.value = null
   closeRowActionMenus()
+}
+
+async function applyRouteProjectFocus(): Promise<boolean> {
+  const focus = resolveProjectManagementRouteFocus({
+    projectRoot: queryString(route.query.projectRoot),
+    workspaceId: queryString(route.query.workspaceId),
+    projects: projectCards.value.map((project) => ({
+      id: project.model.id,
+      path: project.model.path,
+      workspaces: project.model.workspaces.map((workspace) => ({ id: workspace.id })),
+    })),
+  })
+  if (!focus) return false
+
+  selectProject(focus.projectId)
+  if (focus.workspaceId) {
+    selectWorkspace(focus.workspaceId)
+  }
+  await nextTick()
+  if (focus.workspaceId) {
+    document
+      .querySelector(`[data-workspace-id="${cssEscape(focus.workspaceId)}"]`)
+      ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }
+  return true
+}
+
+function queryString(value: unknown): string {
+  if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : ''
+  return typeof value === 'string' ? value : ''
+}
+
+function cssEscape(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value)
+  }
+  return value.replace(/["\\]/g, '\\$&')
 }
 
 function selectStep(step: FlowStep) {

--- a/ecos/gui/apps/renderer/src/views/project-management/projectRouteFocus.test.ts
+++ b/ecos/gui/apps/renderer/src/views/project-management/projectRouteFocus.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { resolveProjectManagementRouteFocus } from './projectRouteFocus'
+
+const projects = [
+  {
+    id: '/projects/alpha',
+    path: '/projects/alpha',
+    workspaces: [{ id: 'ws_0001' }, { id: 'ws_0002' }],
+  },
+  {
+    id: '/projects/gcd',
+    path: '/projects/gcd',
+    workspaces: [{ id: 'ws_0027' }, { id: 'ws_0036' }],
+  },
+]
+
+describe('resolveProjectManagementRouteFocus', () => {
+  it('selects the routed project and workspace', () => {
+    expect(
+      resolveProjectManagementRouteFocus({
+        projectRoot: '/projects/gcd/',
+        workspaceId: 'ws_0036',
+        projects,
+      }),
+    ).toEqual({
+      projectId: '/projects/gcd',
+      workspaceId: 'ws_0036',
+    })
+  })
+
+  it('still selects the project when only projectRoot is provided', () => {
+    expect(
+      resolveProjectManagementRouteFocus({
+        projectRoot: '/projects/gcd',
+        projects,
+      }),
+    ).toEqual({
+      projectId: '/projects/gcd',
+      workspaceId: null,
+    })
+  })
+
+  it('finds a project by workspace id when projectRoot is absent', () => {
+    expect(
+      resolveProjectManagementRouteFocus({
+        workspaceId: 'ws_0002',
+        projects,
+      }),
+    ).toEqual({
+      projectId: '/projects/alpha',
+      workspaceId: 'ws_0002',
+    })
+  })
+
+  it('ignores unknown workspace ids while keeping the project focus', () => {
+    expect(
+      resolveProjectManagementRouteFocus({
+        projectRoot: '/projects/gcd',
+        workspaceId: 'ws_missing',
+        projects,
+      }),
+    ).toEqual({
+      projectId: '/projects/gcd',
+      workspaceId: null,
+    })
+  })
+
+  it('returns null when the route has no usable focus target', () => {
+    expect(
+      resolveProjectManagementRouteFocus({
+        projectRoot: '/projects/missing',
+        workspaceId: 'ws_0036',
+        projects: [projects[0]],
+      }),
+    ).toBeNull()
+    expect(
+      resolveProjectManagementRouteFocus({
+        projects,
+      }),
+    ).toBeNull()
+  })
+})

--- a/ecos/gui/apps/renderer/src/views/project-management/projectRouteFocus.ts
+++ b/ecos/gui/apps/renderer/src/views/project-management/projectRouteFocus.ts
@@ -1,0 +1,67 @@
+export interface ProjectRouteFocusCandidate {
+  id: string
+  path: string
+  workspaces: Array<{ id: string }>
+}
+
+export interface ProjectRouteFocusInput {
+  projectRoot?: string | null
+  workspaceId?: string | null
+  projects: readonly ProjectRouteFocusCandidate[]
+}
+
+export interface ProjectRouteFocus {
+  projectId: string
+  workspaceId: string | null
+}
+
+/**
+ * Resolves which project/workspace Project Management should select when the
+ * route carries focus hints from "Back to Project Management".
+ */
+export function resolveProjectManagementRouteFocus(
+  input: ProjectRouteFocusInput,
+): ProjectRouteFocus | null {
+  const projectRoot = normalizePath(input.projectRoot)
+  const workspaceId = asNonEmpty(input.workspaceId)
+  if (!projectRoot && !workspaceId) return null
+
+  let project =
+    projectRoot != null
+      ? input.projects.find(
+          (candidate) =>
+            normalizePath(candidate.path) === projectRoot ||
+            normalizePath(candidate.id) === projectRoot,
+        )
+      : undefined
+
+  if (!project && workspaceId) {
+    project = input.projects.find((candidate) =>
+      candidate.workspaces.some((workspace) => workspace.id === workspaceId),
+    )
+  }
+
+  if (!project) return null
+
+  const focusedWorkspace =
+    workspaceId && project.workspaces.some((workspace) => workspace.id === workspaceId)
+      ? workspaceId
+      : null
+
+  return {
+    projectId: project.id,
+    workspaceId: focusedWorkspace,
+  }
+}
+
+function asNonEmpty(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+function normalizePath(path: string | null | undefined): string | null {
+  if (typeof path !== 'string') return null
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/g, '').trim()
+  return normalized || null
+}


### PR DESCRIPTION
## Summary

- Improve dashboard, workspace, and flow-log layout behavior, including compact scrollbars and clearer status legends.
- Preserve project context when opening a workspace and focus the matching project-management workspace from route state.
- Add focused renderer coverage for route focus, project context, scrollbar reveal, and updated UI behavior.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other: `cd ecos/gui && pnpm install --frozen-lockfile`
- [x] Other: `cd ecos/gui && pnpm run lint`
- [x] Other: `cd ecos/gui && pnpm run fmt:check`
- [x] Other: `python3 .github/scripts/check-version.py`

Skipped checks and reason:

- `pnpm run build` and `make build` are packaging checks, excluded from this GUI PR's CI gate; `make demo-gcd` and `make demo-retrosoc` are unrelated ECC demos.
- A manual GUI smoke was not recorded because the current Wayland environment lacks a compatible screen-capture tool.

## Screenshots or Recordings
- 

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Renderer behavior changes only; no dependency, version, packaging, ECC runtime-resource, or submodule changes.

## Checklist

- [x] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
