### PR TITLE
fix(gui): preserve config baseline and log copy

### DIFF
--- a/ecos/gui/apps/renderer/src/components/StepConfigPanel.vue
+++ b/ecos/gui/apps/renderer/src/components/StepConfigPanel.vue
@@ -162,6 +162,7 @@
                     v-if="currentStep"
                     v-model="stepConfigDraft"
                     :step="currentStep"
+                    @initialized="markStepConfigEditorInitialized"
                   />
                 </template>
               </template>
@@ -206,6 +207,7 @@ const {
   isSavingStepConfig,
   stepConfigSaveError,
   isMutationLocked,
+  markStepConfigEditorInitialized,
   saveStepConfig,
   resetStepConfig,
   reloadStepConfigFiles,

--- a/ecos/gui/apps/renderer/src/components/step-config/StepConfigDynamicView.vue
+++ b/ecos/gui/apps/renderer/src/components/step-config/StepConfigDynamicView.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  computed,
-  defineAsyncComponent,
-  onMounted,
-  type Component,
-} from 'vue'
+import { computed, defineAsyncComponent, onMounted, type Component } from 'vue'
 import { StepEnum } from '@/api/type'
 import GenericStepConfigView from './GenericStepConfigView.vue'
 /** Sync import: async chunks mount after flex scroll layout in WebKit/GTK, which can break .sc-scroll overflow. */

--- a/ecos/gui/apps/renderer/src/components/step-config/StepConfigDynamicView.vue
+++ b/ecos/gui/apps/renderer/src/components/step-config/StepConfigDynamicView.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, type Component } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  onMounted,
+  type Component,
+} from 'vue'
 import { StepEnum } from '@/api/type'
 import GenericStepConfigView from './GenericStepConfigView.vue'
 /** Sync import: async chunks mount after flex scroll layout in WebKit/GTK, which can break .sc-scroll overflow. */
@@ -10,6 +15,8 @@ const draft = defineModel<unknown>({ required: true })
 const props = defineProps<{
   step: StepEnum
 }>()
+const emit = defineEmits<{ initialized: [] }>()
+let initialized = false
 const CtsStepConfigView = defineAsyncComponent(
   () => import('./views/CtsStepConfigView.vue'),
 )
@@ -35,8 +42,20 @@ const VIEW_MAP: Partial<Record<StepEnum, Component>> = {
 }
 
 const activeView = computed(() => VIEW_MAP[props.step] ?? GenericStepConfigView)
+
+function emitInitialized(): void {
+  if (initialized) return
+  initialized = true
+  emit('initialized')
+}
+
+onMounted(() => {
+  if (activeView.value !== DrcStepConfigView && activeView.value !== PlStepConfigView) {
+    emitInitialized()
+  }
+})
 </script>
 
 <template>
-  <component :is="activeView" v-model="draft" />
+  <component :is="activeView" v-model="draft" @initialized="emitInitialized" />
 </template>

--- a/ecos/gui/apps/renderer/src/components/step-config/views/DrcStepConfigView.vue
+++ b/ecos/gui/apps/renderer/src/components/step-config/views/DrcStepConfigView.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import InputText from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
 
 const draft = defineModel<Record<string, unknown>>({ required: true })
+const emit = defineEmits<{ initialized: [] }>()
 
 function isObj(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v)
@@ -18,6 +20,7 @@ function ensure(): void {
 }
 
 ensure()
+onMounted(() => emit('initialized'))
 </script>
 
 <template>

--- a/ecos/gui/apps/renderer/src/components/step-config/views/FloorplanStepConfigView.vue
+++ b/ecos/gui/apps/renderer/src/components/step-config/views/FloorplanStepConfigView.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import { watchEffect } from 'vue'
+import { onMounted, watchEffect } from 'vue'
 import InputText from 'primevue/inputtext'
 import InputNumber from 'primevue/inputnumber'
 import Checkbox from 'primevue/checkbox'
 
 const draft = defineModel<Record<string, unknown>>({ required: true })
+const emit = defineEmits<{ initialized: [] }>()
+
+onMounted(() => emit('initialized'))
 
 function isObj(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v)

--- a/ecos/gui/apps/renderer/src/components/step-config/views/PlStepConfigView.vue
+++ b/ecos/gui/apps/renderer/src/components/step-config/views/PlStepConfigView.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import { computed, watchEffect } from 'vue'
+import { computed, onMounted, watchEffect } from 'vue'
 import InputText from 'primevue/inputtext'
 import InputNumber from 'primevue/inputnumber'
 import GenericStepConfigView from '../GenericStepConfigView.vue'
 
 const draft = defineModel<Record<string, unknown>>({ required: true })
+const emit = defineEmits<{ initialized: [] }>()
+
+onMounted(() => emit('initialized'))
 
 function isObj(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v)

--- a/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.test.ts
+++ b/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.test.ts
@@ -10,6 +10,14 @@ describe('FlowLogPanel embedded controls', () => {
     expect(source).toContain('ri-arrow-up-s-line')
   })
 
+  it('keeps copy available in the maximizable log dialog', () => {
+    expect(source).toContain('<template #header>')
+    expect(source).toContain('class="flow-log-dialog-header"')
+    expect(source).toContain('@click="copyLog"')
+    expect(source).toContain('class="flow-log-dialog-content"')
+    expect(source).toContain(':content="selectedContent"')
+  })
+
   it('uses the selected flow node to switch logs and render its concise runtime title', () => {
     expect(source).toContain('selectedNode: FlowStatusNode | null')
     expect(source).toContain('selectSegmentForNode')

--- a/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.vue
+++ b/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.vue
@@ -80,7 +80,10 @@
             :disabled="!selectedContent"
             @click="copyLog"
           >
-            <i :class="copied ? 'ri-check-line' : 'ri-file-copy-line'" aria-hidden="true" />
+            <i
+              :class="copied ? 'ri-check-line' : 'ri-file-copy-line'"
+              aria-hidden="true"
+            />
           </button>
         </div>
       </div>

--- a/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.vue
+++ b/ecos/gui/apps/renderer/src/components/workbench/FlowLogPanel.vue
@@ -66,13 +66,32 @@
     class="flow-log-dialog"
     modal
     maximizable
-    :header="logTitle"
     :style="{ width: 'min(980px, calc(100vw - 32px))' }"
     :draggable="false"
   >
-    <pre class="flow-log-dialog-content">{{
-      selectedContent || 'No log content yet.'
-    }}</pre>
+    <template #header>
+      <div class="flow-log-dialog-header">
+        <span class="flow-log-dialog-title">{{ logTitle }}</span>
+        <div class="flow-log-actions">
+          <button
+            type="button"
+            :title="copied ? 'Copied' : 'Copy log'"
+            :aria-label="copied ? 'Copied log' : 'Copy log'"
+            :disabled="!selectedContent"
+            @click="copyLog"
+          >
+            <i :class="copied ? 'ri-check-line' : 'ri-file-copy-line'" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </template>
+    <FlowLogCodeViewer
+      class="flow-log-dialog-content"
+      :content="selectedContent"
+      :live="Boolean(selectedSegment?.live)"
+      :loading="loading || Boolean(selectedSegment?.contentLoading)"
+      :missing="Boolean(selectedSegment?.missing)"
+    />
   </Dialog>
 </template>
 
@@ -328,20 +347,29 @@ onBeforeUnmount(() => {
 }
 
 .flow-log-dialog-content {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  color: var(--text-primary);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 12px;
-  line-height: 1.5;
-  margin: 0;
-  max-height: min(70vh, 760px);
+  flex: 1 1 auto;
+  height: min(70vh, 760px);
   min-height: 0;
-  overflow: auto;
-  padding: 12px;
-  user-select: text;
-  white-space: pre-wrap;
-  word-break: break-word;
+  min-width: 0;
+}
+
+.flow-log-dialog-header {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  gap: 8px;
+  min-width: 0;
+}
+
+.flow-log-dialog-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.flow-log-dialog-header .flow-log-actions {
+  margin-left: auto;
 }
 </style>
 

--- a/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.test.ts
@@ -11,7 +11,7 @@ const testState = vi.hoisted(() => ({
 }))
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, ref, type EffectScope } from 'vue'
+import { effectScope, nextTick, ref, watch, type EffectScope } from 'vue'
 import { InfoEnum, StepEnum } from '@/api/type'
 
 vi.mock('vue-router', () => ({
@@ -506,6 +506,42 @@ describe('useStepConfigInfo', () => {
     await vi.waitFor(() => {
       expect(result.hasStepConfigChanges.value).toBe(false)
     })
+  })
+
+  it('does not treat editor-created empty containers as unsaved changes', async () => {
+    testState.resolveWorkspaceStepInfoApi.mockResolvedValue({
+      response: 'available',
+      info: { config: '/workspace/demo/config/fp_default_config.json' },
+      missing: [],
+      message: [],
+      id: 'config',
+      step: 'Floorplan',
+    })
+    testState.readProjectTextFile.mockResolvedValue('{}')
+
+    const result = scope.run(() => useStepConfigInfo())!
+    watch(
+      result.stepConfigDraft,
+      (draft) => {
+        if (draft && typeof draft === 'object' && !('Floorplan' in draft)) {
+          ;(draft as Record<string, unknown>).Floorplan = {}
+        }
+      },
+      { deep: true },
+    )
+
+    await vi.waitFor(() => expect(result.stepConfigDraft.value).toEqual({ Floorplan: {} }))
+    result.markStepConfigEditorInitialized()
+    expect(result.hasStepConfigChanges.value).toBe(false)
+
+    ;(result.stepConfigDraft.value as Record<string, unknown>).Floorplan = {
+      'Tap distance': 10,
+    }
+    expect(result.hasStepConfigChanges.value).toBe(true)
+
+    result.resetStepConfig()
+    await nextTick()
+    expect(result.hasStepConfigChanges.value).toBe(false)
   })
 
   it('rejects step config saves while the workspace flow is running', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.test.ts
@@ -530,7 +530,9 @@ describe('useStepConfigInfo', () => {
       { deep: true },
     )
 
-    await vi.waitFor(() => expect(result.stepConfigDraft.value).toEqual({ Floorplan: {} }))
+    await vi.waitFor(() =>
+      expect(result.stepConfigDraft.value).toEqual({ Floorplan: {} }),
+    )
     result.markStepConfigEditorInitialized()
     expect(result.hasStepConfigChanges.value).toBe(false)
 

--- a/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.ts
+++ b/ecos/gui/apps/renderer/src/composables/useStepConfigInfo.ts
@@ -1,4 +1,4 @@
-import { ref, computed, unref, watch, type Ref } from 'vue'
+import { computed, nextTick, ref, unref, watch, type Ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { CMDEnum, InfoEnum, ResponseEnum, StepEnum } from '@/api/type'
 import { syncConfigApi } from '@/api/flow'
@@ -112,6 +112,9 @@ export function useStepConfigInfo(stepOverride?: StepEnum | Ref<StepEnum | undef
   const isSavingStepConfig = ref(false)
   const activeStepConfigSave = ref<symbol | null>(null)
   const stepConfigSaveError = ref<string | null>(null)
+  // Specialized editors add empty containers during their first render.
+  let initialEditorDraftPending = false
+  let stepConfigEditorMounted = false
   const isMutationLocked = computed(() =>
     isFlowExecutionActiveForWorkspace(currentProject.value?.path),
   )
@@ -224,6 +227,7 @@ export function useStepConfigInfo(stepOverride?: StepEnum | Ref<StepEnum | undef
   function syncDraftFromRaw(): void {
     const raw = stepConfigRaw.value
     stepConfigSaveError.value = null
+    initialEditorDraftPending = false
     if (raw == null || raw === '') {
       stepConfigDraft.value = null
       stepConfigBaselineSig.value = ''
@@ -245,6 +249,13 @@ export function useStepConfigInfo(stepOverride?: StepEnum | Ref<StepEnum | undef
         currentStep.value,
       )
       stepConfigBaselineSig.value = stableJsonSig(parsed)
+      // Floorplan/placement/DRC forms materialize missing containers on mount. Let
+      // that view-only initialization become the baseline, but keep routing's
+      // enforced layer pinning dirty so it still requires an explicit save.
+      initialEditorDraftPending = currentStep.value !== StepEnum.ROUTING
+      if (stepConfigEditorMounted) {
+        void nextTick(markStepConfigEditorInitialized)
+      }
       stepConfigTextDraft.value = ''
       stepConfigTextBaseline.value = ''
     } catch {
@@ -365,6 +376,13 @@ export function useStepConfigInfo(stepOverride?: StepEnum | Ref<StepEnum | undef
     },
     { immediate: true },
   )
+
+  function markStepConfigEditorInitialized(): void {
+    stepConfigEditorMounted = true
+    if (!initialEditorDraftPending || stepConfigDraft.value === null) return
+    stepConfigBaselineSig.value = stableJsonSig(stepConfigDraft.value)
+    initialEditorDraftPending = false
+  }
 
   const hasStepConfigChanges = computed(() => {
     const raw = stepConfigRaw.value
@@ -546,6 +564,7 @@ export function useStepConfigInfo(stepOverride?: StepEnum | Ref<StepEnum | undef
     isSavingStepConfig,
     stepConfigSaveError,
     isMutationLocked,
+    markStepConfigEditorInitialized,
     saveStepConfig,
     resetStepConfig,
     reloadStepConfigFiles,


### PR DESCRIPTION
## Summary

- Keep editor-created empty config containers from appearing as unsaved changes.
- Restore log copying in the maximizable log dialog by using the shared log viewer.
- Add focused coverage for both regressions.

## Scope

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

- [x] `cd ecos/gui && pnpm install --frozen-lockfile`
- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run lint`
- [x] `cd ecos/gui && pnpm run fmt:check`
- [x] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`

Skipped checks and reason:

- `pnpm run build`: skipped; this change does not affect packaging or release inputs.
- Manual GUI smoke and screenshots: not captured in the current environment.

## Screenshots or Recordings

Not captured in the current environment.

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- The local `ecc` submodule has an unrelated uncommitted pointer change and is not included in this PR.

## Checklist

- [x] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.