### PR TITLE
fix(resource): allow in-root archive links during install

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -45,13 +45,18 @@ async function runFixtureCommand(
   options: { cwd?: string } = {},
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = execFile(command, args, { cwd: options.cwd }, (error, _stdout, stderr) => {
-      if (error) {
-        reject(new Error(`${command} failed: ${stderr || error.message}`))
-        return
-      }
-      resolve()
-    })
+    const child = execFile(
+      command,
+      args,
+      { cwd: options.cwd },
+      (error, _stdout, stderr) => {
+        if (error) {
+          reject(new Error(`${command} failed: ${stderr || error.message}`))
+          return
+        }
+        resolve()
+      },
+    )
     child.on('error', reject)
   })
 }

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -4,10 +4,12 @@ import { execFile } from 'node:child_process'
 import {
   chmod,
   cp,
+  lstat,
   mkdir,
   mkdtemp,
   readdir,
   readFile,
+  readlink,
   rm,
   symlink,
   writeFile,
@@ -37,9 +39,13 @@ async function createFixtureArchive(
   }
 }
 
-async function runFixtureCommand(command: string, args: string[]): Promise<void> {
+async function runFixtureCommand(
+  command: string,
+  args: string[],
+  options: { cwd?: string } = {},
+): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = execFile(command, args, (error, _stdout, stderr) => {
+    const child = execFile(command, args, { cwd: options.cwd }, (error, _stdout, stderr) => {
       if (error) {
         reject(new Error(`${command} failed: ${stderr || error.message}`))
         return
@@ -2177,6 +2183,43 @@ describe('ResourceManagerService', () => {
     ).rejects.toThrow('ENOENT')
   })
 
+  it('rejects a PDK archive whose strip_prefix turns a member path into an escape', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'unsafe-pdk')
+    const archivePath = join(root, 'unsafe-pdk.tar')
+    await mkdir(source, { recursive: true })
+    await writeFile(join(source, 'payload'), 'unsafe\n', 'utf8')
+    await runFixtureCommand('tar', [
+      '-cf',
+      archivePath,
+      '--transform=s|^payload|icsprout55-pdk-1.10.100/../payload|',
+      '-C',
+      source,
+      'payload',
+    ])
+    const registryPath = join(root, 'registry.json')
+    await writeIcs55Registry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('pdk:ics55')).rejects.toThrow(
+      'Archive entry escapes destination: icsprout55-pdk-1.10.100/../payload',
+    )
+    await expect(readdir(join(dirs.pdksDir, 'ics55', '1.10.100'))).rejects.toThrow(
+      'ENOENT',
+    )
+    await expect(
+      readFile(join(dirs.resourcesDir, 'manifest.json'), 'utf8'),
+    ).rejects.toThrow('ENOENT')
+  })
+
   it('rejects a PDK archive containing a symlink', async () => {
     const root = await createTempDir('ecos-resources-')
     const source = join(root, 'unsafe-pdk')
@@ -2197,9 +2240,345 @@ describe('ResourceManagerService', () => {
     })
 
     await expect(service.installResource('pdk:ics55')).rejects.toThrow(
-      'Archive contains unsupported link entry',
+      'Archive link target is outside the extract root: /tmp',
     )
     await expect(readdir(join(dirs.pdksDir, 'ics55', '1.10.100'))).rejects.toThrow(
+      'ENOENT',
+    )
+    await expect(
+      readFile(join(dirs.resourcesDir, 'manifest.json'), 'utf8'),
+    ).rejects.toThrow('ENOENT')
+  })
+
+  it('installs a tool archive that contains an in-root relative symlink', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'yosys-source')
+    const archivePath = join(root, 'yosys-symlink.tar')
+    await mkdir(join(source, 'bin'), { recursive: true })
+    await writeFile(join(source, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(source, 'bin', 'yosys'), 0o755)
+    await writeFile(join(source, 'bin', 'yosys.real'), 'real\n', 'utf8')
+    await symlink('yosys.real', join(source, 'bin', 'yosys-link'))
+    await runFixtureCommand('tar', ['-cf', archivePath, '-C', source, '.'])
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).resolves.toEqual({
+      status: 'started',
+      resource_id: 'tool:yosys',
+      version: '2026-05-13',
+    })
+    const installedRoot = join(dirs.toolsDir, 'yosys', '2026-05-13')
+    await expect(readlink(join(installedRoot, 'bin', 'yosys-link'))).resolves.toBe(
+      'yosys.real',
+    )
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      id: 'tool:yosys',
+      status: 'installed',
+      path: installedRoot,
+    })
+  })
+
+  it('installs a tool archive that contains an in-root hardlink', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'yosys-source')
+    const archivePath = join(root, 'yosys-hardlink.tar')
+    await mkdir(join(source, 'bin'), { recursive: true })
+    await writeFile(join(source, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(source, 'bin', 'yosys'), 0o755)
+    await runFixtureCommand('ln', [
+      join(source, 'bin', 'yosys'),
+      join(source, 'bin', 'yosys.hard'),
+    ])
+    await runFixtureCommand('tar', ['-cf', archivePath, '-C', source, '.'])
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).resolves.toEqual({
+      status: 'started',
+      resource_id: 'tool:yosys',
+      version: '2026-05-13',
+    })
+    const installedRoot = join(dirs.toolsDir, 'yosys', '2026-05-13')
+    const original = await lstat(join(installedRoot, 'bin', 'yosys'))
+    const hardlink = await lstat(join(installedRoot, 'bin', 'yosys.hard'))
+    expect(hardlink.ino).toBe(original.ino)
+    await expect(service.getResource('tool:yosys')).resolves.toMatchObject({
+      id: 'tool:yosys',
+      status: 'installed',
+      path: installedRoot,
+    })
+  })
+
+  it('installs a tool archive that contains an in-root hardlink after strip_prefix', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'yosys-source')
+    const nested = join(source, 'oss-cad-suite')
+    const archivePath = join(root, 'yosys-hardlink-stripped.tar')
+    await mkdir(join(nested, 'bin'), { recursive: true })
+    await mkdir(join(nested, 'lib'), { recursive: true })
+    await writeFile(join(nested, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(nested, 'bin', 'yosys'), 0o755)
+    await runFixtureCommand('ln', [
+      join(nested, 'bin', 'yosys'),
+      join(nested, 'lib', 'yosys.hard'),
+    ])
+    await runFixtureCommand('tar', ['-cf', archivePath, '-C', source, 'oss-cad-suite'])
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+      platforms: {
+        'all-platform': {
+          url: `file://${archivePath}`,
+          sha256: '',
+          size: 1,
+          strip_prefix: 'oss-cad-suite',
+        },
+      },
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).resolves.toEqual({
+      status: 'started',
+      resource_id: 'tool:yosys',
+      version: '2026-05-13',
+    })
+    const installedRoot = join(dirs.toolsDir, 'yosys', '2026-05-13')
+    const original = await lstat(join(installedRoot, 'bin', 'yosys'))
+    const hardlink = await lstat(join(installedRoot, 'lib', 'yosys.hard'))
+    expect(hardlink.ino).toBe(original.ino)
+  })
+
+  it('rejects a tool archive whose hardlink escapes the extract root', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'yosys-source')
+    const archivePath = join(root, 'yosys-hardlink-escape.tar')
+    await mkdir(join(source, 'bin'), { recursive: true })
+    await writeFile(join(source, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(source, 'bin', 'yosys'), 0o755)
+    await runFixtureCommand('ln', [
+      join(source, 'bin', 'yosys'),
+      join(source, 'bin', 'yosys.hard'),
+    ])
+    await runFixtureCommand('tar', [
+      '-cf',
+      archivePath,
+      '-C',
+      source,
+      'bin/yosys',
+      '--transform=s|^bin/yosys.hard|../yosys.hard|',
+      'bin/yosys.hard',
+    ])
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).rejects.toThrow(
+      'Archive entry escapes destination: ../yosys.hard',
+    )
+    await expect(readdir(join(dirs.toolsDir, 'yosys', '2026-05-13'))).rejects.toThrow(
+      'ENOENT',
+    )
+    await expect(
+      readFile(join(dirs.resourcesDir, 'manifest.json'), 'utf8'),
+    ).rejects.toThrow('ENOENT')
+  })
+
+  it('installs a tool archive that contains a dangling in-root relative symlink', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'yosys-source')
+    const archivePath = join(root, 'yosys-dangling.tar')
+    await mkdir(join(source, 'bin'), { recursive: true })
+    await writeFile(join(source, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(source, 'bin', 'yosys'), 0o755)
+    await symlink('missing-optional.so', join(source, 'bin', 'optional.so'))
+    await runFixtureCommand('tar', ['-cf', archivePath, '-C', source, '.'])
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).resolves.toMatchObject({
+      status: 'started',
+      resource_id: 'tool:yosys',
+    })
+    await expect(
+      readlink(join(dirs.toolsDir, 'yosys', '2026-05-13', 'bin', 'optional.so')),
+    ).resolves.toBe('missing-optional.so')
+  })
+
+  it('rejects a tool archive whose strip_prefix turns a link into an escape', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'yosys-source')
+    const nested = join(source, 'oss-cad-suite')
+    const archivePath = join(root, 'yosys-stripped-escape.tar')
+    await mkdir(join(nested, 'bin'), { recursive: true })
+    await writeFile(join(nested, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(nested, 'bin', 'yosys'), 0o755)
+    await symlink('..', join(nested, 'escape'))
+    await runFixtureCommand('tar', ['-cf', archivePath, '-C', source, 'oss-cad-suite'])
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+      platforms: {
+        'all-platform': {
+          url: `file://${archivePath}`,
+          sha256: '',
+          size: 1,
+          strip_prefix: 'oss-cad-suite',
+        },
+      },
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).rejects.toThrow(
+      'Archive link target is outside the extract root: ..',
+    )
+    await expect(readdir(join(dirs.toolsDir, 'yosys', '2026-05-13'))).rejects.toThrow(
+      'ENOENT',
+    )
+    await expect(
+      readFile(join(dirs.resourcesDir, 'manifest.json'), 'utf8'),
+    ).rejects.toThrow('ENOENT')
+  })
+
+  it('installs a zip tool archive that contains an in-root relative symlink', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'yosys-source')
+    const archivePath = join(root, 'yosys-symlink.zip')
+    await mkdir(join(source, 'bin'), { recursive: true })
+    await writeFile(join(source, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(source, 'bin', 'yosys'), 0o755)
+    await writeFile(join(source, 'bin', 'yosys.real'), 'real\n', 'utf8')
+    await symlink('yosys.real', join(source, 'bin', 'yosys-link'))
+    await runFixtureCommand('zip', ['-rqy', archivePath, 'bin'], { cwd: source })
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).resolves.toMatchObject({
+      status: 'started',
+      resource_id: 'tool:yosys',
+    })
+    await expect(
+      readlink(join(dirs.toolsDir, 'yosys', '2026-05-13', 'bin', 'yosys-link')),
+    ).resolves.toBe('yosys.real')
+  })
+
+  it('rejects a zip tool archive whose symlink escapes the extract root', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'unsafe-yosys')
+    const archivePath = join(root, 'unsafe-yosys.zip')
+    await mkdir(join(source, 'bin'), { recursive: true })
+    await writeFile(join(source, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(source, 'bin', 'yosys'), 0o755)
+    await symlink('/tmp', join(source, 'outside'))
+    await runFixtureCommand('zip', ['-rqy', archivePath, 'bin', 'outside'], {
+      cwd: source,
+    })
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).rejects.toThrow(
+      'Archive link target is outside the extract root: /tmp',
+    )
+    await expect(readdir(join(dirs.toolsDir, 'yosys', '2026-05-13'))).rejects.toThrow(
+      'ENOENT',
+    )
+    await expect(
+      readFile(join(dirs.resourcesDir, 'manifest.json'), 'utf8'),
+    ).rejects.toThrow('ENOENT')
+  })
+
+  it('rejects a zip tool archive whose relative symlink escapes the extract root', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const source = join(root, 'unsafe-yosys')
+    const archivePath = join(root, 'unsafe-yosys-relative.zip')
+    await mkdir(join(source, 'bin'), { recursive: true })
+    await writeFile(join(source, 'bin', 'yosys'), '#!/bin/sh\n', 'utf8')
+    await chmod(join(source, 'bin', 'yosys'), 0o755)
+    await symlink('../outside', join(source, 'escape'))
+    await runFixtureCommand('zip', ['-rqy', archivePath, 'bin', 'escape'], {
+      cwd: source,
+    })
+    const registryPath = join(root, 'registry.json')
+    await writeYosysRegistry(registryPath, {
+      url: `file://${archivePath}`,
+      sha256: '',
+      size: 1,
+    })
+    const dirs = testResourceDirs(root)
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      ...dirs,
+    })
+
+    await expect(service.installResource('tool:yosys')).rejects.toThrow(
+      'Archive link target is outside the extract root: ../outside',
+    )
+    await expect(readdir(join(dirs.toolsDir, 'yosys', '2026-05-13'))).rejects.toThrow(
       'ENOENT',
     )
     await expect(

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -3017,10 +3017,15 @@ function posixArchivePath(value: string): string {
 }
 
 function isAbsoluteArchiveTarget(target: string): boolean {
-  return posix.isAbsolute(target) || target.startsWith('/') || /^[A-Za-z]:[\\/]/.test(target)
+  return (
+    posix.isAbsolute(target) || target.startsWith('/') || /^[A-Za-z]:[\\/]/.test(target)
+  )
 }
 
-function stripArchivePrefix(memberPath: string, stripPrefix?: string | null): string | null {
+function stripArchivePrefix(
+  memberPath: string,
+  stripPrefix?: string | null,
+): string | null {
   const normalized = posixArchivePath(memberPath)
   if (!normalized || normalized === '.') return null
   if (!stripPrefix) return normalized
@@ -3077,7 +3082,12 @@ function assertLinkTargetInsideExtractRoot(
   if (strippedMember === null) {
     throw new Error(linkTargetOutsideExtractRootMessage(target))
   }
-  const resolved = resolveArchiveLinkTarget(strippedMember, target, stripPrefix, targetKind)
+  const resolved = resolveArchiveLinkTarget(
+    strippedMember,
+    target,
+    stripPrefix,
+    targetKind,
+  )
   if (!lexicalPathInsideExtractRoot(resolved)) {
     throw new Error(linkTargetOutsideExtractRootMessage(target))
   }
@@ -3150,10 +3160,9 @@ async function assertSafeZipArchive(
     if (memberPath) symlinkNames.push(memberPath)
   }
   for (const memberPath of symlinkNames) {
-    const target = (await runCommandOutput('unzip', ['-p', archivePath, memberPath])).replace(
-      /\r?\n$/,
-      '',
-    )
+    const target = (
+      await runCommandOutput('unzip', ['-p', archivePath, memberPath])
+    ).replace(/\r?\n$/, '')
     assertLinkTargetInsideExtractRoot(memberPath, target, stripPrefix)
   }
 }

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -8,13 +8,23 @@ import {
   open,
   readdir,
   readFile,
+  readlink,
   realpath,
   rename,
   rm,
   stat,
   writeFile,
 } from 'node:fs/promises'
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  posix,
+  relative,
+  resolve,
+  sep,
+} from 'node:path'
 import { homedir } from 'node:os'
 import { spawn } from 'node:child_process'
 import { electronLogger } from './logger'
@@ -2986,6 +2996,168 @@ async function verifySha256(filePath: string, expected: string): Promise<boolean
   return hash.digest('hex') === expected.toLowerCase()
 }
 
+async function isZipArchive(archivePath: string): Promise<boolean> {
+  if (archivePath.toLowerCase().endsWith('.zip')) return true
+  const handle = await open(archivePath, 'r')
+  try {
+    const header = Buffer.alloc(4)
+    const { bytesRead } = await handle.read(header, 0, 4, 0)
+    return bytesRead >= 2 && header[0] === 0x50 && header[1] === 0x4b
+  } finally {
+    await handle.close()
+  }
+}
+
+function linkTargetOutsideExtractRootMessage(target: string): string {
+  return `Archive link target is outside the extract root: ${target}`
+}
+
+function posixArchivePath(value: string): string {
+  return value.replaceAll('\\', '/').replace(/\/+$/, '')
+}
+
+function isAbsoluteArchiveTarget(target: string): boolean {
+  return posix.isAbsolute(target) || target.startsWith('/') || /^[A-Za-z]:[\\/]/.test(target)
+}
+
+function stripArchivePrefix(memberPath: string, stripPrefix?: string | null): string | null {
+  const normalized = posixArchivePath(memberPath)
+  if (!normalized || normalized === '.') return null
+  if (!stripPrefix) return normalized
+  const prefix = posixArchivePath(stripPrefix)
+  if (!prefix) return normalized
+  if (normalized === prefix) return null
+  if (normalized.startsWith(`${prefix}/`)) {
+    const stripped = normalized.slice(prefix.length + 1)
+    return stripped || null
+  }
+  return normalized
+}
+
+function lexicalPathInsideExtractRoot(relativePath: string): boolean {
+  if (!relativePath) return true
+  if (isAbsoluteArchiveTarget(relativePath)) return false
+  const normalized = posix.normalize(relativePath)
+  return normalized !== '..' && !normalized.startsWith('../')
+}
+
+function assertMemberPathInsideExtractRoot(
+  memberPath: string,
+  stripPrefix?: string | null,
+): string | null {
+  const stripped = stripArchivePrefix(memberPath, stripPrefix)
+  if (stripped === null) return null
+  if (!lexicalPathInsideExtractRoot(stripped)) {
+    throw new Error(`Archive entry escapes destination: ${memberPath}`)
+  }
+  return stripped
+}
+
+function resolveArchiveLinkTarget(
+  memberPath: string,
+  target: string,
+  stripPrefix?: string | null,
+  targetKind: 'symlink' | 'hardlink' = 'symlink',
+): string {
+  if (isAbsoluteArchiveTarget(target)) return target
+  if (targetKind === 'hardlink') {
+    const strippedTarget = stripArchivePrefix(target, stripPrefix)
+    return strippedTarget ?? posix.normalize(target)
+  }
+  return posix.normalize(posix.join(posix.dirname(memberPath), target))
+}
+
+function assertLinkTargetInsideExtractRoot(
+  memberPath: string,
+  target: string,
+  stripPrefix?: string | null,
+  targetKind: 'symlink' | 'hardlink' = 'symlink',
+): void {
+  const strippedMember = assertMemberPathInsideExtractRoot(memberPath, stripPrefix)
+  if (strippedMember === null) {
+    throw new Error(linkTargetOutsideExtractRootMessage(target))
+  }
+  const resolved = resolveArchiveLinkTarget(strippedMember, target, stripPrefix, targetKind)
+  if (!lexicalPathInsideExtractRoot(resolved)) {
+    throw new Error(linkTargetOutsideExtractRootMessage(target))
+  }
+}
+
+function parseTarVerboseLink(
+  line: string,
+): { memberPath: string; target: string; kind: 'symlink' | 'hardlink' } | null {
+  const kind = line[0]
+  if (kind !== 'l' && kind !== 'h') return null
+  const separator = kind === 'l' ? ' -> ' : ' link to '
+  const separatorIndex = line.lastIndexOf(separator)
+  if (separatorIndex < 0) return null
+  const target = line.slice(separatorIndex + separator.length)
+  if (!target) return null
+  const metaAndName = line.slice(0, separatorIndex)
+  const match = metaAndName.match(
+    /\d{4}-\d{2}-\d{2}(?:\s+\d{2}:\d{2}(?::\d{2})?)?\s+(.+)$/,
+  )
+  const memberPath = match?.[1]?.trim()
+  if (!memberPath) return null
+  return { memberPath, target, kind: kind === 'h' ? 'hardlink' : 'symlink' }
+}
+
+function parseZipInfoSymlinkName(line: string): string | null {
+  if (!line.startsWith('l')) return null
+  const match = line.match(/^\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(.+)$/)
+  return match?.[1] ?? null
+}
+
+async function assertSafeTarArchive(
+  archivePath: string,
+  stripPrefix?: string | null,
+): Promise<void> {
+  const entries = await runCommandOutput('tar', ['-tf', archivePath])
+  for (const entry of entries.split(/\r?\n/)) {
+    if (!entry) continue
+    assertMemberPathInsideExtractRoot(entry, stripPrefix)
+  }
+
+  const verboseEntries = await runCommandOutput('tar', ['-tvf', archivePath])
+  for (const line of verboseEntries.split(/\r?\n/)) {
+    if (!line) continue
+    const link = parseTarVerboseLink(line)
+    if (!link) continue
+    assertLinkTargetInsideExtractRoot(
+      link.memberPath,
+      link.target,
+      stripPrefix,
+      link.kind,
+    )
+  }
+}
+
+async function assertSafeZipArchive(
+  archivePath: string,
+  stripPrefix?: string | null,
+): Promise<void> {
+  const listing = await runCommandOutput('unzip', ['-Z', '-1', archivePath])
+  for (const entry of listing.split(/\r?\n/)) {
+    if (!entry) continue
+    assertMemberPathInsideExtractRoot(entry, stripPrefix)
+  }
+
+  const verboseListing = await runCommandOutput('unzip', ['-Z', archivePath])
+  const symlinkNames: string[] = []
+  for (const line of verboseListing.split(/\r?\n/)) {
+    if (!line) continue
+    const memberPath = parseZipInfoSymlinkName(line)
+    if (memberPath) symlinkNames.push(memberPath)
+  }
+  for (const memberPath of symlinkNames) {
+    const target = (await runCommandOutput('unzip', ['-p', archivePath, memberPath])).replace(
+      /\r?\n$/,
+      '',
+    )
+    assertLinkTargetInsideExtractRoot(memberPath, target, stripPrefix)
+  }
+}
+
 async function extractZipArchive(
   archivePath: string,
   destination: string,
@@ -3010,11 +3182,16 @@ async function extractArchive(
   destination: string,
   stripPrefix?: string | null,
 ): Promise<void> {
-  if (!archivePath.endsWith('.zip')) await assertSafeTarArchive(archivePath)
+  const zipArchive = await isZipArchive(archivePath)
+  if (zipArchive) {
+    await assertSafeZipArchive(archivePath, stripPrefix)
+  } else {
+    await assertSafeTarArchive(archivePath, stripPrefix)
+  }
   await mkdir(destination, { recursive: true })
-  if (archivePath.endsWith('.zip')) {
+  if (zipArchive) {
     await extractZipArchive(archivePath, destination, stripPrefix)
-    await assertNoArchiveLinks(destination)
+    await assertExtractedLinksStayInsideRoot(destination)
     return
   }
   const args = ['-xf', archivePath, '-C', destination]
@@ -3022,34 +3199,27 @@ async function extractArchive(
     args.push('--strip-components', '1')
   }
   await runCommand('tar', args)
-  await assertNoArchiveLinks(destination)
+  await assertExtractedLinksStayInsideRoot(destination)
 }
 
-async function assertSafeTarArchive(archivePath: string): Promise<void> {
-  const entries = await runCommandOutput('tar', ['-tf', archivePath])
-  for (const entry of entries.split(/\r?\n/)) {
-    if (!entry) continue
-    if (entry.startsWith('/') || entry.split('/').includes('..')) {
-      throw new Error(`Archive entry escapes destination: ${entry}`)
-    }
-  }
-  const verboseEntries = await runCommandOutput('tar', ['-tvf', archivePath])
-  if (
-    verboseEntries
-      .split(/\r?\n/)
-      .some((entry) => entry.startsWith('l') || entry.startsWith('h'))
-  ) {
-    throw new Error('Archive contains unsupported link entry')
-  }
-}
-
-async function assertNoArchiveLinks(root: string): Promise<void> {
+async function assertExtractedLinksStayInsideRoot(
+  root: string,
+  relativeDirectory = '',
+): Promise<void> {
   const entries = await readdir(root, { withFileTypes: true })
   for (const entry of entries) {
+    const relativePath = relativeDirectory
+      ? `${relativeDirectory}/${entry.name}`
+      : entry.name
     const path = join(root, entry.name)
     const stats = await lstat(path)
-    if (stats.isSymbolicLink()) throw new Error('Archive contains unsupported link entry')
-    if (stats.isDirectory()) await assertNoArchiveLinks(path)
+    if (stats.isSymbolicLink()) {
+      assertLinkTargetInsideExtractRoot(relativePath, await readlink(path))
+      continue
+    }
+    if (stats.isDirectory()) {
+      await assertExtractedLinksStayInsideRoot(path, relativePath)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Resource Manager no longer fails a managed install just because the archive contains a symlink or hardlink.
- In-package relative links stay; absolute targets and `..` escapes are still rejected, before unpack and again after extract.
- Failed installs still leave no destination tree and no inventory entry. The error now says the link target is outside the extract root.

Fixes https://github.com/openecos-projects/ecos-studio/issues/174

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [x] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [x] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other: `cd ecos/gui/apps/desktop-electron && pnpm exec vitest run electron/services/resourceManagerService.test.ts` (53 passed); `pnpm typecheck` in desktop-electron.

Skipped checks and reason:

- `pnpm run build` and `make build` were skipped because this PR does not change packaging.
- `make demo-gcd` and `make demo-retrosoc` are not applicable to this installer change.

## Screenshots or Recordings

Required for visible GUI changes.

- No UI chrome change. Manual Resource Manager install of Yosys completed after download and SHA256.

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [x] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Users on `0.1.0-alpha.8` still see the old reject-all behavior until this ships.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.