### PR TITLE
revert(gui): restore state before home qor context

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# ECOS Studio Product
+
+## Register
+
+product
+
+## Users
+
+ECOS Studio serves chip engineers, researchers, and students working through the RTL-to-GDS flow. They use the desktop application to configure designs, inspect evidence, confirm execution contracts, and control long-running local EDA and Agent workflows without losing traceability.
+
+## Product Purpose
+
+ECOS Studio lowers the barrier to custom silicon by combining open-source IP, PDKs, EDA tools, and guided workflows in one desktop environment. The Agent experience should help users make valid decisions quickly while keeping execution deterministic, reviewable, interruptible, and under explicit user control.
+
+## Brand Personality
+
+Restrained, precise, and trustworthy. Product surfaces should feel compact and work-focused, with the clarity and responsiveness associated with tools such as Cursor and Linear.
+
+## Anti-references
+
+Avoid marketing-style composition, oversized headlines, decorative card grids, ornamental effects, and generic chatbot interfaces. Do not hide execution state or critical choices behind vague conversational copy.
+
+## Design Principles
+
+- Make the current state and next valid action immediately visible.
+- Prefer direct manipulation and structured decisions over instructions to type magic values.
+- Keep users in control of execution, interruption, and queued work.
+- Preserve deterministic contracts and auditability across conversational flows.
+- Use density and hierarchy to support repeated engineering work without visual noise.
+
+## Accessibility & Inclusion
+
+Meet a WCAG 2.1 AA baseline. Support keyboard operation, visible focus states, reduced-motion preferences, and status communication that does not rely on color alone.

--- a/ecos/agent/README.md
+++ b/ecos/agent/README.md
@@ -52,9 +52,8 @@ printf 'ECOS_AGENT_CODEX_BIN=%s\n' "$codex_bin" \
   > "$HOME/.config/environment.d/ecos-agent.conf"
 ```
 
-Agent 仅接受可执行的 `ECOS_AGENT_CODEX_BIN` / 设置路径；无效时依次回退到托管安装
-路径和 GUI 进程 `PATH` 中的 `codex`。启动检查失败时不会创建 workspace，也不会启动
-ECC 流程。
+Agent 仅接受可执行的 `ECOS_AGENT_CODEX_BIN` / 设置路径，否则回退到 GUI 进程
+`PATH` 中的 `codex`。启动检查失败时不会创建 workspace，也不会启动 ECC 流程。
 
 ## 在 ECOS Studio 中使用
 
@@ -64,14 +63,15 @@ Workspace 目录名。
 
 按上下文分流：
 
-- **未打开 workspace（首页）**：Topbar Chat 打开 Agent 聊天。开场给出主 CTA
+- **未打开 workspace（首页）**：Topbar Chat 打开右侧 Agent 抽屉。开场给出主 CTA
   「开始创建 Workspace」，也可直接用自然语言说明意图（例如已有 Project 路径、
-  Workspace 名、设计名）；寒暄或无关输入会留在开场；Agent 可提供只读答复，无法处理时会提示错误或重新展示可用选项。随后选择或新建Project，再创建其下的 Workspace 并运行完整流程。
-- **已打开 workspace**：Home / 步骤页共用 Topbar Chat。欢迎语同时展示 Project 与
-  Workspace。操作是「修改参数（只保存）」「从指定阶段重跑」
+  Workspace 名、设计名）；寒暄或无关输入会失败关闭并留在开场。随后选择或新建
+  Project，再创建其下的 Workspace 并运行完整流程。
+- **已打开 workspace**：Topbar Chat 展开右侧聊天栏（Home / 步骤页共用）。欢迎语
+  同时展示 Project 与 Workspace。操作是「修改参数（只保存）」「从指定阶段重跑」
   「继续未完成 flow」「在当前 Project 下新建 Workspace」。Standalone workspace
   （无 `project.json` 父目录）不提供第 4 项。自然语言仅在能明确映射到上述操作时
-  前进；其他输入会给出只读答复并保留当前操作选项。
+  前进，否则失败关闭并重新展示选项。
 
 Agent 会将操作、重跑源、阶段、执行范围和最终确认显示为结构化选项；合同确认前
 不会执行流程。运行时状态条显示 Agent 状态，工具活动合并在可展开的 Tool 卡中。
@@ -147,8 +147,7 @@ Codex CLI 仅用于生成**只读、带类型约束的建议**，不会取得流
   不能自行选择没有证据的阶段、不能创建或覆盖 workspace，也不能宣称流程成功。
 
 项目根目录和重跑 source workspace 是 Codex 可读取建议的边界。Codex 不可用、
-超时或返回不符合合同的内容时，不会生成可执行合同或调用 ECC；Agent 会保留当前
-输入步骤，供用户修正输入后重试。
+超时或返回不符合合同的内容时，当前操作会失败关闭，ECC 不会被调用。
 
 ### 边界靠什么保证
 

--- a/ecos/gui/apps/renderer/src/App.agentWorkspaceSetup.test.ts
+++ b/ecos/gui/apps/renderer/src/App.agentWorkspaceSetup.test.ts
@@ -15,10 +15,4 @@ describe('agent workspace creation', () => {
     expect(source).toContain('lastWorkspaceCreationError.value')
     expect(source).toContain('created: false')
   })
-
-  it('keeps the managed project context when opening the new workspace home', () => {
-    expect(source).toContain("path: '/workspace/home'")
-    expect(source).toContain('projectRoot: contract.project_context.project_root')
-    expect(source).toContain('projectName: contract.project_context.project_name')
-  })
 })

--- a/ecos/gui/apps/renderer/src/App.vue
+++ b/ecos/gui/apps/renderer/src/App.vue
@@ -282,13 +282,7 @@ async function createWorkspaceFromAgent(
     workspacePath,
   })
   agentShell.setMode('workspace')
-  await router.push({
-    path: '/workspace/home',
-    query: {
-      projectRoot: contract.project_context.project_root,
-      projectName: contract.project_context.project_name,
-    },
-  })
+  await router.push('/workspace/home')
   await nextTick()
   return { created: true, workspacePath }
 }

--- a/ecos/gui/apps/renderer/src/components/AgentExecutionContractPanel.test.ts
+++ b/ecos/gui/apps/renderer/src/components/AgentExecutionContractPanel.test.ts
@@ -9,7 +9,7 @@ describe('AgentExecutionContractPanel', () => {
     expect(source).toContain('v-for="[key, value] in rows"')
     expect(source).toContain('{{ key }}')
     expect(source).toContain('{{ value }}')
-    expect(source).toMatch(/class="[^"]*\bw-full\b[^"]*\btable-fixed\b/)
+    expect(source).toContain('class="w-full table-fixed')
     expect(source).toContain('class="contract-table-shell selectable"')
     expect(source).toContain('max-height: min(18rem, 42vh)')
     expect(source.indexOf('</table>')).toBeLessThan(

--- a/ecos/gui/apps/renderer/src/composables/useHomeQorComparison.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useHomeQorComparison.test.ts
@@ -21,7 +21,6 @@ const testState = vi.hoisted(() => ({
   writeProjectTextFile: vi.fn(),
   readProjectWorkspaceAnalysisInputs: vi.fn(),
   readProjectWorkspaceFlowStates: vi.fn(),
-  resolveProjectRouteContextForWorkspace: vi.fn(),
 }))
 
 vi.mock('./useWorkspace', () => ({
@@ -52,11 +51,6 @@ vi.mock('@/utils/projectFiles', () => ({
 vi.mock('@/views/project-management/projectWorkspaceAnalysisData', () => ({
   readProjectWorkspaceAnalysisInputs: testState.readProjectWorkspaceAnalysisInputs,
   readProjectWorkspaceFlowStates: testState.readProjectWorkspaceFlowStates,
-}))
-
-vi.mock('@/utils/projectManifestRegistration', () => ({
-  resolveProjectRouteContextForWorkspace:
-    testState.resolveProjectRouteContextForWorkspace,
 }))
 
 import { clearHomeQorComparisonCache, useHomeQorComparison } from './useHomeQorComparison'
@@ -112,8 +106,6 @@ describe('useHomeQorComparison', () => {
     testState.writeProjectTextFile.mockReset()
     testState.readProjectWorkspaceAnalysisInputs.mockReset()
     testState.readProjectWorkspaceFlowStates.mockReset()
-    testState.resolveProjectRouteContextForWorkspace.mockReset()
-    testState.resolveProjectRouteContextForWorkspace.mockResolvedValue(null)
     testState.readOptionalProjectTextFile.mockResolvedValue(
       JSON.stringify(projectManifest()),
     )
@@ -193,20 +185,14 @@ describe('useHomeQorComparison', () => {
     expect(restored.state.value.comparison).toBe(previousComparison)
   })
 
-  it('restores a project context from a parent manifest that owns the workspace', async () => {
+  it('does not infer a baseline when the project route is absent', async () => {
     testState.route.query = {}
-    testState.resolveProjectRouteContextForWorkspace.mockResolvedValue({
-      projectRoot: '/projects/gcd',
-      projectName: 'gcd',
-    })
     const comparison = scope.run(() => useHomeQorComparison())!
 
     await vi.waitFor(() => {
-      expect(comparison.state.value.status).toBe('available')
+      expect(comparison.state.value.status).toBe('no-project')
     })
-    expect(testState.resolveProjectRouteContextForWorkspace).toHaveBeenCalledWith(
-      '/projects/gcd/ws_0004',
-    )
+    expect(testState.registerProjectReadRoot).not.toHaveBeenCalled()
   })
 
   it('uses the first other workspace as the legacy project default baseline without writing', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useHomeQorComparison.ts
+++ b/ecos/gui/apps/renderer/src/composables/useHomeQorComparison.ts
@@ -11,7 +11,6 @@ import {
   type ProjectQorWorkspaceComparison,
 } from '@/utils/projectQorTrend'
 import { readOptionalProjectTextFile } from '@/utils/projectFiles'
-import { resolveProjectRouteContextForWorkspace } from '@/utils/projectManifestRegistration'
 import {
   readProjectWorkspaceAnalysisInputs,
   readProjectWorkspaceFlowStates,
@@ -78,16 +77,9 @@ export function useHomeQorComparison() {
   async function refresh(): Promise<void> {
     const token = ++requestToken
     const workspacePath = currentProject.value?.path
-    if (!workspacePath) {
+    const projectRoot = routeString(route.query.projectRoot)
+    if (!workspacePath || !projectRoot) {
       state.value = EMPTY_STATE
-      return
-    }
-
-    const projectRoot =
-      routeString(route.query.projectRoot) ??
-      (await resolveProjectRouteContextForWorkspace(workspacePath))?.projectRoot
-    if (token !== requestToken || !projectRoot) {
-      if (token === requestToken) state.value = EMPTY_STATE
       return
     }
 


### PR DESCRIPTION
## Summary

- Revert PR #152, restoring the state before the Home QoR context change.
- A follow-up PR will reintroduce the same change as one squashed commit.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other: `cd ecos/gui && pnpm run lint`; tracked-files `pnpm exec oxfmt --check`; `python3 .github/scripts/check-version.py`

Skipped checks and reason:

- GUI and AppImage builds, demos, and manual smoke testing were not run because this PR mechanically reverts a previously merged change; CI will run the AppImage build.

## Screenshots or Recordings

Required for visible GUI changes.

- Not captured; this reverts behavior without a layout change.

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- No dependency, version, or submodule changes.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
