### PR TITLE
feat: add chip design 3d view

### DIFF
--- a/ecos/chip-viewer/apps/chip-viewer-native/src/app.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/app.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
-use chip_display::{FillPattern, LayerRole, LayerStyle};
+use chip_display::{FillPattern, LayerRole, LayerStack, LayerStyle};
 use chip_render::{RenderCacheStats, RenderPlanCache, ViewTilePlaneCache};
 use chip_view_db::{
     ChipViewDb, ChipViewMemoryStats, ConnectivityMetadata, DeltaStats, GridMetadata, NearestShape,
@@ -156,6 +156,11 @@ struct LoadedViewer {
     ruler_tool: OrthogonalRuler,
     object_visibility: ObjectVisibility,
     coordinate_unit: CoordinateUnit,
+    view_mode: ViewMode,
+    camera3d: crate::camera3d::OrbitCamera,
+    layer_stack: LayerStack,
+    view3d_fitted: bool,
+    view3d_bootstrapped: bool,
     sidebar_info_panel: Option<SidebarInfoPanel>,
     geometry_epoch: u64,
     owner_category_cache: OwnerCategoryCache,
@@ -729,6 +734,12 @@ fn ruler_start_requested(
 enum CoordinateUnit {
     Dbu,
     Micron,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ViewMode {
+    TwoD,
+    ThreeD,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2016,6 +2027,11 @@ impl LoadedViewer {
             ruler_tool: OrthogonalRuler::default(),
             object_visibility: ObjectVisibility::default(),
             coordinate_unit: CoordinateUnit::Dbu,
+            view_mode: ViewMode::TwoD,
+            camera3d: crate::camera3d::OrbitCamera::default(),
+            layer_stack: LayerStack::default(),
+            view3d_fitted: false,
+            view3d_bootstrapped: false,
             sidebar_info_panel: None,
             geometry_epoch: 1,
             owner_category_cache: OwnerCategoryCache::default(),
@@ -2551,11 +2567,36 @@ impl LoadedViewer {
             });
         });
         ui.horizontal(|ui| {
+            for (mode, label) in [(ViewMode::TwoD, "2D"), (ViewMode::ThreeD, "3D")] {
+                if ui
+                    .selectable_label(self.view_mode == mode, label)
+                    .on_hover_text(if mode == ViewMode::ThreeD {
+                        "Orbit the extruded metal stack"
+                    } else {
+                        "Plan-view layout canvas"
+                    })
+                    .clicked()
+                {
+                    if self.view_mode != mode {
+                        self.view_mode = mode;
+                        self.pan_drag.reset();
+                        self.focus_animation = None;
+                        if mode == ViewMode::ThreeD {
+                            self.view3d_fitted = false;
+                        }
+                    }
+                }
+            }
+            ui.separator();
             if ui.button("⛶").on_hover_text("Fit layout to view").clicked() {
                 self.focus_animation = None;
-                self.zoom = 1.0;
-                self.pan = egui::Vec2::ZERO;
                 self.pan_drag.reset();
+                if self.view_mode == ViewMode::ThreeD {
+                    self.view3d_fitted = false;
+                } else {
+                    self.zoom = 1.0;
+                    self.pan = egui::Vec2::ZERO;
+                }
             }
             let can_reload = self.pending_edit.is_none() && self.draft.is_none();
             if ui
@@ -2608,6 +2649,36 @@ impl LoadedViewer {
                 self.shortcuts_overlay_visible = !self.shortcuts_overlay_visible;
             }
         });
+        if self.view_mode == ViewMode::ThreeD {
+            ui.horizontal(|ui| {
+                if ui
+                    .small_button("Iso")
+                    .on_hover_text("Isometric camera")
+                    .clicked()
+                {
+                    self.camera3d.set_iso();
+                }
+                if ui
+                    .small_button("Top")
+                    .on_hover_text("Look down from +Z")
+                    .clicked()
+                {
+                    self.camera3d.set_top();
+                }
+                if ui
+                    .small_button("Front")
+                    .on_hover_text("Look across the stack")
+                    .clicked()
+                {
+                    self.camera3d.set_front();
+                }
+            });
+            ui.add(
+                egui::Slider::new(&mut self.camera3d.z_scale, 0.05..=6.0)
+                    .logarithmic(true)
+                    .text("Z-scale"),
+            );
+        }
     }
 
     fn sidebar_physical_layers_section(&mut self, ui: &mut egui::Ui, max_height: f32) {
@@ -3103,6 +3174,20 @@ impl LoadedViewer {
             );
             return;
         };
+
+        if self.view_mode == ViewMode::ThreeD {
+            self.canvas_3d(
+                ui,
+                &response,
+                canvas,
+                &painter,
+                pointer_over_layout,
+                pointer_over_heatmap,
+                drag_started_in_canvas,
+                world,
+            );
+            return;
+        }
 
         if response.hovered() && !pointer_over_heatmap {
             let raw_scroll_delta_y = ui.ctx().input(|input| input.raw_scroll_delta.y);
@@ -4258,6 +4343,450 @@ impl LoadedViewer {
             });
     }
 
+    fn canvas_3d(
+        &mut self,
+        ui: &mut egui::Ui,
+        response: &egui::Response,
+        canvas: egui::Rect,
+        painter: &egui::Painter,
+        pointer_over_layout: bool,
+        pointer_over_heatmap: bool,
+        drag_started_in_canvas: bool,
+        world: Rect32,
+    ) {
+        self.ensure_3d_view(world, canvas);
+
+        if let Some(focus) = self.pending_focus.take() {
+            let span = ((focus.bbox.hx - focus.bbox.lx).max(focus.bbox.hy - focus.bbox.ly) as f32)
+                .max(1.0);
+            self.camera3d.focus_xy(
+                (focus.bbox.lx + focus.bbox.hx) as f32 * 0.5,
+                (focus.bbox.ly + focus.bbox.hy) as f32 * 0.5,
+                span,
+                self.layer_stack.height(),
+            );
+            self.selected = focus.select_shape_id;
+            self.pan_drag.reset();
+        }
+
+        let pointer_over_zoom_target = !pointer_over_heatmap
+            && ui.ctx().input(|input| {
+                input
+                    .pointer
+                    .hover_pos()
+                    .is_some_and(|pos| canvas.contains(pos) || response.rect.contains(pos))
+            });
+        if pointer_over_zoom_target {
+            let (scroll_y, pinch_zoom) = ui.ctx().input(|input| {
+                let scroll_y = if input.raw_scroll_delta.y.abs() > f32::EPSILON {
+                    input.raw_scroll_delta.y
+                } else {
+                    input.smooth_scroll_delta.y
+                };
+                (scroll_y, input.zoom_delta())
+            });
+            let zoom_factor = if scroll_y.abs() > f32::EPSILON {
+                scroll_zoom_factor(scroll_y)
+            } else {
+                pinch_zoom
+            };
+            if (zoom_factor - 1.0).abs() > f32::EPSILON {
+                let pivot = ui
+                    .ctx()
+                    .input(|input| input.pointer.hover_pos())
+                    .and_then(|pos| {
+                        self.camera3d
+                            .ray_from_screen(
+                                [pos.x, pos.y],
+                                [canvas.left(), canvas.top()],
+                                [canvas.width(), canvas.height()],
+                            )
+                            .and_then(|ray| {
+                                ray.intersect_z_plane(self.camera3d.target.z)
+                                    .or_else(|| ray.intersect_z_plane(0.0))
+                            })
+                    });
+                self.camera3d
+                    .zoom_toward(1.0 / zoom_factor.max(0.05), pivot);
+                ui.ctx().input_mut(|input| {
+                    input.raw_scroll_delta.y = 0.0;
+                    input.smooth_scroll_delta.y = 0.0;
+                });
+                self.pan_drag.reset();
+                ui.ctx().request_repaint();
+            }
+        }
+
+        if response.drag_started() && drag_started_in_canvas && !pointer_over_heatmap {
+            let mode = if response.drag_started_by(egui::PointerButton::Middle)
+                || response.drag_started_by(egui::PointerButton::Secondary)
+            {
+                Some(CanvasDragMode::Edit)
+            } else if response.drag_started_by(egui::PointerButton::Primary) {
+                Some(CanvasDragMode::Pan)
+            } else {
+                None
+            };
+            if let Some(mode) = mode {
+                self.pan_drag.start(mode);
+            }
+        }
+        if response.dragged() && !pointer_over_heatmap {
+            let delta = response.drag_delta();
+            match self.pan_drag.mode() {
+                Some(CanvasDragMode::Edit) => {
+                    self.camera3d.orbit(delta.x * 0.008, -delta.y * 0.008);
+                    ui.ctx().request_repaint();
+                }
+                Some(CanvasDragMode::Pan) => {
+                    self.camera3d.pan(delta.x, delta.y);
+                    ui.ctx().request_repaint();
+                }
+                _ => {}
+            }
+        }
+        if response.drag_stopped() {
+            self.pan_drag.reset();
+        }
+
+        let query_layer_ids = render_query_layer_ids(&self.layers, self.object_visibility);
+        if response.clicked_by(egui::PointerButton::Primary) && pointer_over_layout {
+            self.selected = response
+                .interact_pointer_pos()
+                .and_then(|pos| self.pick_shape_at_3d(pos, canvas, world, &query_layer_ids));
+        }
+
+        if pointer_over_layout {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::Grab);
+        }
+
+        let aspect = (canvas.width() / canvas.height().max(1.0)).max(0.2);
+        let viewport = crate::canvas_gpu3d::query_rect_for_camera(self.camera3d, world, aspect);
+        let instances =
+            std::sync::Arc::new(self.build_3d_instances(world, viewport, &query_layer_ids));
+        let drawn = instances.len();
+
+        if !self.gpu_canvas.enabled || self.gpu_canvas.failed {
+            painter.text(
+                canvas.center(),
+                egui::Align2::CENTER_CENTER,
+                "3D view requires the GPU canvas",
+                egui::FontId::proportional(14.0),
+                ecos_text_secondary(),
+            );
+        } else {
+            let pixels_per_point = ui.ctx().pixels_per_point();
+            let callback = crate::canvas_gpu3d::CanvasGpu3dCallback {
+                uniform: crate::canvas_gpu3d::CanvasUniform3d::from_camera(self.camera3d, aspect),
+                instances,
+                target_pixels: [
+                    (canvas.width() * pixels_per_point).round().max(1.0) as u32,
+                    (canvas.height() * pixels_per_point).round().max(1.0) as u32,
+                ],
+                target_format: self.gpu_canvas.target_format,
+            };
+            ui.painter()
+                .add(egui_wgpu::Callback::new_paint_callback(canvas, callback));
+        }
+
+        self.status_line_buffer.clear();
+        use std::fmt::Write as _;
+        let using_overview_tiles = crate::canvas_gpu3d::use_overview_slabs(self.camera3d, world)
+            && self.db.view_tile_count() > 0
+            && drawn > 0;
+        let _ = write!(
+            self.status_line_buffer,
+            "3D  {} {}  yaw {:.0}°  pitch {:.0}°  z×{:.1}",
+            drawn,
+            if using_overview_tiles {
+                "tiles"
+            } else {
+                "shapes"
+            },
+            self.camera3d.yaw.to_degrees(),
+            self.camera3d.pitch.to_degrees(),
+            self.camera3d.z_scale
+        );
+        painter.text(
+            canvas.left_top() + egui::vec2(10.0, 10.0),
+            egui::Align2::LEFT_TOP,
+            self.status_line_buffer.as_str(),
+            egui::FontId::proportional(13.0),
+            ecos_text_secondary(),
+        );
+
+        if let Some(pos) = ui
+            .ctx()
+            .input(|input| input.pointer.hover_pos())
+            .filter(|_| pointer_over_layout)
+        {
+            if let Some(point) = self.hover_world_point_3d(pos, canvas) {
+                self.status_line_buffer.clear();
+                hover_status_line_into(
+                    &mut self.status_line_buffer,
+                    point,
+                    self.coordinate_unit,
+                    self.db.snapshot().manifest().dbu_per_micron,
+                    None,
+                );
+                painter.text(
+                    canvas.left_top() + egui::vec2(10.0, 28.0),
+                    egui::Align2::LEFT_TOP,
+                    self.status_line_buffer.as_str(),
+                    egui::FontId::monospace(12.0),
+                    ecos_text_secondary(),
+                );
+            }
+        }
+
+        self.canvas_info_overlay(ui, canvas);
+        self.drc_detail_overlay(ui, canvas);
+        self.antenna_detail_overlay(ui, canvas);
+        self.map_heatmap_overlay(ui, canvas);
+    }
+
+    fn ensure_3d_view(&mut self, world: Rect32, canvas: egui::Rect) {
+        self.rebuild_layer_stack();
+        if !self.view3d_bootstrapped {
+            self.view3d_bootstrapped = true;
+            if visible_layer_count(&self.layers) == 0 {
+                set_layer_visibility(&mut self.layers, true);
+            }
+            if !self.object_visibility.net_signal
+                && !self.object_visibility.net_clock
+                && !self.object_visibility.pdn
+                && !self.object_visibility.vias
+            {
+                self.object_visibility.net_signal = true;
+                self.object_visibility.vias = true;
+                self.apply_object_visibility();
+            }
+        }
+        if !self.view3d_fitted {
+            let aspect = (canvas.width() / canvas.height().max(1.0)).max(0.2);
+            self.camera3d.fit_world_with_aspect(
+                crate::camera3d::Vec3::new(world.lx as f32, world.ly as f32, 0.0),
+                crate::camera3d::Vec3::new(world.hx as f32, world.hy as f32, 0.0),
+                self.layer_stack.height(),
+                aspect,
+            );
+            self.view3d_fitted = true;
+        }
+    }
+
+    fn rebuild_layer_stack(&mut self) {
+        let mut entries: Vec<(LayerId, LayerRole, u32)> = self
+            .layers
+            .iter()
+            .map(|layer| {
+                (
+                    layer.layer_id,
+                    LayerRole::from_metadata(&layer.name, &layer.layer_type),
+                    layer.order,
+                )
+            })
+            .collect();
+        if !entries
+            .iter()
+            .any(|(layer_id, _, _)| *layer_id == LAYOUT_GEOMETRY_LAYER)
+        {
+            entries.push((LAYOUT_GEOMETRY_LAYER, LayerRole::Overlap, 0));
+        }
+        self.layer_stack = chip_display::heuristic_layer_stack(entries);
+    }
+
+    fn build_3d_instances(
+        &self,
+        world: Rect32,
+        viewport: Rect32,
+        query_layer_ids: &[LayerId],
+    ) -> Vec<crate::canvas_gpu3d::GpuShapeInstance3d> {
+        if crate::canvas_gpu3d::use_overview_slabs(self.camera3d, world)
+            && self.db.view_tile_count() > 0
+        {
+            let overview = self.build_3d_overview_instances(world, viewport);
+            if !overview.is_empty() {
+                return overview;
+            }
+        }
+
+        let visibility_hash = layers_visibility_hash(&self.layers);
+        let layer_index = if self.visibility_rules_cache.epoch == self.geometry_epoch
+            && self.visibility_rules_cache.layer_visibility_hash == visibility_hash
+        {
+            Some(&self.visibility_rules_cache.layer_index)
+        } else {
+            None
+        };
+        let fallback_index = layer_index
+            .is_none()
+            .then(|| LayerRenderIndex::new(&self.layers));
+        let layer_index = layer_index.unwrap_or_else(|| fallback_index.as_ref().unwrap());
+        let zoom_rules = ZoomVisibilityRules::new(&self.db);
+
+        let mut prepared = Vec::new();
+        for shape_id in self
+            .db
+            .query_layers_intersect(query_layer_ids, viewport)
+            .into_iter()
+            .chain(overlay_shape_ids(self.selected, &self.highlighted))
+        {
+            let Some(shape) = self.db.find_shape(shape_id) else {
+                continue;
+            };
+            if !is_renderable_shape(shape) {
+                continue;
+            }
+            let owner = self.db.owner_for_shape(shape);
+            let owner_type = owner.and_then(|owner| OwnerType::from_raw(owner.owner_type));
+            if !zoom_rules.is_drawn_at_zoom(owner_type, 8.0) {
+                continue;
+            }
+            let owner_category =
+                owner.and_then(|owner| drawing_category_for_owner(&self.db, owner));
+            if !shape_is_visible_fast(
+                shape,
+                owner_type,
+                owner_category,
+                layer_index,
+                &self.object_visibility,
+            ) {
+                continue;
+            }
+            let Some(mut style) =
+                visible_style_for_shape_fast(shape, owner, owner_type, layer_index)
+            else {
+                continue;
+            };
+            if self.selected == Some(shape_id) {
+                style.rgba = [76, 196, 255, 230];
+                style.fill_alpha = 230;
+            } else if self.highlighted.contains(&shape_id) {
+                style.rgba = [255, 214, 90, 210];
+                style.fill_alpha = 210;
+            }
+            let band =
+                self.layer_stack
+                    .band(shape.layer_id)
+                    .unwrap_or(chip_display::LayerStackBand {
+                        layer_id: shape.layer_id,
+                        z0: 0.0,
+                        z1: 400.0,
+                    });
+            prepared.push((self.db.shape_geometry(shape), style, band.z0, band.z1));
+            if prepared.len() >= crate::canvas_gpu3d::MAX_3D_INSTANCES {
+                break;
+            }
+        }
+        crate::canvas_gpu3d::build_gpu_instances_3d(prepared.into_iter())
+    }
+
+    fn build_3d_overview_instances(
+        &self,
+        world: Rect32,
+        viewport: Rect32,
+    ) -> Vec<crate::canvas_gpu3d::GpuShapeInstance3d> {
+        let mut layers: Vec<(&LayerUiState, chip_display::LayerStackBand)> = self
+            .layers
+            .iter()
+            .filter(|layer| layer.visible)
+            .filter_map(|layer| {
+                self.layer_stack
+                    .band(layer.layer_id)
+                    .map(|band| (layer, band))
+            })
+            .collect();
+        layers.sort_by(|lhs, rhs| lhs.1.z0.total_cmp(&rhs.1.z0));
+        let layer_ids: Vec<LayerId> = layers.iter().map(|(layer, _)| layer.layer_id).collect();
+        let preferred_lod = select_overview_lod(&self.db, &layer_ids, viewport, world)
+            .unwrap_or_else(|| crate::canvas_gpu3d::overview_lod_level(self.camera3d, world));
+
+        let mut instances = Vec::new();
+        for (layer, band) in layers {
+            for tile in
+                overview_tiles_for_layer(&self.db, preferred_lod, layer.layer_id, viewport, world)
+            {
+                crate::canvas_gpu3d::push_overview_tile_instance(
+                    &mut instances,
+                    tile.bbox,
+                    tile.shape_count,
+                    band.z0,
+                    band.z1,
+                    &layer.style,
+                );
+                if instances.len() >= crate::canvas_gpu3d::MAX_3D_INSTANCES {
+                    return instances;
+                }
+            }
+        }
+        instances
+    }
+
+    fn hover_world_point_3d(&self, pos: egui::Pos2, canvas: egui::Rect) -> Option<Point32> {
+        let ray = self.camera3d.ray_from_screen(
+            [pos.x, pos.y],
+            [canvas.left(), canvas.top()],
+            [canvas.width(), canvas.height()],
+        )?;
+        let hit = ray.intersect_z_plane(0.0)?;
+        Some(Point32 {
+            x: hit.x.round() as i32,
+            y: hit.y.round() as i32,
+        })
+    }
+
+    fn pick_shape_at_3d(
+        &self,
+        pos: egui::Pos2,
+        canvas: egui::Rect,
+        world: Rect32,
+        query_layer_ids: &[LayerId],
+    ) -> Option<ShapeId> {
+        let ray = self.camera3d.ray_from_screen(
+            [pos.x, pos.y],
+            [canvas.left(), canvas.top()],
+            [canvas.width(), canvas.height()],
+        )?;
+        let aspect = (canvas.width() / canvas.height().max(1.0)).max(0.2);
+        let viewport = crate::canvas_gpu3d::query_rect_for_camera(self.camera3d, world, aspect);
+        let mut best: Option<(f32, ShapeId)> = None;
+        for shape_id in self.db.query_layers_intersect(query_layer_ids, viewport) {
+            let Some(shape) = self.db.find_shape(shape_id) else {
+                continue;
+            };
+            if !is_renderable_shape(shape) || !self.shape_is_visible(shape) {
+                continue;
+            }
+            let Some(rect) = shape_xy_rect(self.db.shape_geometry(shape)) else {
+                continue;
+            };
+            let band =
+                self.layer_stack
+                    .band(shape.layer_id)
+                    .unwrap_or(chip_display::LayerStackBand {
+                        layer_id: shape.layer_id,
+                        z0: 0.0,
+                        z1: 400.0,
+                    });
+            let min = crate::camera3d::Vec3::new(
+                rect.lx as f32,
+                rect.ly as f32,
+                band.z0 * self.camera3d.z_scale,
+            );
+            let max = crate::camera3d::Vec3::new(
+                rect.hx as f32,
+                rect.hy as f32,
+                band.z1 * self.camera3d.z_scale,
+            );
+            if let Some(t) = ray.intersect_aabb(min, max) {
+                if best.is_none_or(|(best_t, _)| t < best_t) {
+                    best = Some((t, shape_id));
+                }
+            }
+        }
+        best.map(|(_, shape_id)| shape_id)
+    }
+
     fn should_use_view_tiles(&self, viewport: Rect32, world: Rect32) -> bool {
         if self.gpu_canvas.enabled {
             return false;
@@ -4897,6 +5426,8 @@ impl LoadedViewer {
         retain_existing_shape_ids(&mut self.highlighted, |shape_id| {
             db.find_shape(shape_id).is_some()
         });
+        self.rebuild_layer_stack();
+        self.view3d_fitted = false;
     }
 
     fn allocate_command_id(&mut self) -> u64 {
@@ -8168,6 +8699,63 @@ fn translate_rect(rect: Rect32, dx: i32, dy: i32) -> Rect32 {
     }
 }
 
+fn overview_lod_candidates(preferred_lod: u8) -> [u8; 4] {
+    match preferred_lod {
+        3 => [3, 2, 1, 0],
+        2 => [2, 1, 0, 3],
+        1 => [1, 0, 2, 3],
+        _ => [0, 1, 2, 3],
+    }
+}
+
+fn tile_is_useful_overview(tile: &chipgeom_format::GeometryViewTileRecord, world: Rect32) -> bool {
+    tile.shape_count > 0 && !crate::canvas_gpu3d::tile_is_full_die(tile.bbox, world)
+}
+
+fn select_overview_lod(
+    db: &ChipViewDb,
+    layer_ids: &[LayerId],
+    viewport: Rect32,
+    world: Rect32,
+) -> Option<u8> {
+    crate::canvas_gpu3d::choose_overview_lod(
+        [0_u8, 1, 2, 3].into_iter().map(|lod| {
+            let mut total = 0usize;
+            let mut useful = 0usize;
+            for layer_id in layer_ids {
+                for tile in db.query_view_tiles(lod, *layer_id, viewport) {
+                    total += 1;
+                    if tile_is_useful_overview(tile, world) {
+                        useful += 1;
+                    }
+                }
+            }
+            (lod, total, useful)
+        }),
+        crate::canvas_gpu3d::OVERVIEW_INSTANCE_BUDGET,
+    )
+}
+
+fn overview_tiles_for_layer<'a>(
+    db: &'a ChipViewDb,
+    preferred_lod: u8,
+    layer_id: LayerId,
+    viewport: Rect32,
+    world: Rect32,
+) -> Vec<&'a chipgeom_format::GeometryViewTileRecord> {
+    for lod in overview_lod_candidates(preferred_lod) {
+        let tiles: Vec<_> = db
+            .query_view_tiles(lod, layer_id, viewport)
+            .into_iter()
+            .filter(|tile| tile_is_useful_overview(tile, world))
+            .collect();
+        if !tiles.is_empty() {
+            return tiles;
+        }
+    }
+    Vec::new()
+}
+
 fn should_use_view_tiles_for_state(
     view_tile_count: usize,
     _has_highlight: bool,
@@ -8595,6 +9183,44 @@ fn overlay_shape_ids(
         overlay.insert(shape_id);
     }
     overlay
+}
+
+fn shape_xy_rect(geometry: ShapeGeometry) -> Option<Rect32> {
+    match geometry {
+        ShapeGeometry::Rect(rect) => Some(rect),
+        ShapeGeometry::Line(line) => {
+            let width = line.width.abs().max(80);
+            let half = (width / 2).max(40);
+            if line.begin.y == line.end.y {
+                Some(Rect32 {
+                    lx: line.begin.x.min(line.end.x),
+                    ly: line.begin.y.saturating_sub(half),
+                    hx: line.begin.x.max(line.end.x),
+                    hy: line.begin.y.saturating_add(half),
+                })
+            } else if line.begin.x == line.end.x {
+                Some(Rect32 {
+                    lx: line.begin.x.saturating_sub(half),
+                    ly: line.begin.y.min(line.end.y),
+                    hx: line.begin.x.saturating_add(half),
+                    hy: line.begin.y.max(line.end.y),
+                })
+            } else {
+                Some(Rect32 {
+                    lx: line.begin.x.min(line.end.x).saturating_sub(half),
+                    ly: line.begin.y.min(line.end.y).saturating_sub(half),
+                    hx: line.begin.x.max(line.end.x).saturating_add(half),
+                    hy: line.begin.y.max(line.end.y).saturating_add(half),
+                })
+            }
+        }
+        ShapeGeometry::Point(point) => Some(Rect32 {
+            lx: point.point.x.saturating_sub(80),
+            ly: point.point.y.saturating_sub(80),
+            hx: point.point.x.saturating_add(80),
+            hy: point.point.y.saturating_add(80),
+        }),
+    }
 }
 
 fn clear_search_state(search_text: &mut String, highlighted: &mut BTreeSet<ShapeId>) {
@@ -9820,6 +10446,170 @@ mod tests {
             overview_viewport,
             world,
         ));
+    }
+
+    #[test]
+    fn overview_tile_query_falls_back_when_preferred_lod_is_missing() {
+        let dir = temp_snapshot_dir("3d-overview-lod-fallback");
+        write_empty_snapshot(&dir, false);
+        let tile = chipgeom_format::GeometryViewTileRecord {
+            lod_level: 2,
+            layer_id: 4,
+            shape_count: 12,
+            bbox: Rect32 {
+                lx: 10,
+                ly: 20,
+                hx: 110,
+                hy: 220,
+            },
+            ..chipgeom_format::GeometryViewTileRecord::default()
+        };
+        write_empty_geometry_file(
+            &dir.join("geometry.view.bin"),
+            chipgeom_format::GeometryFileKind::View,
+            core::mem::size_of::<chipgeom_format::GeometryViewTileRecord>() as u32,
+            any_as_bytes(&tile),
+        );
+        let db = ChipViewDb::open(dir.join("geometry.manifest")).unwrap();
+        let viewport = Rect32 {
+            lx: 0,
+            ly: 0,
+            hx: 1_000,
+            hy: 1_000,
+        };
+        let tiles = overview_tiles_for_layer(&db, 3, 4, viewport, viewport);
+        assert_eq!(tiles.len(), 1);
+        assert_eq!(tiles[0].lod_level, 2);
+        assert_eq!(tiles[0].bbox.lx, 10);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn three_d_overview_extrudes_snapshot_tiles_instead_of_full_die_slabs() {
+        let dir = temp_snapshot_dir("3d-overview-tiles");
+        write_empty_snapshot(&dir, false);
+        let tile = chipgeom_format::GeometryViewTileRecord {
+            lod_level: 3,
+            layer_id: 1,
+            shape_count: 32,
+            bbox: Rect32 {
+                lx: 100,
+                ly: 200,
+                hx: 1_400,
+                hy: 1_800,
+            },
+            ..chipgeom_format::GeometryViewTileRecord::default()
+        };
+        write_empty_geometry_file(
+            &dir.join("geometry.view.bin"),
+            chipgeom_format::GeometryFileKind::View,
+            core::mem::size_of::<chipgeom_format::GeometryViewTileRecord>() as u32,
+            any_as_bytes(&tile),
+        );
+        let db = ChipViewDb::open(dir.join("geometry.manifest")).unwrap();
+        let mut loaded = LoadedViewer::new(
+            db,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            wgpu::TextureFormat::Bgra8Unorm,
+        );
+        loaded.layers = vec![layer_state(1, true)];
+        loaded.rebuild_layer_stack();
+        let world = Rect32 {
+            lx: 0,
+            ly: 0,
+            hx: 10_000,
+            hy: 8_000,
+        };
+        loaded.camera3d.fit_world(
+            crate::camera3d::Vec3::new(world.lx as f32, world.ly as f32, 0.0),
+            crate::camera3d::Vec3::new(world.hx as f32, world.hy as f32, 0.0),
+            loaded.layer_stack.height(),
+        );
+        let instances = loaded.build_3d_instances(world, world, &[1]);
+        assert_eq!(instances.len(), 1);
+        assert_eq!(
+            instances[0].rect_dbu,
+            [tile.bbox.lx, tile.bbox.ly, tile.bbox.hx, tile.bbox.hy]
+        );
+        assert_ne!(
+            instances[0].rect_dbu,
+            [world.lx, world.ly, world.hx, world.hy]
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn three_d_fit_prefers_detailed_tiles_over_full_die_panels() {
+        let dir = temp_snapshot_dir("3d-fit-detailed-tiles");
+        write_empty_snapshot(&dir, false);
+        let world = Rect32 {
+            lx: 0,
+            ly: 0,
+            hx: 10_000,
+            hy: 8_000,
+        };
+        let coarse = chipgeom_format::GeometryViewTileRecord {
+            lod_level: 3,
+            layer_id: 1,
+            shape_count: 80,
+            bbox: world,
+            ..chipgeom_format::GeometryViewTileRecord::default()
+        };
+        let fine = chipgeom_format::GeometryViewTileRecord {
+            lod_level: 0,
+            layer_id: 1,
+            shape_count: 6,
+            bbox: Rect32 {
+                lx: 200,
+                ly: 300,
+                hx: 900,
+                hy: 1_100,
+            },
+            ..chipgeom_format::GeometryViewTileRecord::default()
+        };
+        let mut payload = Vec::new();
+        payload.extend_from_slice(any_as_bytes(&coarse));
+        payload.extend_from_slice(any_as_bytes(&fine));
+        write_empty_geometry_file(
+            &dir.join("geometry.view.bin"),
+            chipgeom_format::GeometryFileKind::View,
+            core::mem::size_of::<chipgeom_format::GeometryViewTileRecord>() as u32,
+            &payload,
+        );
+        let db = ChipViewDb::open(dir.join("geometry.manifest")).unwrap();
+        let mut loaded = LoadedViewer::new(
+            db,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            wgpu::TextureFormat::Bgra8Unorm,
+        );
+        loaded.layers = vec![layer_state(1, true)];
+        loaded.rebuild_layer_stack();
+        loaded.camera3d.fit_world_with_aspect(
+            crate::camera3d::Vec3::new(world.lx as f32, world.ly as f32, 0.0),
+            crate::camera3d::Vec3::new(world.hx as f32, world.hy as f32, 0.0),
+            loaded.layer_stack.height(),
+            1.2,
+        );
+        let instances = loaded.build_3d_instances(world, world, &[1]);
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].rect_dbu, [200, 300, 900, 1_100]);
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/ecos/chip-viewer/apps/chip-viewer-native/src/camera3d.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/camera3d.rs
@@ -1,0 +1,518 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Vec3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+impl Vec3 {
+    pub const ZERO: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+    pub const UNIT_Z: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        z: 1.0,
+    };
+
+    pub fn new(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+
+    pub fn to_array(self) -> [f32; 3] {
+        [self.x, self.y, self.z]
+    }
+
+    pub fn length(self) -> f32 {
+        self.x.hypot(self.y).hypot(self.z)
+    }
+
+    pub fn normalized(self) -> Self {
+        let length = self.length();
+        if length <= f32::EPSILON {
+            Self::ZERO
+        } else {
+            Self::new(self.x / length, self.y / length, self.z / length)
+        }
+    }
+
+    pub fn dot(self, other: Self) -> f32 {
+        self.x * other.x + self.y * other.y + self.z * other.z
+    }
+
+    pub fn cross(self, other: Self) -> Self {
+        Self::new(
+            self.y * other.z - self.z * other.y,
+            self.z * other.x - self.x * other.z,
+            self.x * other.y - self.y * other.x,
+        )
+    }
+
+    pub fn add(self, other: Self) -> Self {
+        Self::new(self.x + other.x, self.y + other.y, self.z + other.z)
+    }
+
+    pub fn sub(self, other: Self) -> Self {
+        Self::new(self.x - other.x, self.y - other.y, self.z - other.z)
+    }
+
+    pub fn scale(self, value: f32) -> Self {
+        Self::new(self.x * value, self.y * value, self.z * value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Mat4 {
+    pub cols: [[f32; 4]; 4],
+}
+
+impl Mat4 {
+    pub fn from_cols(cols: [[f32; 4]; 4]) -> Self {
+        Self { cols }
+    }
+
+    pub fn mul(self, other: Self) -> Self {
+        let mut cols = [[0.0; 4]; 4];
+        for c in 0..4 {
+            for r in 0..4 {
+                cols[c][r] = (0..4).map(|k| self.cols[k][r] * other.cols[c][k]).sum();
+            }
+        }
+        Self { cols }
+    }
+
+    pub fn transform_point(self, point: [f32; 4]) -> [f32; 4] {
+        let mut out = [0.0; 4];
+        for r in 0..4 {
+            out[r] = (0..4).map(|c| self.cols[c][r] * point[c]).sum();
+        }
+        out
+    }
+
+    pub fn invert(self) -> Option<Self> {
+        let m = self.cols;
+        let mut inv = [[0.0; 4]; 4];
+
+        inv[0][0] =
+            m[1][1] * m[2][2] * m[3][3] - m[1][1] * m[2][3] * m[3][2] - m[2][1] * m[1][2] * m[3][3]
+                + m[2][1] * m[1][3] * m[3][2]
+                + m[3][1] * m[1][2] * m[2][3]
+                - m[3][1] * m[1][3] * m[2][2];
+        inv[1][0] = -m[1][0] * m[2][2] * m[3][3]
+            + m[1][0] * m[2][3] * m[3][2]
+            + m[2][0] * m[1][2] * m[3][3]
+            - m[2][0] * m[1][3] * m[3][2]
+            - m[3][0] * m[1][2] * m[2][3]
+            + m[3][0] * m[1][3] * m[2][2];
+        inv[2][0] =
+            m[1][0] * m[2][1] * m[3][3] - m[1][0] * m[2][3] * m[3][1] - m[2][0] * m[1][1] * m[3][3]
+                + m[2][0] * m[1][3] * m[3][1]
+                + m[3][0] * m[1][1] * m[2][3]
+                - m[3][0] * m[1][3] * m[2][1];
+        inv[3][0] = -m[1][0] * m[2][1] * m[3][2]
+            + m[1][0] * m[2][2] * m[3][1]
+            + m[2][0] * m[1][1] * m[3][2]
+            - m[2][0] * m[1][2] * m[3][1]
+            - m[3][0] * m[1][1] * m[2][2]
+            + m[3][0] * m[1][2] * m[2][1];
+        inv[0][1] = -m[0][1] * m[2][2] * m[3][3]
+            + m[0][1] * m[2][3] * m[3][2]
+            + m[2][1] * m[0][2] * m[3][3]
+            - m[2][1] * m[0][3] * m[3][2]
+            - m[3][1] * m[0][2] * m[2][3]
+            + m[3][1] * m[0][3] * m[2][2];
+        inv[1][1] =
+            m[0][0] * m[2][2] * m[3][3] - m[0][0] * m[2][3] * m[3][2] - m[2][0] * m[0][2] * m[3][3]
+                + m[2][0] * m[0][3] * m[3][2]
+                + m[3][0] * m[0][2] * m[2][3]
+                - m[3][0] * m[0][3] * m[2][2];
+        inv[2][1] = -m[0][0] * m[2][1] * m[3][3]
+            + m[0][0] * m[2][3] * m[3][1]
+            + m[2][0] * m[0][1] * m[3][3]
+            - m[2][0] * m[0][3] * m[3][1]
+            - m[3][0] * m[0][1] * m[2][3]
+            + m[3][0] * m[0][3] * m[2][1];
+        inv[3][1] =
+            m[0][0] * m[2][1] * m[3][2] - m[0][0] * m[2][2] * m[3][1] - m[2][0] * m[0][1] * m[3][2]
+                + m[2][0] * m[0][2] * m[3][1]
+                + m[3][0] * m[0][1] * m[2][2]
+                - m[3][0] * m[0][2] * m[2][1];
+        inv[0][2] =
+            m[0][1] * m[1][2] * m[3][3] - m[0][1] * m[1][3] * m[3][2] - m[1][1] * m[0][2] * m[3][3]
+                + m[1][1] * m[0][3] * m[3][2]
+                + m[3][1] * m[0][2] * m[1][3]
+                - m[3][1] * m[0][3] * m[1][2];
+        inv[1][2] = -m[0][0] * m[1][2] * m[3][3]
+            + m[0][0] * m[1][3] * m[3][2]
+            + m[1][0] * m[0][2] * m[3][3]
+            - m[1][0] * m[0][3] * m[3][2]
+            - m[3][0] * m[0][2] * m[1][3]
+            + m[3][0] * m[0][3] * m[1][2];
+        inv[2][2] =
+            m[0][0] * m[1][1] * m[3][3] - m[0][0] * m[1][3] * m[3][1] - m[1][0] * m[0][1] * m[3][3]
+                + m[1][0] * m[0][3] * m[3][1]
+                + m[3][0] * m[0][1] * m[1][3]
+                - m[3][0] * m[0][3] * m[1][1];
+        inv[3][2] = -m[0][0] * m[1][1] * m[3][2]
+            + m[0][0] * m[1][2] * m[3][1]
+            + m[1][0] * m[0][1] * m[3][2]
+            - m[1][0] * m[0][2] * m[3][1]
+            - m[3][0] * m[0][1] * m[1][2]
+            + m[3][0] * m[0][2] * m[1][1];
+        inv[0][3] = -m[0][1] * m[1][2] * m[2][3]
+            + m[0][1] * m[1][3] * m[2][2]
+            + m[1][1] * m[0][2] * m[2][3]
+            - m[1][1] * m[0][3] * m[2][2]
+            - m[2][1] * m[0][2] * m[1][3]
+            + m[2][1] * m[0][3] * m[1][2];
+        inv[1][3] =
+            m[0][0] * m[1][2] * m[2][3] - m[0][0] * m[1][3] * m[2][2] - m[1][0] * m[0][2] * m[2][3]
+                + m[1][0] * m[0][3] * m[2][2]
+                + m[2][0] * m[0][2] * m[1][3]
+                - m[2][0] * m[0][3] * m[1][2];
+        inv[2][3] = -m[0][0] * m[1][1] * m[2][3]
+            + m[0][0] * m[1][3] * m[2][1]
+            + m[1][0] * m[0][1] * m[2][3]
+            - m[1][0] * m[0][3] * m[2][1]
+            - m[2][0] * m[0][1] * m[1][3]
+            + m[2][0] * m[0][3] * m[1][1];
+        inv[3][3] =
+            m[0][0] * m[1][1] * m[2][2] - m[0][0] * m[1][2] * m[2][1] - m[1][0] * m[0][1] * m[2][2]
+                + m[1][0] * m[0][2] * m[2][1]
+                + m[2][0] * m[0][1] * m[1][2]
+                - m[2][0] * m[0][2] * m[1][1];
+
+        let det =
+            m[0][0] * inv[0][0] + m[0][1] * inv[1][0] + m[0][2] * inv[2][0] + m[0][3] * inv[3][0];
+        if det.abs() <= 1e-8 {
+            return None;
+        }
+        let inv_det = 1.0 / det;
+        for col in &mut inv {
+            for value in col {
+                *value *= inv_det;
+            }
+        }
+        Some(Self { cols: inv })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Ray3 {
+    pub origin: Vec3,
+    pub direction: Vec3,
+}
+
+impl Ray3 {
+    pub fn point_at(self, t: f32) -> Vec3 {
+        self.origin.add(self.direction.scale(t))
+    }
+
+    pub fn intersect_z_plane(self, z: f32) -> Option<Vec3> {
+        if self.direction.z.abs() <= 1e-6 {
+            return None;
+        }
+        let t = (z - self.origin.z) / self.direction.z;
+        (t >= 0.0).then(|| self.point_at(t))
+    }
+
+    pub fn intersect_aabb(self, min: Vec3, max: Vec3) -> Option<f32> {
+        let mut tmin = 0.0_f32;
+        let mut tmax = f32::INFINITY;
+        for (origin, dir, min_b, max_b) in [
+            (self.origin.x, self.direction.x, min.x, max.x),
+            (self.origin.y, self.direction.y, min.y, max.y),
+            (self.origin.z, self.direction.z, min.z, max.z),
+        ] {
+            if dir.abs() <= 1e-8 {
+                if origin < min_b || origin > max_b {
+                    return None;
+                }
+                continue;
+            }
+            let inv = 1.0 / dir;
+            let mut t0 = (min_b - origin) * inv;
+            let mut t1 = (max_b - origin) * inv;
+            if t0 > t1 {
+                std::mem::swap(&mut t0, &mut t1);
+            }
+            tmin = tmin.max(t0);
+            tmax = tmax.min(t1);
+            if tmax < tmin {
+                return None;
+            }
+        }
+        let t = if tmin >= 0.0 { tmin } else { tmax };
+        (t >= 0.0).then_some(t)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct OrbitCamera {
+    pub target: Vec3,
+    pub distance: f32,
+    pub yaw: f32,
+    pub pitch: f32,
+    pub z_scale: f32,
+    pub fov_y: f32,
+}
+
+impl Default for OrbitCamera {
+    fn default() -> Self {
+        Self {
+            target: Vec3::ZERO,
+            distance: 1.0,
+            yaw: 45_f32.to_radians(),
+            pitch: 38_f32.to_radians(),
+            z_scale: 1.0,
+            fov_y: 40_f32.to_radians(),
+        }
+    }
+}
+
+impl OrbitCamera {
+    pub const MIN_PITCH: f32 = 6_f32.to_radians();
+    pub const MAX_PITCH: f32 = 88_f32.to_radians();
+
+    pub fn fit_world(&mut self, world_min: Vec3, world_max: Vec3, stack_height: f32) {
+        self.fit_world_with_aspect(world_min, world_max, stack_height, 1.0);
+    }
+
+    pub fn fit_world_with_aspect(
+        &mut self,
+        world_min: Vec3,
+        world_max: Vec3,
+        stack_height: f32,
+        aspect: f32,
+    ) {
+        let width = (world_max.x - world_min.x).max(1.0);
+        let height = (world_max.y - world_min.y).max(1.0);
+        self.z_scale = auto_z_scale(width, height, stack_height);
+        self.target = Vec3::new(
+            (world_min.x + world_max.x) * 0.5,
+            (world_min.y + world_max.y) * 0.5,
+            stack_height * self.z_scale * 0.45,
+        );
+        self.yaw = 45_f32.to_radians();
+        self.pitch = 38_f32.to_radians();
+        self.distance = fit_camera_distance(
+            width.hypot(height),
+            stack_height * self.z_scale,
+            self.fov_y,
+            aspect,
+        );
+    }
+
+    pub fn set_iso(&mut self) {
+        self.yaw = 45_f32.to_radians();
+        self.pitch = 38_f32.to_radians();
+    }
+
+    pub fn set_top(&mut self) {
+        self.yaw = -90_f32.to_radians();
+        self.pitch = Self::MAX_PITCH;
+    }
+
+    pub fn set_front(&mut self) {
+        self.yaw = -90_f32.to_radians();
+        self.pitch = 12_f32.to_radians();
+    }
+
+    pub fn focus_xy(&mut self, x: f32, y: f32, span: f32, stack_height: f32) {
+        self.target.x = x;
+        self.target.y = y;
+        self.target.z = stack_height * self.z_scale * 0.45;
+        self.distance = span.max(1.0) * 2.4;
+    }
+
+    pub fn eye(self) -> Vec3 {
+        let cos_pitch = self.pitch.cos();
+        Vec3::new(
+            self.target.x + self.distance * cos_pitch * self.yaw.cos(),
+            self.target.y + self.distance * cos_pitch * self.yaw.sin(),
+            self.target.z + self.distance * self.pitch.sin(),
+        )
+    }
+
+    pub fn orbit(&mut self, delta_yaw: f32, delta_pitch: f32) {
+        self.yaw += delta_yaw;
+        self.pitch = (self.pitch + delta_pitch).clamp(Self::MIN_PITCH, Self::MAX_PITCH);
+    }
+
+    pub fn zoom(&mut self, factor: f32) {
+        self.zoom_toward(factor, None);
+    }
+
+    pub fn zoom_toward(&mut self, factor: f32, pivot: Option<Vec3>) {
+        let factor = factor.clamp(0.05, 20.0);
+        let new_distance = (self.distance * factor).clamp(1.0, 1.0e12);
+        if let Some(pivot) = pivot {
+            let ratio = new_distance / self.distance.max(1.0);
+            self.target = pivot.add(self.target.sub(pivot).scale(ratio));
+        }
+        self.distance = new_distance;
+    }
+
+    pub fn pan(&mut self, delta_x: f32, delta_y: f32) {
+        let eye = self.eye();
+        let forward = self.target.sub(eye).normalized();
+        let right = forward.cross(Vec3::UNIT_Z).normalized();
+        let up = right.cross(forward).normalized();
+        let scale = self.distance * 0.0025;
+        self.target = self
+            .target
+            .add(right.scale(-delta_x * scale))
+            .add(up.scale(delta_y * scale));
+    }
+
+    pub fn view_proj(self, aspect: f32) -> Mat4 {
+        let eye = self.eye();
+        let view = look_at(eye, self.target, Vec3::UNIT_Z);
+        let near = (self.distance * 0.01).max(1.0);
+        let far = (self.distance * 20.0).max(near * 10.0);
+        perspective(self.fov_y, aspect.max(0.05), near, far).mul(view)
+    }
+
+    pub fn ray_from_screen(
+        self,
+        pos: [f32; 2],
+        canvas_min: [f32; 2],
+        canvas_size: [f32; 2],
+    ) -> Option<Ray3> {
+        if canvas_size[0] <= 1.0 || canvas_size[1] <= 1.0 {
+            return None;
+        }
+        let ndc_x = ((pos[0] - canvas_min[0]) / canvas_size[0]) * 2.0 - 1.0;
+        let ndc_y = 1.0 - ((pos[1] - canvas_min[1]) / canvas_size[1]) * 2.0;
+        let inv = self.view_proj(canvas_size[0] / canvas_size[1]).invert()?;
+        let near = unproject(inv, [ndc_x, ndc_y, 0.0])?;
+        let far = unproject(inv, [ndc_x, ndc_y, 1.0])?;
+        Some(Ray3 {
+            origin: near,
+            direction: far.sub(near).normalized(),
+        })
+    }
+}
+
+pub fn fit_camera_distance(diagonal: f32, stack_height: f32, fov_y: f32, aspect: f32) -> f32 {
+    let diagonal = diagonal.max(1.0);
+    let extent = diagonal.max(stack_height.max(0.0));
+    let half_fov = (fov_y * 0.5).max(0.05);
+    let aspect = aspect.max(0.2);
+    // Iso yaw presents the die diagonal on screen. Keep a margin so the
+    // near edge and metal stack stay inside the canvas after Fit.
+    let framed = extent * 1.22;
+    framed / (2.0 * half_fov.tan() * aspect.min(1.0))
+}
+
+fn auto_z_scale(world_width: f32, world_height: f32, stack_height: f32) -> f32 {
+    let stack_height = stack_height.max(1.0);
+    let diagonal = world_width.hypot(world_height).max(1.0);
+    (diagonal * 0.02 / stack_height).clamp(0.1, 4.0)
+}
+
+pub fn look_at(eye: Vec3, target: Vec3, up: Vec3) -> Mat4 {
+    let forward = target.sub(eye).normalized();
+    let right = forward.cross(up).normalized();
+    let up = right.cross(forward).normalized();
+    Mat4::from_cols([
+        [right.x, up.x, -forward.x, 0.0],
+        [right.y, up.y, -forward.y, 0.0],
+        [right.z, up.z, -forward.z, 0.0],
+        [-right.dot(eye), -up.dot(eye), forward.dot(eye), 1.0],
+    ])
+}
+
+pub fn perspective(fov_y: f32, aspect: f32, near: f32, far: f32) -> Mat4 {
+    let f = 1.0 / (fov_y * 0.5).tan();
+    Mat4::from_cols([
+        [f / aspect, 0.0, 0.0, 0.0],
+        [0.0, f, 0.0, 0.0],
+        [0.0, 0.0, far / (near - far), -1.0],
+        [0.0, 0.0, (far * near) / (near - far), 0.0],
+    ])
+}
+
+fn unproject(inv_view_proj: Mat4, ndc: [f32; 3]) -> Option<Vec3> {
+    let clip = inv_view_proj.transform_point([ndc[0], ndc[1], ndc[2], 1.0]);
+    if clip[3].abs() <= 1e-8 {
+        return None;
+    }
+    Some(Vec3::new(
+        clip[0] / clip[3],
+        clip[1] / clip[3],
+        clip[2] / clip[3],
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orbit_eye_sits_above_target_at_top_view() {
+        let mut camera = OrbitCamera::default();
+        camera.target = Vec3::new(10.0, 20.0, 0.0);
+        camera.distance = 100.0;
+        camera.set_top();
+        let eye = camera.eye();
+        assert!(eye.z > camera.target.z);
+        assert!((eye.x - camera.target.x).abs() < 10.0);
+        assert!((eye.y - camera.target.y).abs() < 10.0);
+    }
+
+    #[test]
+    fn ray_hits_unit_aabb() {
+        let ray = Ray3 {
+            origin: Vec3::new(-10.0, 0.5, 0.5),
+            direction: Vec3::new(1.0, 0.0, 0.0),
+        };
+        let t = ray
+            .intersect_aabb(Vec3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 1.0, 1.0))
+            .unwrap();
+        assert!((t - 10.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn view_proj_is_invertible() {
+        let camera = OrbitCamera {
+            target: Vec3::new(100.0, 200.0, 10.0),
+            distance: 500.0,
+            ..OrbitCamera::default()
+        };
+        assert!(camera.view_proj(1.5).invert().is_some());
+    }
+
+    #[test]
+    fn fit_world_backs_up_enough_to_frame_iso_silhouette() {
+        let mut camera = OrbitCamera::default();
+        camera.fit_world_with_aspect(
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(10_000.0, 8_000.0, 0.0),
+            4_000.0,
+            1.35,
+        );
+        let diagonal = 10_000.0_f32.hypot(8_000.0);
+        assert!(camera.distance > diagonal * 1.45);
+        assert!(camera.distance < diagonal * 2.4);
+        let tight = fit_camera_distance(diagonal, 0.0, camera.fov_y, 0.7);
+        let wide = fit_camera_distance(diagonal, 0.0, camera.fov_y, 1.6);
+        assert!(tight > wide);
+    }
+
+    #[test]
+    fn zoom_toward_keeps_pivot_and_shortens_distance() {
+        let mut camera = OrbitCamera {
+            target: Vec3::new(100.0, 100.0, 10.0),
+            distance: 400.0,
+            ..OrbitCamera::default()
+        };
+        let pivot = Vec3::new(80.0, 90.0, 0.0);
+        camera.zoom_toward(0.5, Some(pivot));
+        assert!((camera.distance - 200.0).abs() < 1e-3);
+        assert!((camera.target.x - 90.0).abs() < 1e-3);
+        assert!((camera.target.y - 95.0).abs() < 1e-3);
+    }
+}

--- a/ecos/chip-viewer/apps/chip-viewer-native/src/canvas_gpu3d.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/canvas_gpu3d.rs
@@ -1,0 +1,990 @@
+use std::sync::Arc;
+
+use crate::camera3d::OrbitCamera;
+use crate::canvas_gpu::pack_rgba_u32;
+use bytemuck::{Pod, Zeroable};
+
+pub const MAX_3D_INSTANCES: usize = 180_000;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct CanvasUniform3d {
+    pub view_proj: [[f32; 4]; 4],
+    pub camera_pos: [f32; 3],
+    pub z_scale: f32,
+    pub light_dir: [f32; 3],
+    pub _pad: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct GpuShapeInstance3d {
+    pub rect_dbu: [i32; 4],
+    pub z0: f32,
+    pub z1: f32,
+    pub fill_rgba: u32,
+    pub flags: u32,
+}
+
+impl CanvasUniform3d {
+    pub fn from_camera(camera: OrbitCamera, aspect: f32) -> Self {
+        let view_proj = camera.view_proj(aspect);
+        let light = crate::camera3d::Vec3::new(0.62, -0.18, 0.76).normalized();
+        Self {
+            view_proj: view_proj.cols,
+            camera_pos: camera.eye().to_array(),
+            z_scale: camera.z_scale,
+            light_dir: light.to_array(),
+            _pad: 0.0,
+        }
+    }
+}
+
+pub fn build_gpu_instances_3d(
+    shapes: impl Iterator<
+        Item = (
+            chip_view_db::ShapeGeometry,
+            chip_display::LayerStyle,
+            f32,
+            f32,
+        ),
+    >,
+) -> Vec<GpuShapeInstance3d> {
+    let mut instances = Vec::new();
+    for (geometry, style, z0, z1) in shapes {
+        if instances.len() >= MAX_3D_INSTANCES {
+            break;
+        }
+        let Some((rect_dbu, flags)) = geometry_to_instance(geometry) else {
+            continue;
+        };
+        instances.push(GpuShapeInstance3d {
+            rect_dbu,
+            z0,
+            z1: z1.max(z0 + 1.0),
+            fill_rgba: pack_rgba_u32(layer_style_rgba_3d(&style)),
+            flags,
+        });
+    }
+    instances
+}
+
+pub fn slab_instance(
+    rect: chipgeom_format::Rect32,
+    z0: f32,
+    z1: f32,
+    rgba: [u8; 4],
+) -> GpuShapeInstance3d {
+    GpuShapeInstance3d {
+        rect_dbu: [rect.lx, rect.ly, rect.hx, rect.hy],
+        z0,
+        z1: z1.max(z0 + 1.0),
+        fill_rgba: pack_rgba_u32(rgba),
+        flags: 0,
+    }
+}
+
+pub fn layer_style_rgba_3d(style: &chip_display::LayerStyle) -> [u8; 4] {
+    let source = if style.fill_alpha == 0 {
+        [
+            style.frame_rgba[0],
+            style.frame_rgba[1],
+            style.frame_rgba[2],
+        ]
+    } else {
+        [style.rgba[0], style.rgba[1], style.rgba[2]]
+    };
+    let rgb = tech_layer_rgb(source);
+    [rgb[0], rgb[1], rgb[2], 208]
+}
+
+fn tech_layer_rgb(rgb: [u8; 3]) -> [u8; 3] {
+    const PAIRS: [([u8; 3], [u8; 3]); 14] = [
+        ([126, 204, 255], [36, 214, 255]),
+        ([255, 211, 111], [255, 164, 32]),
+        ([119, 225, 175], [18, 232, 158]),
+        ([255, 150, 185], [255, 58, 138]),
+        ([176, 155, 255], [164, 112, 255]),
+        ([255, 236, 150], [255, 210, 88]),
+        ([255, 218, 112], [255, 188, 56]),
+        ([255, 244, 186], [255, 226, 132]),
+        ([242, 224, 255], [206, 184, 255]),
+        ([108, 222, 236], [40, 236, 248]),
+        ([255, 216, 120], [255, 176, 48]),
+        ([255, 224, 142], [255, 198, 84]),
+        ([160, 242, 255], [96, 236, 255]),
+        ([84, 168, 255], [48, 168, 255]),
+    ];
+    let mut best = None;
+    for (source, tech) in PAIRS {
+        let dist = rgb_distance2(rgb, source);
+        if best.is_none_or(|(best_dist, _)| dist < best_dist) {
+            best = Some((dist, tech));
+        }
+    }
+    if let Some((dist, tech)) = best {
+        if dist <= 28 * 28 {
+            return tech;
+        }
+    }
+    neonize_rgb(rgb)
+}
+
+fn rgb_distance2(lhs: [u8; 3], rhs: [u8; 3]) -> i32 {
+    let dr = i32::from(lhs[0]) - i32::from(rhs[0]);
+    let dg = i32::from(lhs[1]) - i32::from(rhs[1]);
+    let db = i32::from(lhs[2]) - i32::from(rhs[2]);
+    dr * dr + dg * dg + db * db
+}
+
+fn neonize_rgb(rgb: [u8; 3]) -> [u8; 3] {
+    let max = rgb.into_iter().max().unwrap_or(0) as f32;
+    let min = rgb.into_iter().min().unwrap_or(0) as f32;
+    if max - min < 8.0 {
+        return [72, 196, 220];
+    }
+    let mid = (f32::from(rgb[0]) + f32::from(rgb[1]) + f32::from(rgb[2])) / 3.0;
+    let boosted = rgb.map(|channel| {
+        let value = mid + (f32::from(channel) - mid) * 1.55;
+        value.clamp(16.0, 255.0)
+    });
+    let peak = boosted.into_iter().fold(1.0_f32, f32::max);
+    boosted.map(|channel| ((channel / peak) * 232.0).round().clamp(24.0, 255.0) as u8)
+}
+
+fn geometry_to_instance(geometry: chip_view_db::ShapeGeometry) -> Option<([i32; 4], u32)> {
+    match geometry {
+        chip_view_db::ShapeGeometry::Rect(rect) => {
+            if rect.hx <= rect.lx || rect.hy <= rect.ly {
+                return None;
+            }
+            Some(([rect.lx, rect.ly, rect.hx, rect.hy], 0))
+        }
+        chip_view_db::ShapeGeometry::Line(line) => Some((line_to_rect_dbu(line), 1)),
+        chip_view_db::ShapeGeometry::Point(point) => {
+            let half = 80;
+            Some((
+                [
+                    point.point.x.saturating_sub(half),
+                    point.point.y.saturating_sub(half),
+                    point.point.x.saturating_add(half),
+                    point.point.y.saturating_add(half),
+                ],
+                2,
+            ))
+        }
+    }
+}
+
+fn line_to_rect_dbu(line: chipgeom_format::LinePayload) -> [i32; 4] {
+    let width = line.width.abs().max(80);
+    let half = (width / 2).max(40);
+    if line.begin.y == line.end.y {
+        let y = line.begin.y;
+        [
+            line.begin.x.min(line.end.x),
+            y.saturating_sub(half),
+            line.begin.x.max(line.end.x),
+            y.saturating_add(half),
+        ]
+    } else if line.begin.x == line.end.x {
+        let x = line.begin.x;
+        [
+            x.saturating_sub(half),
+            line.begin.y.min(line.end.y),
+            x.saturating_add(half),
+            line.begin.y.max(line.end.y),
+        ]
+    } else {
+        [
+            line.begin.x.min(line.end.x).saturating_sub(half),
+            line.begin.y.min(line.end.y).saturating_sub(half),
+            line.begin.x.max(line.end.x).saturating_add(half),
+            line.begin.y.max(line.end.y).saturating_add(half),
+        ]
+    }
+}
+
+const WGSL_SCENE_SHADER: &str = r#"
+struct Uniform3d {
+    view_proj: mat4x4<f32>,
+    camera_pos: vec3<f32>,
+    z_scale: f32,
+    light_dir: vec3<f32>,
+    pad: f32,
+};
+
+struct Instance3d {
+    rect_dbu: vec4<i32>,
+    z0: f32,
+    z1: f32,
+    fill_rgba: u32,
+    flags: u32,
+};
+
+@group(0) @binding(0) var<uniform> u_scene: Uniform3d;
+@group(0) @binding(1) var<storage, read> s_instances: array<Instance3d>;
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) world_normal: vec3<f32>,
+    @location(1) world_position: vec3<f32>,
+    @location(2) @interpolate(flat) instance_idx: u32,
+};
+
+fn unpack_rgba(packed: u32) -> vec4<f32> {
+    let r = f32(packed & 0xFFu) / 255.0;
+    let g = f32((packed >> 8u) & 0xFFu) / 255.0;
+    let b = f32((packed >> 16u) & 0xFFu) / 255.0;
+    let a = f32((packed >> 24u) & 0xFFu) / 255.0;
+    return vec4<f32>(r, g, b, a);
+}
+
+fn srgb_to_linear(srgb: f32) -> f32 {
+    if srgb <= 0.04045 {
+        return srgb / 12.92;
+    }
+    return pow((srgb + 0.055) / 1.055, 2.4);
+}
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vertex_index: u32,
+    @builtin(instance_index) instance_index: u32,
+) -> VertexOutput {
+    var face_normals = array<vec3<f32>, 6>(
+        vec3<f32>(0.0, 0.0, -1.0),
+        vec3<f32>(0.0, 0.0, 1.0),
+        vec3<f32>(0.0, -1.0, 0.0),
+        vec3<f32>(0.0, 1.0, 0.0),
+        vec3<f32>(-1.0, 0.0, 0.0),
+        vec3<f32>(1.0, 0.0, 0.0),
+    );
+    var face_uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(1.0, 1.0),
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(1.0, 1.0),
+        vec2<f32>(0.0, 1.0),
+    );
+
+    let face = vertex_index / 6u;
+    let corner = vertex_index % 6u;
+    let uv = face_uvs[corner];
+    let inst = s_instances[instance_index];
+    let min_xy = vec2<f32>(f32(inst.rect_dbu.x), f32(inst.rect_dbu.y));
+    let max_xy = vec2<f32>(f32(inst.rect_dbu.z), f32(inst.rect_dbu.w));
+    let z0 = inst.z0 * u_scene.z_scale;
+    let z1 = inst.z1 * u_scene.z_scale;
+
+    var position = vec3<f32>(0.0);
+    if face == 0u {
+        position = vec3<f32>(mix(min_xy.x, max_xy.x, uv.x), mix(min_xy.y, max_xy.y, 1.0 - uv.y), z0);
+    } else if face == 1u {
+        position = vec3<f32>(mix(min_xy.x, max_xy.x, uv.x), mix(min_xy.y, max_xy.y, uv.y), z1);
+    } else if face == 2u {
+        position = vec3<f32>(mix(min_xy.x, max_xy.x, uv.x), min_xy.y, mix(z0, z1, uv.y));
+    } else if face == 3u {
+        position = vec3<f32>(mix(max_xy.x, min_xy.x, uv.x), max_xy.y, mix(z0, z1, uv.y));
+    } else if face == 4u {
+        position = vec3<f32>(min_xy.x, mix(max_xy.y, min_xy.y, uv.x), mix(z0, z1, uv.y));
+    } else {
+        position = vec3<f32>(max_xy.x, mix(min_xy.y, max_xy.y, uv.x), mix(z0, z1, uv.y));
+    }
+
+    var out: VertexOutput;
+    out.clip_position = u_scene.view_proj * vec4<f32>(position, 1.0);
+    out.world_normal = face_normals[face];
+    out.world_position = position;
+    out.instance_idx = instance_index;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let inst = s_instances[in.instance_idx];
+    let rgba = unpack_rgba(inst.fill_rgba);
+    let albedo = vec3<f32>(
+        srgb_to_linear(rgba.x),
+        srgb_to_linear(rgba.y),
+        srgb_to_linear(rgba.z),
+    );
+    let normal = normalize(in.world_normal);
+    let view_dir = normalize(u_scene.camera_pos - in.world_position);
+    let light_dir = normalize(u_scene.light_dir);
+    let half_dir = normalize(light_dir + view_dir);
+    let n_dot_l = max(dot(normal, light_dir), 0.0);
+    let n_dot_v = max(dot(normal, view_dir), 0.0);
+    let spec = pow(max(dot(normal, half_dir), 0.0), 42.0);
+    let fresnel = pow(1.0 - n_dot_v, 3.0);
+    let wrap = max(dot(normal, normalize(vec3<f32>(-light_dir.x, -light_dir.y, 0.35))), 0.0);
+
+    let ambient = albedo * 0.08;
+    let key = albedo * n_dot_l * 1.05;
+    let fill = albedo * wrap * 0.16;
+    let rim = vec3<f32>(0.18, 0.78, 1.0) * fresnel * (0.28 + 0.62 * (1.0 - n_dot_l));
+    let highlight = vec3<f32>(0.82, 0.96, 1.0) * spec * 0.62;
+    let color = ambient + key + fill + rim + highlight;
+    return vec4<f32>(color * rgba.w, rgba.w);
+}
+"#;
+
+const WGSL_BLIT_SHADER: &str = r#"
+@group(0) @binding(0) var color_tex: texture_2d<f32>;
+@group(0) @binding(1) var color_samp: sampler;
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(1.0, -1.0),
+        vec2<f32>(1.0, 1.0),
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(1.0, 1.0),
+        vec2<f32>(-1.0, 1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(1.0, 1.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(0.0, 0.0),
+    );
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(positions[vertex_index], 0.0, 1.0);
+    out.uv = uvs[vertex_index];
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(color_tex, color_samp, in.uv);
+}
+"#;
+
+struct OffscreenTarget {
+    color_view: wgpu::TextureView,
+    depth_view: wgpu::TextureView,
+    blit_bind_group: wgpu::BindGroup,
+    width: u32,
+    height: u32,
+}
+
+struct CanvasGpu3dResources {
+    scene_pipeline: wgpu::RenderPipeline,
+    blit_pipeline: wgpu::RenderPipeline,
+    scene_bind_group_layout: wgpu::BindGroupLayout,
+    blit_bind_group_layout: wgpu::BindGroupLayout,
+    uniform_buffer: wgpu::Buffer,
+    sampler: wgpu::Sampler,
+    instance_buffer: Option<wgpu::Buffer>,
+    instance_capacity: u32,
+    scene_bind_group: Option<wgpu::BindGroup>,
+    offscreen: Option<OffscreenTarget>,
+}
+
+impl CanvasGpu3dResources {
+    fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Canvas 3D Uniform Buffer"),
+            size: std::mem::size_of::<CanvasUniform3d>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let scene_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("WGSL_SCENE_3D_SHADER"),
+            source: wgpu::ShaderSource::Wgsl(WGSL_SCENE_SHADER.into()),
+        });
+        let blit_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("WGSL_BLIT_3D_SHADER"),
+            source: wgpu::ShaderSource::Wgsl(WGSL_BLIT_SHADER.into()),
+        });
+        let scene_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Canvas 3D Scene Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+        let blit_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Canvas 3D Blit Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+        let scene_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Canvas 3D Scene Pipeline Layout"),
+                bind_group_layouts: &[&scene_bind_group_layout],
+                push_constant_ranges: &[],
+            });
+        let blit_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Canvas 3D Blit Pipeline Layout"),
+            bind_group_layouts: &[&blit_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+        let scene_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Canvas 3D Scene Pipeline"),
+            layout: Some(&scene_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &scene_shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &scene_shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: Some(wgpu::Face::Back),
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::Less,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+        let blit_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Canvas 3D Blit Pipeline"),
+            layout: Some(&blit_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &blit_shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &blit_shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("Canvas 3D Sampler"),
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+        Self {
+            scene_pipeline,
+            blit_pipeline,
+            scene_bind_group_layout,
+            blit_bind_group_layout,
+            uniform_buffer,
+            sampler,
+            instance_buffer: None,
+            instance_capacity: 0,
+            scene_bind_group: None,
+            offscreen: None,
+        }
+    }
+
+    fn ensure_offscreen(&mut self, device: &wgpu::Device, width: u32, height: u32) {
+        if self
+            .offscreen
+            .as_ref()
+            .is_some_and(|target| target.width == width && target.height == height)
+        {
+            return;
+        }
+        let color = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Canvas 3D Color"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let depth = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Canvas 3D Depth"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth32Float,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let color_view = color.create_view(&wgpu::TextureViewDescriptor::default());
+        let depth_view = depth.create_view(&wgpu::TextureViewDescriptor::default());
+        let blit_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Canvas 3D Blit Bind Group"),
+            layout: &self.blit_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&color_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+            ],
+        });
+        self.offscreen = Some(OffscreenTarget {
+            color_view,
+            depth_view,
+            blit_bind_group,
+            width,
+            height,
+        });
+    }
+
+    fn upload_instances(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        instances: &[GpuShapeInstance3d],
+    ) {
+        let count = instances.len().max(1) as u32;
+        if self.instance_capacity < count {
+            let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("Canvas 3D Instance Buffer"),
+                size: (count as u64).max(64) * std::mem::size_of::<GpuShapeInstance3d>() as u64,
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            self.instance_capacity = count.max(64);
+            self.instance_buffer = Some(buffer);
+            self.scene_bind_group = None;
+        }
+        if let Some(buffer) = &self.instance_buffer {
+            if !instances.is_empty() {
+                queue.write_buffer(buffer, 0, bytemuck::cast_slice(instances));
+            }
+            if self.scene_bind_group.is_none() {
+                self.scene_bind_group =
+                    Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+                        label: Some("Canvas 3D Scene Bind Group"),
+                        layout: &self.scene_bind_group_layout,
+                        entries: &[
+                            wgpu::BindGroupEntry {
+                                binding: 0,
+                                resource: self.uniform_buffer.as_entire_binding(),
+                            },
+                            wgpu::BindGroupEntry {
+                                binding: 1,
+                                resource: buffer.as_entire_binding(),
+                            },
+                        ],
+                    }));
+            }
+        }
+    }
+}
+
+pub struct CanvasGpu3dCallback {
+    pub uniform: CanvasUniform3d,
+    pub instances: Arc<Vec<GpuShapeInstance3d>>,
+    pub target_pixels: [u32; 2],
+    pub target_format: wgpu::TextureFormat,
+}
+
+impl egui_wgpu::CallbackTrait for CanvasGpu3dCallback {
+    fn prepare(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        _screen_descriptor: &egui_wgpu::ScreenDescriptor,
+        egui_encoder: &mut wgpu::CommandEncoder,
+        callback_resources: &mut egui_wgpu::CallbackResources,
+    ) -> Vec<wgpu::CommandBuffer> {
+        if callback_resources.get::<CanvasGpu3dResources>().is_none() {
+            callback_resources.insert(CanvasGpu3dResources::new(device, self.target_format));
+        }
+        let resources: &mut CanvasGpu3dResources = callback_resources.get_mut().unwrap();
+        let width = self.target_pixels[0].max(1);
+        let height = self.target_pixels[1].max(1);
+        resources.ensure_offscreen(device, width, height);
+        resources.upload_instances(device, queue, &self.instances);
+        queue.write_buffer(
+            &resources.uniform_buffer,
+            0,
+            bytemuck::bytes_of(&self.uniform),
+        );
+        let Some(offscreen) = resources.offscreen.as_ref() else {
+            return Vec::new();
+        };
+        let Some(bind_group) = resources.scene_bind_group.as_ref() else {
+            return Vec::new();
+        };
+        {
+            let mut pass = egui_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Canvas 3D Scene Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &offscreen.color_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &offscreen.depth_view,
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: wgpu::StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            if !self.instances.is_empty() {
+                pass.set_pipeline(&resources.scene_pipeline);
+                pass.set_bind_group(0, bind_group, &[]);
+                pass.draw(0..36, 0..self.instances.len() as u32);
+            }
+        }
+        Vec::new()
+    }
+
+    fn paint(
+        &self,
+        info: egui::PaintCallbackInfo,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        callback_resources: &egui_wgpu::CallbackResources,
+    ) {
+        let resources: &CanvasGpu3dResources = callback_resources.get().unwrap();
+        let Some(offscreen) = resources.offscreen.as_ref() else {
+            return;
+        };
+        let clip = info.clip_rect_in_pixels();
+        let clip_min_x = clip.left_px.max(0) as u32;
+        let clip_min_y = clip.top_px.max(0) as u32;
+        let clip_w = clip.width_px.max(0) as u32;
+        let clip_h = clip.height_px.max(0) as u32;
+        if clip_w == 0 || clip_h == 0 {
+            return;
+        }
+        render_pass.set_scissor_rect(clip_min_x, clip_min_y, clip_w, clip_h);
+        render_pass.set_pipeline(&resources.blit_pipeline);
+        render_pass.set_bind_group(0, &offscreen.blit_bind_group, &[]);
+        render_pass.draw(0..6, 0..1);
+    }
+}
+
+pub fn query_rect_for_camera(
+    camera: OrbitCamera,
+    world: chipgeom_format::Rect32,
+    aspect: f32,
+) -> chipgeom_format::Rect32 {
+    let half_y = camera.distance * (camera.fov_y * 0.5).tan();
+    let half_x = half_y * aspect.max(0.25);
+    let pad = half_x.max(half_y) * 1.35;
+    let lx = (camera.target.x - pad).floor() as i32;
+    let ly = (camera.target.y - pad).floor() as i32;
+    let hx = (camera.target.x + pad).ceil() as i32;
+    let hy = (camera.target.y + pad).ceil() as i32;
+    chipgeom_format::Rect32 {
+        lx: lx.max(world.lx),
+        ly: ly.max(world.ly),
+        hx: hx.min(world.hx).max(lx + 1),
+        hy: hy.min(world.hy).max(ly + 1),
+    }
+}
+
+pub fn die_diagonal(world: chipgeom_format::Rect32) -> f32 {
+    let width = (world.hx - world.lx).max(1) as f32;
+    let height = (world.hy - world.ly).max(1) as f32;
+    width.hypot(height)
+}
+
+pub fn use_overview_slabs(camera: OrbitCamera, world: chipgeom_format::Rect32) -> bool {
+    camera.distance > die_diagonal(world) * 0.9
+}
+
+pub const OVERVIEW_INSTANCE_BUDGET: usize = 48_000;
+
+pub fn overview_lod_level(camera: OrbitCamera, world: chipgeom_format::Rect32) -> u8 {
+    let ratio = camera.distance / die_diagonal(world).max(1.0);
+    if ratio > 1.0 {
+        3
+    } else if ratio > 0.5 {
+        2
+    } else {
+        1
+    }
+}
+
+pub fn tile_is_full_die(bbox: chipgeom_format::Rect32, world: chipgeom_format::Rect32) -> bool {
+    let tile_w = i64::from((bbox.hx - bbox.lx).max(1));
+    let tile_h = i64::from((bbox.hy - bbox.ly).max(1));
+    let world_w = i64::from((world.hx - world.lx).max(1));
+    let world_h = i64::from((world.hy - world.ly).max(1));
+    tile_w.saturating_mul(tile_h) * 10 >= world_w.saturating_mul(world_h) * 7
+}
+
+pub fn choose_overview_lod(
+    lods: impl IntoIterator<Item = (u8, usize, usize)>,
+    budget: usize,
+) -> Option<u8> {
+    let mut fallback = None;
+    for (lod, total, useful) in lods {
+        if useful == 0 {
+            continue;
+        }
+        fallback = Some(lod);
+        if total <= budget {
+            return Some(lod);
+        }
+    }
+    fallback
+}
+
+pub fn overview_tile_rgba_3d(style: &chip_display::LayerStyle, shape_count: u32) -> [u8; 4] {
+    let mut rgba = layer_style_rgba_3d(style);
+    let occupancy = 90.0 + (shape_count.max(1) as f32).sqrt() * 8.0;
+    rgba[3] = occupancy.round().clamp(90.0, 210.0) as u8;
+    rgba
+}
+
+pub fn push_overview_tile_instance(
+    instances: &mut Vec<GpuShapeInstance3d>,
+    bbox: chipgeom_format::Rect32,
+    shape_count: u32,
+    z0: f32,
+    z1: f32,
+    style: &chip_display::LayerStyle,
+) -> bool {
+    if shape_count == 0 || instances.len() >= MAX_3D_INSTANCES {
+        return false;
+    }
+    if bbox.hx <= bbox.lx || bbox.hy <= bbox.ly {
+        return false;
+    }
+    instances.push(slab_instance(
+        bbox,
+        z0,
+        z1,
+        overview_tile_rgba_3d(style, shape_count),
+    ));
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_instances_use_axis_aligned_thickness() {
+        let instances = build_gpu_instances_3d(std::iter::once((
+            chip_view_db::ShapeGeometry::Line(chipgeom_format::LinePayload {
+                begin: chipgeom_format::Point32 { x: 0, y: 10 },
+                end: chipgeom_format::Point32 { x: 100, y: 10 },
+                width: 8,
+                flags: 0,
+            }),
+            chip_display::LayerStyle::default_for_layer(1),
+            0.0,
+            100.0,
+        )));
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].rect_dbu[0], 0);
+        assert_eq!(instances[0].rect_dbu[2], 100);
+        assert!(instances[0].rect_dbu[3] > instances[0].rect_dbu[1]);
+    }
+
+    #[test]
+    fn uniform_and_instance_layouts_are_aligned() {
+        assert_eq!(std::mem::size_of::<CanvasUniform3d>() % 16, 0);
+        assert_eq!(std::mem::size_of::<GpuShapeInstance3d>(), 32);
+    }
+
+    #[test]
+    fn three_d_fill_uses_opaque_tech_metal_color() {
+        let style = chip_display::LayerStyle::default_for_metadata(1, "MET1", 0);
+        let rgba = layer_style_rgba_3d(&style);
+        assert_eq!(rgba[3], 208);
+        assert!(rgba[2] > rgba[0]);
+        assert_ne!(&rgba[..3], &style.rgba[..3]);
+    }
+
+    fn test_world() -> chipgeom_format::Rect32 {
+        chipgeom_format::Rect32 {
+            lx: 0,
+            ly: 0,
+            hx: 10_000,
+            hy: 8_000,
+        }
+    }
+
+    #[test]
+    fn fit_camera_uses_overview_tiles_instead_of_close_shapes() {
+        let world = test_world();
+        let mut camera = OrbitCamera::default();
+        camera.fit_world(
+            crate::camera3d::Vec3::new(world.lx as f32, world.ly as f32, 0.0),
+            crate::camera3d::Vec3::new(world.hx as f32, world.hy as f32, 0.0),
+            4_000.0,
+        );
+        assert!(use_overview_slabs(camera, world));
+        assert_eq!(overview_lod_level(camera, world), 3);
+        camera.distance = die_diagonal(world) * 0.4;
+        assert!(!use_overview_slabs(camera, world));
+        assert_eq!(overview_lod_level(camera, world), 1);
+    }
+
+    #[test]
+    fn overview_lod_prefers_finer_tiles_and_skips_full_die_slabs() {
+        let world = test_world();
+        assert!(tile_is_full_die(world, world));
+        assert!(!tile_is_full_die(
+            chipgeom_format::Rect32 {
+                lx: 100,
+                ly: 100,
+                hx: 400,
+                hy: 400,
+            },
+            world,
+        ));
+        assert_eq!(
+            choose_overview_lod([(0, 1_200, 1_200), (1, 80, 80), (3, 8, 0)], 48_000),
+            Some(0)
+        );
+        assert_eq!(
+            choose_overview_lod(
+                [(0, 90_000, 90_000), (1, 12_000, 12_000), (3, 8, 8)],
+                48_000
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            choose_overview_lod([(0, 8, 0), (1, 8, 0), (3, 8, 0)], 48_000),
+            None
+        );
+    }
+
+    #[test]
+    fn overview_tiles_keep_snapshot_bboxes_not_full_die_slabs() {
+        let world = test_world();
+        let style = chip_display::LayerStyle::default_for_metadata(1, "MET1", 0);
+        let mut instances = Vec::new();
+        let occupied = chipgeom_format::Rect32 {
+            lx: 100,
+            ly: 200,
+            hx: 1_400,
+            hy: 1_800,
+        };
+        assert!(push_overview_tile_instance(
+            &mut instances,
+            occupied,
+            48,
+            200.0,
+            2_200.0,
+            &style,
+        ));
+        assert!(!push_overview_tile_instance(
+            &mut instances,
+            chipgeom_format::Rect32 {
+                lx: 0,
+                ly: 0,
+                hx: 10,
+                hy: 10,
+            },
+            0,
+            200.0,
+            2_200.0,
+            &style,
+        ));
+        assert_eq!(instances.len(), 1);
+        assert_eq!(
+            instances[0].rect_dbu,
+            [occupied.lx, occupied.ly, occupied.hx, occupied.hy]
+        );
+        assert_ne!(
+            instances[0].rect_dbu,
+            [world.lx, world.ly, world.hx, world.hy]
+        );
+        assert!(instances[0].fill_rgba >> 24 < 208);
+    }
+
+    #[test]
+    fn denser_overview_tiles_use_higher_alpha() {
+        let style = chip_display::LayerStyle::default_for_metadata(2, "MET2", 1);
+        let sparse = overview_tile_rgba_3d(&style, 1);
+        let dense = overview_tile_rgba_3d(&style, 10_000);
+        assert!(dense[3] > sparse[3]);
+        assert_eq!(&dense[..3], &sparse[..3]);
+    }
+}

--- a/ecos/chip-viewer/apps/chip-viewer-native/src/main.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/main.rs
@@ -1,5 +1,7 @@
 mod app;
+mod camera3d;
 mod canvas_gpu;
+mod canvas_gpu3d;
 mod map_data;
 
 use std::path::PathBuf;

--- a/ecos/chip-viewer/crates/chip-display/src/lib.rs
+++ b/ecos/chip-viewer/crates/chip-display/src/lib.rs
@@ -366,6 +366,116 @@ fn routing_pattern(level: u8) -> FillPattern {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LayerStackBand {
+    pub layer_id: LayerId,
+    pub z0: f32,
+    pub z1: f32,
+}
+
+impl LayerStackBand {
+    pub fn mid(self) -> f32 {
+        (self.z0 + self.z1) * 0.5
+    }
+
+    pub fn thickness(self) -> f32 {
+        (self.z1 - self.z0).max(0.0)
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LayerStack {
+    pub bands: Vec<LayerStackBand>,
+}
+
+impl LayerStack {
+    pub fn height(&self) -> f32 {
+        self.bands
+            .iter()
+            .map(|band| band.z1)
+            .fold(0.0_f32, f32::max)
+    }
+
+    pub fn band(&self, layer_id: LayerId) -> Option<LayerStackBand> {
+        self.bands
+            .iter()
+            .copied()
+            .find(|band| band.layer_id == layer_id)
+    }
+
+    pub fn auto_z_scale(&self, world_width: f32, world_height: f32) -> f32 {
+        let stack_height = self.height().max(1.0);
+        let diagonal = (world_width.hypot(world_height)).max(1.0);
+        (diagonal * 0.02 / stack_height).clamp(0.1, 4.0)
+    }
+}
+
+pub fn heuristic_layer_stack(
+    layers: impl IntoIterator<Item = (LayerId, LayerRole, u32)>,
+) -> LayerStack {
+    let mut entries: Vec<(u32, u32, LayerId, LayerRole)> = layers
+        .into_iter()
+        .map(|(layer_id, role, order)| {
+            let (major, minor) = stack_sort_key(role, order);
+            (major, minor, layer_id, role)
+        })
+        .collect();
+    entries.sort_by_key(|(major, minor, layer_id, _)| (*major, *minor, *layer_id));
+
+    let mut bands = Vec::with_capacity(entries.len());
+    let mut cursor = 0.0_f32;
+    for (_, _, layer_id, role) in entries {
+        let thickness = heuristic_layer_thickness(role);
+        let z0 = cursor;
+        let z1 = cursor + thickness;
+        bands.push(LayerStackBand { layer_id, z0, z1 });
+        cursor = z1 + heuristic_layer_gap(role);
+    }
+    LayerStack { bands }
+}
+
+fn stack_sort_key(role: LayerRole, order: u32) -> (u32, u32) {
+    match role {
+        LayerRole::Implant | LayerRole::MasterSlice => (10, order),
+        LayerRole::Overlap => (20, order),
+        LayerRole::Metal { level } => (100 + u32::from(level) * 2, 0),
+        LayerRole::Routing => (100 + order.saturating_mul(2), 1),
+        LayerRole::Via { level } => (101 + u32::from(level) * 2, 0),
+        LayerRole::Cut => (101 + order.saturating_mul(2), 1),
+        LayerRole::TopMetal { level } => (300 + u32::from(level) * 2, 0),
+        LayerRole::TopVia { level } => (301 + u32::from(level) * 2, 0),
+        LayerRole::RedistributionVia => (398, order),
+        LayerRole::Rdl => (400, order),
+        LayerRole::Fill | LayerRole::Blockage | LayerRole::Row => (500 + order, 0),
+        LayerRole::Unknown => (600 + order, 0),
+    }
+}
+
+fn heuristic_layer_thickness(role: LayerRole) -> f32 {
+    match role {
+        LayerRole::Implant | LayerRole::MasterSlice => 300.0,
+        LayerRole::Overlap => 120.0,
+        LayerRole::Metal { .. } | LayerRole::Routing => 2000.0,
+        LayerRole::Via { .. } | LayerRole::Cut => 360.0,
+        LayerRole::TopMetal { .. } => 2600.0,
+        LayerRole::TopVia { .. } => 420.0,
+        LayerRole::RedistributionVia => 400.0,
+        LayerRole::Rdl => 2200.0,
+        LayerRole::Fill | LayerRole::Blockage | LayerRole::Row => 220.0,
+        LayerRole::Unknown => 500.0,
+    }
+}
+
+fn heuristic_layer_gap(role: LayerRole) -> f32 {
+    match role {
+        LayerRole::Via { .. }
+        | LayerRole::Cut
+        | LayerRole::TopVia { .. }
+        | LayerRole::RedistributionVia => 80.0,
+        _ => 200.0,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -424,5 +534,27 @@ mod tests {
         assert_eq!(style.fill_pattern, FillPattern::Hollow);
         assert_eq!(style.fill_alpha, 0);
         assert_eq!(style.line_width_px, 2);
+    }
+
+    #[test]
+    fn heuristic_stack_orders_metal_via_metal() {
+        let stack = heuristic_layer_stack([
+            (2, LayerRole::Metal { level: 2 }, 20),
+            (3, LayerRole::Via { level: 1 }, 15),
+            (1, LayerRole::Metal { level: 1 }, 10),
+        ]);
+
+        assert_eq!(
+            stack
+                .bands
+                .iter()
+                .map(|band| band.layer_id)
+                .collect::<Vec<_>>(),
+            vec![1, 3, 2]
+        );
+        assert!(stack.band(1).unwrap().z1 <= stack.band(3).unwrap().z0 + 0.01);
+        assert!(stack.band(3).unwrap().z1 <= stack.band(2).unwrap().z0 + 0.01);
+        assert!(stack.height() > 4000.0);
+        assert!(stack.band(3).unwrap().thickness() < stack.band(1).unwrap().thickness() * 0.3);
     }
 }


### PR DESCRIPTION
## Summary

feat: add chip design 3d view

## Scope

Select the areas touched by this PR:

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
