### PR TITLE
fix(build): limit ECC native build concurrency

### DIFF
--- a/ecos/scripts/ecc-wrapper.sh
+++ b/ecos/scripts/ecc-wrapper.sh
@@ -14,7 +14,7 @@ if ! [[ "$cpu_count" =~ ^[1-9][0-9]*$ ]]; then
   cpu_count=1
 fi
 
-build_jobs=$((cpu_count > 3 ? cpu_count - 3 : 1))
+build_jobs=$((cpu_count > 2 ? cpu_count - 2 : 1))
 export CMAKE_BUILD_PARALLEL_LEVEL="$build_jobs"
 export MAKEFLAGS="-j${build_jobs}"
 export NINJAFLAGS="-j${build_jobs}"

--- a/ecos/scripts/ecc-wrapper.sh
+++ b/ecos/scripts/ecc-wrapper.sh
@@ -4,6 +4,24 @@ set -euo pipefail
 SCRIPT_FILE="$(dirname "${BASH_SOURCE[0]}")"
 cd "$SCRIPT_FILE/../../ecc"
 
+# Keep native dependency builds responsive on development machines.  Use the
+# available CPU count, leaving three cores for the desktop and the OS.
+cpu_count="$(nproc 2>/dev/null || true)"
+if ! [[ "$cpu_count" =~ ^[1-9][0-9]*$ ]]; then
+  cpu_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+fi
+if ! [[ "$cpu_count" =~ ^[1-9][0-9]*$ ]]; then
+  cpu_count=1
+fi
+
+build_jobs=$((cpu_count > 3 ? cpu_count - 3 : 1))
+export CMAKE_BUILD_PARALLEL_LEVEL="$build_jobs"
+export MAKEFLAGS="-j${build_jobs}"
+export NINJAFLAGS="-j${build_jobs}"
+
+printf '[ecc-wrapper] limiting native builds to %s job(s) (%s online CPU core(s))\n' \
+  "$build_jobs" "$cpu_count" >&2
+
 if [ "${ECOS_ECC_USE_NIX:-}" = "1" ]; then
   exec nix develop --command uv run ecc "$@"
 fi


### PR DESCRIPTION
## Summary
- detect the available CPU cores in the ECC development wrapper
- reserve three cores for the desktop and OS
- propagate the resulting limit to CMake, Make, and Ninja native builds

## Verification
- `bash -n ecos/scripts/ecc-wrapper.sh`
- `git diff --check`
- verified 8 available cores produce 5 build jobs

## Scope
- changes only `ecos/scripts/ecc-wrapper.sh`
- existing submodule and unrelated working-tree changes are not included