### PR TITLE
fix(gui): read selected project.json without an open workspace

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/projectManagementReadService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectManagementReadService.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { mkdir, mkdtemp, rm, symlink, unlink, writeFile } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
@@ -66,6 +74,21 @@ describe('ProjectManagementReadService', () => {
       },
       unavailablePaths: [],
     })
+  })
+
+  it('returns project.json text even when root_path does not match the selected directory', async () => {
+    const { projectRoot } = await createProject()
+    const manifest = JSON.parse(
+      await readFile(join(projectRoot, 'project.json'), 'utf8'),
+    ) as {
+      root_path: string
+    }
+    manifest.root_path = '/old/location/gcd'
+    await writeFile(join(projectRoot, 'project.json'), JSON.stringify(manifest))
+
+    await expect(
+      new ProjectManagementReadService().readManifest(projectRoot),
+    ).resolves.toContain('"root_path":"/old/location/gcd"')
   })
 
   it('rejects undeclared workspaces and files outside the summary allowlist', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/services/projectManagementReadService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectManagementReadService.ts
@@ -82,8 +82,11 @@ async function mapWithConcurrency<T, R>(
 
 export class ProjectManagementReadService {
   async readManifest(projectRoot: string): Promise<string | null> {
-    const project = await this.loadProject(projectRoot)
-    return project.content
+    const root = await canonicalizeExistingDirectory(projectRoot)
+    return await readOptionalBoundedTextFile(
+      join(root, 'project.json'),
+      PROJECT_MANIFEST_MAX_BYTES,
+    )
   }
 
   async listProjectEntries(projectRoot: string): Promise<string[]> {

--- a/ecos/gui/apps/renderer/src/components/NewProjectWizard.test.ts
+++ b/ecos/gui/apps/renderer/src/components/NewProjectWizard.test.ts
@@ -48,7 +48,8 @@ describe('NewProjectWizard RTL browsing', () => {
   it('uses the project workspace naming rule for the default workspace name', () => {
     expect(source).toContain('defaultWorkspaceName')
     expect(source).toContain('nextWorkspaceNameForProject')
-    expect(source).toContain("readOptionalProjectTextFile('project.json'")
+    expect(source).toContain('readProjectManagementManifest')
+    expect(source).not.toContain("readOptionalProjectTextFile('project.json'")
     expect(source).toContain('parseProjectManifest')
     expect(source).toContain("`ws_${String(next).padStart(4, '0')}`")
   })

--- a/ecos/gui/apps/renderer/src/components/NewProjectWizard.vue
+++ b/ecos/gui/apps/renderer/src/components/NewProjectWizard.vue
@@ -1567,7 +1567,7 @@ import { usePdkManager } from '../composables/usePdkManager'
 import { useWorkspace } from '../composables/useWorkspace'
 import { getDesktopApi } from '@/platform/desktop'
 import { loadProjectHistory } from '@/utils/projectHistory'
-import { readOptionalProjectTextFile } from '@/utils/projectFiles'
+import { readProjectManagementManifest } from '@/utils/projectManagementRead'
 import {
   parseProjectManifest,
   type ProjectManifest,
@@ -1973,9 +1973,7 @@ async function readProjectManifestForProject(
 ): Promise<ProjectManifest | null> {
   const root = normalizePath(projectRoot)
   if (!root) return null
-  const manifestText = await readOptionalProjectTextFile('project.json', {
-    projectPath: root,
-  })
+  const manifestText = await readProjectManagementManifest(root)
   if (!manifestText) return null
   return parseProjectManifest(manifestText)
 }


### PR DESCRIPTION
## Summary

- Opening New Workspace from Backend Design or File no longer fails when selecting a recent project.
- The wizard now reads `project.json` through the project-management API, so it does not need an already-registered workspace.
- Manifest text is returned even if `root_path` is stale; the wizard still parses and shows an error only when the file is actually unreadable or invalid.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other: `cd ecos/gui && pnpm install --frozen-lockfile && pnpm run lint && pnpm run fmt:check`

Skipped checks and reason:

- `pnpm run build`, `make build`, demos, and AppImage: no packaging or ECC runtime change.
- Manual GUI smoke: not re-run in this checkout after the final commit; unit tests cover the read path.

## Screenshots or Recordings

Required for visible GUI changes.

- No visual design change. The red "project.json could not be read" banner should no longer appear when selecting a valid recent project from New Workspace with no workspace open.

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- None.

## Checklist

- [x] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
