### PR TITLE
fix(gui): restore dashboard physical metrics fallback

### DIFF
--- a/ecos/gui/apps/renderer/src/components/home/dashboardData.test.ts
+++ b/ecos/gui/apps/renderer/src/components/home/dashboardData.test.ts
@@ -7,6 +7,7 @@ import {
   dashboardMetrics,
   formatDashboardMetric,
   instanceMetricsFromDbFeature,
+  instanceMetricsFromStepFeature,
   maxFanoutFromParameters,
   mpcConstraintsFromParameters,
   mpcDisplayNameFromParameters,
@@ -159,6 +160,7 @@ describe('dashboard data presentation', () => {
 
   it('extracts physical instance metrics from the Floorplan-through-Route db feature', () => {
     const dbMetrics = instanceMetricsFromDbFeature({
+      'Design Statis': { num_iopins: 54, num_instances: 432, num_nets: 777 },
       Instances: {
         macros: { num: 3, area: 41.25 },
         logic: { num: 316, area: 803.04 },
@@ -176,6 +178,22 @@ describe('dashboard data presentation', () => {
       { id: 'std-cell-area', label: 'Std Cell Area', value: 803.04, unit: 'um2' },
       { id: 'io-pad-number', label: 'IO Pad Number', value: 54 },
     ])
+    expect(metrics.find((metric) => metric.id === 'io-pins')?.value).toBe(54)
+    expect(metrics.find((metric) => metric.id === 'nets')?.value).toBe(777)
+  })
+
+  it('extracts physical counters from a previous step feature fallback', () => {
+    expect(
+      instanceMetricsFromStepFeature({
+        route: { instance_cnt: 432, total_pins: 54, net_cnt: 777 },
+      }),
+    ).toEqual(
+      new Map([
+        ['instance_count', 432],
+        ['io_pin_count', 54],
+        ['net_count', 777],
+      ]),
+    )
   })
 
   it('selects only the latest successful step except for the Harden summary', () => {

--- a/ecos/gui/apps/renderer/src/components/home/dashboardData.ts
+++ b/ecos/gui/apps/renderer/src/components/home/dashboardData.ts
@@ -298,7 +298,8 @@ export function synthesisMetricsFromStat(value: unknown): Map<string, number> {
 }
 
 export function instanceMetricsFromDbFeature(value: unknown): Map<string, number> {
-  const instances = record(record(value)?.Instances)
+  const source = record(value)
+  const instances = record(source?.Instances)
   const metrics = new Map<string, number>()
   const metricKeys: readonly [string, string, 'num' | 'area'][] = [
     ['macro_count', 'macros', 'num'],
@@ -313,6 +314,67 @@ export function instanceMetricsFromDbFeature(value: unknown): Map<string, number
     const metricValue = finiteNumber(instanceMetrics?.[sourceKey])
     if (metricValue !== null) metrics.set(metricId, metricValue)
   }
+
+  const statistics = record(source?.['Design Statis'])
+  const totalMetricKeys: readonly [string, string][] = [
+    ['io_pin_count', 'num_iopins'],
+    ['instance_count', 'num_instances'],
+    ['net_count', 'num_nets'],
+  ]
+  for (const [metricId, sourceKey] of totalMetricKeys) {
+    const metricValue = finiteNumber(statistics?.[sourceKey])
+    if (metricValue !== null) metrics.set(metricId, metricValue)
+  }
+  return metrics
+}
+
+/**
+ * Extracts the physical counters that older step feature files may expose
+ * without the full DB summary shape. These files are only a fallback when the
+ * current step has no db.json, so unrecognised step-specific values are ignored.
+ */
+export function instanceMetricsFromStepFeature(value: unknown): Map<string, number> {
+  const metrics = instanceMetricsFromDbFeature(value)
+  const aliases: Record<string, string> = {
+    iopin_count: 'io_pin_count',
+    io_pin_count: 'io_pin_count',
+    num_iopins: 'io_pin_count',
+    pin_count: 'io_pin_count',
+    total_pins: 'io_pin_count',
+    instance_count: 'instance_count',
+    instance_cnt: 'instance_count',
+    num_instances: 'instance_count',
+    total_instances: 'instance_count',
+    net_count: 'net_count',
+    net_cnt: 'net_count',
+    num_nets: 'net_count',
+    total_nets: 'net_count',
+    macro_count: 'macro_count',
+    macro_num: 'macro_count',
+    std_cell_count: 'std_cell_count',
+    stdcell_count: 'std_cell_count',
+    io_pad_count: 'io_pad_count',
+    iopad_count: 'io_pad_count',
+  }
+
+  function visit(node: unknown): void {
+    const source = record(node)
+    if (!source) return
+    for (const [key, child] of Object.entries(source)) {
+      const normalizedKey = key
+        .trim()
+        .toLowerCase()
+        .replace(/[\s-]+/g, '_')
+      const metricId = aliases[normalizedKey]
+      const numeric = finiteNumber(child)
+      if (metricId && numeric !== null && !metrics.has(metricId)) {
+        metrics.set(metricId, numeric)
+      }
+      if (record(child)) visit(child)
+    }
+  }
+
+  visit(value)
   return metrics
 }
 

--- a/ecos/gui/apps/renderer/src/composables/useDashboardOverview.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDashboardOverview.test.ts
@@ -38,6 +38,8 @@ import { useDashboardOverview } from './useDashboardOverview'
 
 const ANALYSIS_PATH = '/workspace/Floorplan_ecc/analysis/qor_metrics.json'
 const DB_FEATURE_PATH = '/workspace/Floorplan_ecc/feature/Floorplan.db.json'
+const STA_ANALYSIS_PATH = '/workspace/Sta_ecc/analysis/qor_metrics.json'
+const ROUTE_STEP_FEATURE_PATH = '/workspace/Route_ecc/feature/route.step.json'
 
 function workspaceStep(): WorkspaceStepResource {
   return {
@@ -93,6 +95,54 @@ function workspaceIndex(
     flow: { steps: [workspaceStep()] },
     status: 'available',
     messages: [],
+  }
+}
+
+function stepWith(
+  name: string,
+  state: string,
+  directory: string,
+  options: {
+    analysisPath?: string
+    dbPath?: string
+    dbExists?: boolean
+    stepPath?: string
+  } = {},
+): WorkspaceStepResource {
+  return {
+    name,
+    tool: 'ecc',
+    state,
+    runtime: '0:0:1',
+    directory,
+    info: {},
+    resources: {
+      output: {},
+      data: {},
+      feature: {
+        ...(options.dbPath
+          ? {
+              db: {
+                exists: options.dbExists ?? true,
+                kind: 'analysis',
+                path: options.dbPath,
+              },
+            }
+          : {}),
+        ...(options.stepPath
+          ? { step: { exists: true, kind: 'analysis', path: options.stepPath } }
+          : {}),
+      },
+      report: {},
+      log: {},
+      script: {},
+      analysis: options.analysisPath
+        ? { metrics: { exists: true, kind: 'metrics', path: options.analysisPath } }
+        : {},
+      subflow: {},
+      checklist: {},
+      config: {},
+    },
   }
 }
 
@@ -181,5 +231,102 @@ describe('useDashboardOverview db feature metrics', () => {
     })
 
     expect(overview.maxFanout.value).toBe(32)
+  })
+
+  it('falls back to the previous successful step feature when the current step has no db', async () => {
+    const route = stepWith('Route', 'Success', '/workspace/Route_ecc', {
+      stepPath: ROUTE_STEP_FEATURE_PATH,
+    })
+    const sta = stepWith('STA', 'Success', '/workspace/Sta_ecc', {
+      analysisPath: STA_ANALYSIS_PATH,
+      dbPath: '/workspace/Sta_ecc/feature/STA.db.json',
+      dbExists: false,
+    })
+    testState.getWorkspaceResourceIndexApi.mockResolvedValue({
+      ...workspaceIndex(),
+      flow: { steps: [route, sta] },
+    })
+    testState.readOptionalProjectTextFile.mockImplementation(async (path: string) => {
+      if (path === STA_ANALYSIS_PATH) {
+        return JSON.stringify({ metrics: [{ id: 'sta_setup_wns', value: -0.12 }] })
+      }
+      if (
+        path ===
+        `${STA_ANALYSIS_PATH.slice(0, -'qor_metrics.json'.length)}qor_summary.json`
+      ) {
+        return JSON.stringify({ quality_status: 'pass', metric_count: 1 })
+      }
+      if (path === ROUTE_STEP_FEATURE_PATH) {
+        return JSON.stringify({
+          route: { instance_cnt: 432, total_pins: 54, net_cnt: 777 },
+        })
+      }
+      return null
+    })
+
+    const overview = scope.run(() => useDashboardOverview())!
+    await vi.waitFor(() => {
+      expect(overview.qorSteps.value).toHaveLength(2)
+    })
+
+    const metric = (id: string) =>
+      overview.keyMetrics.value.find((entry) => entry.id === id)
+    expect(metric('setup-wns')?.value).toBe(-0.12)
+    expect(metric('instances')?.value).toBe(432)
+    expect(metric('io-pins')?.value).toBe(54)
+    expect(metric('nets')?.value).toBe(777)
+    expect(testState.readOptionalProjectTextFile).toHaveBeenCalledWith(
+      ROUTE_STEP_FEATURE_PATH,
+    )
+  })
+
+  it('prefers the current step db over a previous step feature fallback', async () => {
+    const route = stepWith('Route', 'Success', '/workspace/Route_ecc', {
+      stepPath: ROUTE_STEP_FEATURE_PATH,
+    })
+    const staDbPath = '/workspace/Sta_ecc/feature/STA.db.json'
+    const sta = stepWith('STA', 'Success', '/workspace/Sta_ecc', {
+      analysisPath: STA_ANALYSIS_PATH,
+      dbPath: staDbPath,
+      dbExists: true,
+    })
+    testState.getWorkspaceResourceIndexApi.mockResolvedValue({
+      ...workspaceIndex(),
+      flow: { steps: [route, sta] },
+    })
+    testState.readOptionalProjectTextFile.mockImplementation(async (path: string) => {
+      if (path === STA_ANALYSIS_PATH) {
+        return JSON.stringify({ metrics: [{ id: 'sta_setup_wns', value: -0.12 }] })
+      }
+      if (
+        path ===
+        `${STA_ANALYSIS_PATH.slice(0, -'qor_metrics.json'.length)}qor_summary.json`
+      ) {
+        return JSON.stringify({ quality_status: 'pass', metric_count: 1 })
+      }
+      if (path === staDbPath) {
+        return JSON.stringify({
+          Instances: { macros: { num: 9 }, logic: { num: 800 }, iopads: { num: 21 } },
+        })
+      }
+      if (path === ROUTE_STEP_FEATURE_PATH) {
+        return JSON.stringify({ route: { instance_cnt: 432, total_pins: 54 } })
+      }
+      return null
+    })
+
+    const overview = scope.run(() => useDashboardOverview())!
+    await vi.waitFor(() => {
+      expect(overview.qorSteps.value).toHaveLength(2)
+    })
+
+    const metric = (id: string) =>
+      overview.keyMetrics.value.find((entry) => entry.id === id)
+    expect(metric('macro-number')?.value).toBe(9)
+    expect(metric('std-cell-number')?.value).toBe(800)
+    expect(metric('io-pad-number')?.value).toBe(21)
+    expect(testState.readOptionalProjectTextFile).not.toHaveBeenCalledWith(
+      ROUTE_STEP_FEATURE_PATH,
+    )
   })
 })

--- a/ecos/gui/apps/renderer/src/composables/useDashboardOverview.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDashboardOverview.ts
@@ -9,6 +9,7 @@ import {
   dashboardMetricSourceStepIndexes,
   dashboardMetrics,
   instanceMetricsFromDbFeature,
+  instanceMetricsFromStepFeature,
   maxFanoutFromParameters,
   metricsFromAnalysis,
   mpcDisplayNameFromParameters,
@@ -76,21 +77,43 @@ async function synthesisDashboardMetrics(
 async function dbFeatureDashboardMetrics(
   step: WorkspaceStepResource,
 ): Promise<Map<string, number>> {
-  const stepName = step.name.trim().toLowerCase()
-  if (
-    !['floorplan', 'fixfanout', 'place', 'cts', 'legalization', 'route'].includes(
-      stepName,
-    )
-  ) {
-    return new Map()
-  }
-
   const dbPath = step.resources.feature.db
   if (!dbPath?.exists) return new Map()
   return metricsFromTextWith(
     await readAuthorizedProjectTextFile(dbPath.path),
     instanceMetricsFromDbFeature,
   )
+}
+
+function hasDbFeature(step: WorkspaceStepResource | undefined): boolean {
+  return Boolean(step?.resources.feature.db?.exists)
+}
+
+async function previousSuccessfulStepFeatureMetrics(
+  steps: readonly WorkspaceStepResource[],
+  currentIndex: number,
+): Promise<Map<string, number>> {
+  for (let index = currentIndex - 1; index >= 0; index -= 1) {
+    const step = steps[index]
+    if (!step || !isSuccessfulStep(step) || !step.resources.feature.step?.exists) continue
+    return metricsFromTextWith(
+      await readAuthorizedProjectTextFile(step.resources.feature.step.path),
+      instanceMetricsFromStepFeature,
+    )
+  }
+  return new Map()
+}
+
+function isSuccessfulStep(step: WorkspaceStepResource): boolean {
+  switch (step.state.trim().toLowerCase()) {
+    case 'success':
+    case 'succeeded':
+    case 'complete':
+    case 'completed':
+      return true
+    default:
+      return false
+  }
 }
 
 function metricsFromTextWith(
@@ -187,15 +210,41 @@ export function useDashboardOverview() {
 
       const latestSourceStep =
         sourceIndexes.length === 1 ? nextIndex.flow.steps[sourceIndexes[0]!] : null
+      const latestSourceGroup =
+        sourceIndexes.length === 1 ? metricGroups[sourceIndexes[0]!] : undefined
       const nextMetricValues =
         latestSourceStep?.name.trim().toLowerCase() === 'synthesis'
-          ? await synthesisDashboardMetrics(latestSourceStep)
+          ? mergeMetrics([
+              await synthesisDashboardMetrics(latestSourceStep),
+              latestSourceGroup?.metrics ?? new Map<string, number>(),
+            ])
           : mergeMetrics(
               sourceIndexes.flatMap((index) => {
                 const group = metricGroups[index]
                 return group ? [group.metrics] : []
               }),
             )
+      const latestSourceIndex = sourceIndexes.length === 1 ? sourceIndexes[0] : undefined
+      const latestSource =
+        latestSourceIndex === undefined
+          ? undefined
+          : nextIndex.flow.steps[latestSourceIndex]
+      if (
+        latestSourceIndex !== undefined &&
+        latestSource &&
+        !hasDbFeature(latestSource)
+      ) {
+        const fallbackMetrics = await previousSuccessfulStepFeatureMetrics(
+          nextIndex.flow.steps,
+          latestSourceIndex,
+        )
+        if (token !== loadToken || currentProject.value?.path !== projectPath) return
+        const merged = mergeMetrics([fallbackMetrics, nextMetricValues])
+        index.value = nextIndex
+        qorSteps.value = metricGroups.map((group) => group.step)
+        metricValues.value = merged
+        return
+      }
       if (token !== loadToken || currentProject.value?.path !== projectPath) return
 
       index.value = nextIndex


### PR DESCRIPTION
## Summary

restore dashboard physical metrics fallback

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
