### PR TITLE
fix(gui): address six frontend workflow code review findings

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/main/index.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/index.ts
@@ -34,6 +34,7 @@ import {
   registerApplicationMenu,
 } from '../services/menuService'
 import { ProjectScopeService } from '../services/projectScopeService'
+import { ProjectReadGrantStore } from '../services/projectReadGrantStore'
 import { ProjectManifestService } from '../services/projectManifestService'
 import { ProjectManagementReadService } from '../services/projectManagementReadService'
 import { ResourceManagerService } from '../services/resourceManagerService'
@@ -123,7 +124,12 @@ function getDesktopServices() {
   const settingsStore = new SettingsStore({
     filePath: join(app.getPath('userData'), 'settings.json'),
   })
-  projectScopeService = new ProjectScopeService()
+  const projectReadGrantStore = new ProjectReadGrantStore({
+    filePath: join(app.getPath('userData'), 'project-read-grants.json'),
+  })
+  projectScopeService = new ProjectScopeService({
+    readGrantProvider: projectReadGrantStore,
+  })
   const eccRuntimeOptions = {
     appPath: app.getAppPath(),
     cwd: process.cwd(),

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
@@ -18,6 +18,7 @@ const {
   fromWebContents,
   getAllWindows,
   openExternal,
+  showMessageBox,
   showOpenDialog,
   showSaveDialog,
   mkdirMock,
@@ -27,6 +28,7 @@ const {
   getAllWindows: vi.fn<() => MockBrowserWindow[]>(() => []),
   mkdirMock: vi.fn(),
   openExternal: vi.fn(),
+  showMessageBox: vi.fn(),
   showOpenDialog: vi.fn(),
   showSaveDialog: vi.fn(),
   statMock: vi.fn(),
@@ -47,6 +49,7 @@ vi.mock('electron', () => ({
     getAllWindows,
   },
   dialog: {
+    showMessageBox,
     showOpenDialog,
     showSaveDialog,
   },
@@ -107,8 +110,10 @@ function registerHandlers(
       readWorkspaceTexts: vi.fn(),
     },
     workspaceService: {
+      approvePendingExternalReadRoots: vi.fn(),
       clearProjectRoot: vi.fn(),
       isProjectDirectory: vi.fn(),
+      listPendingExternalReadRoots: vi.fn(),
       readProjectBinaryFile: vi.fn(),
       readOptionalProjectTextFile: vi.fn(),
       readOptionalProjectTextFileChunk: vi.fn(),
@@ -267,6 +272,7 @@ describe('registerIpc', () => {
     executeWorkspaceRerunMock.mockReset()
     prepareWorkspaceRerunMock.mockReset()
     showOpenDialog.mockReset()
+    showMessageBox.mockReset()
     showSaveDialog.mockReset()
     mkdirMock.mockReset()
     setMenuActionEnabled.mockReset()
@@ -294,6 +300,59 @@ describe('registerIpc', () => {
     expect(Array.from(handlers.keys()).sort()).toEqual(
       Object.values(desktopApiIpcChannels).sort(),
     )
+  })
+
+  it('requires native confirmation before approving external frontend roots', async () => {
+    const { handlers, services } = registerHandlers()
+    const event = { sender: { id: 7 } }
+    const windowDouble = createWindowDouble(false)
+    fromWebContents.mockReturnValue(windowDouble)
+    services.workspaceService.registerProjectRoot.mockResolvedValue('/tmp/project')
+    services.workspaceService.listPendingExternalReadRoots.mockResolvedValue([
+      '/tmp/external-rtl',
+    ])
+    showMessageBox.mockResolvedValue({ response: 1 })
+
+    await expect(
+      handlers.get(desktopApiIpcChannels.workspaceRegisterProjectRoot)?.(
+        event,
+        '/tmp/project',
+      ),
+    ).resolves.toBe('/tmp/project')
+
+    expect(showMessageBox).toHaveBeenCalledWith(
+      windowDouble,
+      expect.objectContaining({
+        buttons: ['Not Now', 'Allow Access'],
+        cancelId: 0,
+        defaultId: 0,
+        detail: expect.stringContaining('/tmp/external-rtl'),
+        type: 'warning',
+      }),
+    )
+    expect(
+      services.workspaceService.approvePendingExternalReadRoots,
+    ).toHaveBeenCalledOnce()
+  })
+
+  it('keeps external frontend roots blocked when native confirmation is denied', async () => {
+    const { handlers, services } = registerHandlers()
+    const event = { sender: { id: 7 } }
+    fromWebContents.mockReturnValue(createWindowDouble(false))
+    services.workspaceService.registerProjectRoot.mockResolvedValue('/tmp/project')
+    services.workspaceService.listPendingExternalReadRoots.mockResolvedValue([
+      '/tmp/external-rtl',
+    ])
+    showMessageBox.mockResolvedValue({ response: 0 })
+
+    await handlers.get(desktopApiIpcChannels.workspaceRegisterProjectRoot)?.(
+      event,
+      '/tmp/project',
+    )
+
+    expect(
+      services.workspaceService.approvePendingExternalReadRoots,
+    ).not.toHaveBeenCalled()
   })
 
   it('rejects a renderer-supplied rerun contract without a main-process token', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
@@ -18,6 +18,7 @@ const {
   fromWebContents,
   getAllWindows,
   openExternal,
+  openPath,
   showMessageBox,
   showOpenDialog,
   showSaveDialog,
@@ -28,6 +29,7 @@ const {
   getAllWindows: vi.fn<() => MockBrowserWindow[]>(() => []),
   mkdirMock: vi.fn(),
   openExternal: vi.fn(),
+  openPath: vi.fn(),
   showMessageBox: vi.fn(),
   showOpenDialog: vi.fn(),
   showSaveDialog: vi.fn(),
@@ -58,6 +60,7 @@ vi.mock('electron', () => ({
   },
   shell: {
     openExternal,
+    openPath,
   },
 }))
 
@@ -169,6 +172,7 @@ function registerHandlers(
     },
     surferProtocolService: {
       authorizeWaveform: vi.fn(),
+      resolveWaveformPath: vi.fn(),
     },
     appInfoService: {
       getVersions: vi.fn(),
@@ -269,6 +273,7 @@ describe('registerIpc', () => {
     getAllWindows.mockReturnValue([])
     electronLogger.warn.mockReset()
     openExternal.mockReset()
+    openPath.mockReset()
     executeWorkspaceRerunMock.mockReset()
     prepareWorkspaceRerunMock.mockReset()
     showOpenDialog.mockReset()
@@ -1081,6 +1086,47 @@ describe('registerIpc', () => {
     )
 
     expect(openExternal).toHaveBeenCalledWith('https://openecos.org')
+  })
+
+  it('opens validated waveform paths without converting Windows paths to URLs', async () => {
+    const { handlers, services } = registerHandlers()
+    const requestedPath = String.raw`C:\work\cpu\trace.vcd`
+    const canonicalPath = String.raw`C:\work\cpu\trace.vcd`
+    services.surferProtocolService.resolveWaveformPath.mockResolvedValue(canonicalPath)
+    openPath.mockResolvedValue('')
+
+    await handlers.get(desktopApiIpcChannels.workspaceOpenWaveformExternal)?.(
+      { sender: { id: 'web-contents' } },
+      requestedPath,
+    )
+
+    expect(services.surferProtocolService.resolveWaveformPath).toHaveBeenCalledWith(
+      requestedPath,
+    )
+    expect(openPath).toHaveBeenCalledWith(canonicalPath)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects waveform opens when the operating system reports an error', async () => {
+    const { handlers, services } = registerHandlers()
+    services.surferProtocolService.resolveWaveformPath.mockResolvedValue(
+      '/work/trace.vcd',
+    )
+    openPath.mockResolvedValue('No application is associated with this file type')
+
+    await expect(
+      handlers.get(desktopApiIpcChannels.workspaceOpenWaveformExternal)?.(
+        { sender: { id: 'web-contents' } },
+        '/work/trace.vcd',
+      ),
+    ).resolves.toEqual({
+      error: {
+        message:
+          'Unable to open waveform: No application is associated with this file type',
+        name: 'Error',
+      },
+      ok: false,
+    })
   })
 
   it('shows a Save As dialog for the requesting window and returns its path', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
@@ -160,6 +160,7 @@ export interface DesktopBridgeServices {
     ): Promise<DesktopProjectManagementWorkspaceTextsResult>
   }
   workspaceService: {
+    approvePendingExternalReadRoots?(): Promise<string[]>
     clearProjectRoot(): Promise<void>
     isProjectDirectory(path: string): Promise<boolean>
     readProjectBinaryFile(path: string): Promise<Uint8Array>
@@ -180,6 +181,7 @@ export interface DesktopBridgeServices {
       fromOffsetBytes: number,
       maxBytes: number,
     ): Promise<DesktopProjectTextFileChunk | null>
+    listPendingExternalReadRoots?(): Promise<string[]>
     subscribeProjectLogTail(
       path: string,
       options: {
@@ -1279,7 +1281,44 @@ export function registerIpc(
   })
 
   handle(desktopApiIpcChannels.workspaceRegisterProjectRoot, async (_event, path) => {
-    return await services.workspaceService.registerProjectRoot(path as string)
+    const projectRoot = await services.workspaceService.registerProjectRoot(
+      path as string,
+    )
+    const pendingRoots =
+      (await services.workspaceService.listPendingExternalReadRoots?.()) ?? []
+    if (pendingRoots.length === 0) return projectRoot
+
+    const visibleRoots = pendingRoots.slice(0, 8)
+    const hiddenCount = pendingRoots.length - visibleRoots.length
+    const detail = [
+      'This frontend workspace references files outside its project directory:',
+      '',
+      ...visibleRoots.map((root) => `- ${root}`),
+      ...(hiddenCount > 0 ? [`- ...and ${hiddenCount} more`] : []),
+      '',
+      'Allow read-only access to these locations?',
+    ].join('\n')
+    const result = await dialog.showMessageBox(getEventWindow(_event), {
+      type: 'warning',
+      title: 'External Frontend Sources',
+      message: 'Allow this workspace to read external source locations?',
+      detail,
+      buttons: ['Not Now', 'Allow Access'],
+      defaultId: 0,
+      cancelId: 0,
+      noLink: true,
+    })
+    if (result.response === 1) {
+      try {
+        await services.workspaceService.approvePendingExternalReadRoots?.()
+      } catch (error) {
+        electronLogger.warn(
+          '[workspace] Failed to persist external source approval: %s',
+          error instanceof Error ? error.message : String(error),
+        )
+      }
+    }
+    return projectRoot
   })
 
   handle(desktopApiIpcChannels.workspaceRegisterProjectReadRoot, async (_event, path) => {

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
@@ -222,6 +222,7 @@ export interface DesktopBridgeServices {
   }
   surferProtocolService: {
     authorizeWaveform(path: string): Promise<string>
+    resolveWaveformPath(path: string): Promise<string>
   }
   chipViewerService: {
     open(request: ChipViewerOpenRequest): Promise<ChipViewerOpenResult>
@@ -1352,6 +1353,14 @@ export function registerIpc(
 
   handle(desktopApiIpcChannels.workspaceAuthorizeWaveform, async (_event, path) => {
     return await services.surferProtocolService.authorizeWaveform(path as string)
+  })
+
+  handle(desktopApiIpcChannels.workspaceOpenWaveformExternal, async (_event, path) => {
+    const canonicalPath = await services.surferProtocolService.resolveWaveformPath(
+      path as string,
+    )
+    const error = await shell.openPath(canonicalPath)
+    if (error) throw new Error(`Unable to open waveform: ${error}`)
   })
 
   handle(desktopApiIpcChannels.workspaceReadProjectTextFile, async (_event, path) => {

--- a/ecos/gui/apps/desktop-electron/electron/preload/index.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/preload/index.test.ts
@@ -70,6 +70,7 @@ async function loadDesktopBridge() {
       setActionEnabled(action: string, enabled: boolean): Promise<void>
     }
     workspace: {
+      openWaveformExternal(path: string): Promise<void>
       readProjectTextFile(path: string): Promise<unknown>
       listProjectDirectory(path: string): Promise<unknown>
       prepareProjectDirectoryReplacement(path: string): Promise<unknown>
@@ -208,6 +209,20 @@ describe('preload desktop bridge contract', () => {
     expect(ipcRenderer.invoke).toHaveBeenCalledWith(
       desktopApiIpcChannels.eccFlowRunStep,
       request,
+    )
+  })
+
+  it('routes external waveform opens through the scoped workspace channel', async () => {
+    const bridge = await loadDesktopBridge()
+    const waveformPath = String.raw`C:\work\cpu\trace.vcd`
+    ipcRenderer.invoke.mockResolvedValueOnce(undefined)
+
+    await expect(
+      bridge.workspace.openWaveformExternal(waveformPath),
+    ).resolves.toBeUndefined()
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      desktopApiIpcChannels.workspaceOpenWaveformExternal,
+      waveformPath,
     )
   })
 

--- a/ecos/gui/apps/desktop-electron/electron/preload/index.ts
+++ b/ecos/gui/apps/desktop-electron/electron/preload/index.ts
@@ -169,6 +169,8 @@ const desktopApi: DesktopApi = {
       invokeDesktop(desktopApiIpcChannels.workspaceRequestProjectPathAccess, path),
     authorizeWaveform: (path) =>
       invokeDesktop(desktopApiIpcChannels.workspaceAuthorizeWaveform, path),
+    openWaveformExternal: (path) =>
+      invokeDesktop(desktopApiIpcChannels.workspaceOpenWaveformExternal, path),
     readProjectTextFile: (path) =>
       invokeDesktop(desktopApiIpcChannels.workspaceReadProjectTextFile, path),
     readOptionalProjectTextFile: (path) =>

--- a/ecos/gui/apps/desktop-electron/electron/services/projectReadGrantStore.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectReadGrantStore.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ProjectReadGrantStore } from './projectReadGrantStore'
+
+const tempDirectories: string[] = []
+
+async function createStore(): Promise<{
+  directory: string
+  filePath: string
+  store: ProjectReadGrantStore
+}> {
+  const directory = await mkdtemp(join(tmpdir(), 'ecos-project-read-grants-'))
+  tempDirectories.push(directory)
+  const filePath = join(directory, 'project-read-grants.json')
+  return {
+    directory,
+    filePath,
+    store: new ProjectReadGrantStore({ filePath }),
+  }
+}
+
+describe('ProjectReadGrantStore', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirectories
+        .splice(0)
+        .map((directory) => rm(directory, { force: true, recursive: true })),
+    )
+  })
+
+  it('persists grants independently for each project', async () => {
+    const { filePath, store } = await createStore()
+    await store.set('/work/project-a', ['/work/rtl-a', '/work/rtl-a'])
+    await store.set('/work/project-b', ['/work/rtl-b'])
+
+    const reloaded = new ProjectReadGrantStore({ filePath })
+    await expect(reloaded.get('/work/project-a')).resolves.toEqual(['/work/rtl-a'])
+    await expect(reloaded.get('/work/project-b')).resolves.toEqual(['/work/rtl-b'])
+  })
+
+  it('treats malformed state as empty instead of granting access', async () => {
+    const { filePath, store } = await createStore()
+    await writeFile(filePath, '{not-json', 'utf8')
+
+    await expect(store.get('/work/project')).resolves.toEqual([])
+    expect(await readFile(filePath, 'utf8')).toBe('{not-json')
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/projectReadGrantStore.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectReadGrantStore.ts
@@ -1,0 +1,96 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+interface ProjectReadGrantRecord {
+  project_root: string
+  roots: string[]
+}
+
+interface ProjectReadGrantFile {
+  version: 1
+  projects: ProjectReadGrantRecord[]
+}
+
+export interface ProjectReadGrantStoreOptions {
+  filePath: string
+}
+
+function emptyGrantFile(): ProjectReadGrantFile {
+  return { version: 1, projects: [] }
+}
+
+function parseGrantFile(value: unknown): ProjectReadGrantFile {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return emptyGrantFile()
+  }
+
+  const record = value as Record<string, unknown>
+  if (record.version !== 1 || !Array.isArray(record.projects)) {
+    return emptyGrantFile()
+  }
+
+  const projects = record.projects.flatMap((entry) => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return []
+    const candidate = entry as Record<string, unknown>
+    if (typeof candidate.project_root !== 'string' || !Array.isArray(candidate.roots)) {
+      return []
+    }
+    const roots = candidate.roots.filter(
+      (root): root is string => typeof root === 'string' && root.length > 0,
+    )
+    return [{ project_root: candidate.project_root, roots }]
+  })
+
+  return { version: 1, projects }
+}
+
+export class ProjectReadGrantStore {
+  private readonly filePath: string
+  private writeChain: Promise<void> = Promise.resolve()
+
+  constructor(options: ProjectReadGrantStoreOptions) {
+    this.filePath = options.filePath
+  }
+
+  async get(projectRoot: string): Promise<string[]> {
+    await this.writeChain
+    const grants = await this.read()
+    return [
+      ...(grants.projects.find((entry) => entry.project_root === projectRoot)?.roots ??
+        []),
+    ]
+  }
+
+  async set(projectRoot: string, roots: string[]): Promise<void> {
+    const operation = this.writeChain.then(async () => {
+      const grants = await this.read()
+      const projects = grants.projects.filter(
+        (entry) => entry.project_root !== projectRoot,
+      )
+      projects.push({ project_root: projectRoot, roots: [...new Set(roots)] })
+      await this.write({ version: 1, projects })
+    })
+    this.writeChain = operation.then(
+      () => undefined,
+      () => undefined,
+    )
+    await operation
+  }
+
+  private async read(): Promise<ProjectReadGrantFile> {
+    try {
+      return parseGrantFile(JSON.parse(await readFile(this.filePath, 'utf8')) as unknown)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return emptyGrantFile()
+      if (error instanceof SyntaxError) return emptyGrantFile()
+      throw error
+    }
+  }
+
+  private async write(grants: ProjectReadGrantFile): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true })
+    const temporaryPath = `${this.filePath}.tmp`
+    await writeFile(temporaryPath, `${JSON.stringify(grants, null, 2)}\n`, 'utf8')
+    await rename(temporaryPath, this.filePath)
+  }
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.test.ts
@@ -209,7 +209,7 @@ describe('ProjectScopeService', () => {
     })
   })
 
-  it('allows frontend source roots declared by workspace parameters', async () => {
+  it('requires explicit approval before allowing frontend source roots', async () => {
     const root = await createTempDir('ecos-project-root-')
     const sourceRoot = await createTempDir('ecos-frontend-source-')
     const sourceFile = join(sourceRoot, 'rtl', 'cpu.sv')
@@ -232,6 +232,15 @@ describe('ProjectScopeService', () => {
     await runWithWindowScope(1, async () => {
       await service.registerProjectRoot(root)
 
+      await expect(service.requestProjectPathAccess(sourceFile)).rejects.toThrow(
+        'outside current project root',
+      )
+      await expect(service.listPendingExternalReadRoots()).resolves.toEqual([
+        join(sourceRoot, 'rtl'),
+      ])
+      await expect(service.approvePendingExternalReadRoots()).resolves.toEqual([
+        join(sourceRoot, 'rtl'),
+      ])
       await expect(service.requestProjectPathAccess(sourceFile)).resolves.toBe(sourceFile)
       await expect(service.requestProjectPathAccess(outsideFile)).rejects.toThrow(
         'outside current project scope',
@@ -263,10 +272,73 @@ describe('ProjectScopeService', () => {
     const service = new ProjectScopeService()
     await runWithWindowScope(1, async () => {
       await service.registerProjectRoot(root)
+      await service.approvePendingExternalReadRoots()
 
       await expect(service.requestProjectPathAccess(sourceFile)).resolves.toBe(sourceFile)
       await expect(service.requestProjectPathAccess(siblingFile)).rejects.toThrow(
         'outside current project scope',
+      )
+    })
+  })
+
+  it('reuses persisted approval only for roots still declared by the project', async () => {
+    const root = await createTempDir('ecos-project-root-')
+    const sourceRoot = await createTempDir('ecos-frontend-source-')
+    const sourceFile = join(sourceRoot, 'cpu.sv')
+    const storedGrants = new Map<string, string[]>()
+    const readGrantProvider = {
+      get: async (projectRoot: string) => storedGrants.get(projectRoot) ?? [],
+      set: async (projectRoot: string, roots: string[]) => {
+        storedGrants.set(projectRoot, roots)
+      },
+    }
+    await mkdir(join(root, 'home'), { recursive: true })
+    await writeFile(sourceFile, 'module cpu; endmodule')
+    await writeFile(join(sourceRoot, 'filelist.cpu.f'), 'cpu.sv')
+    await writeFile(
+      join(root, 'home', 'parameters.json'),
+      JSON.stringify({
+        'Design Tool': 'frontend',
+        cpu_filelist: join(sourceRoot, 'filelist.cpu.f'),
+      }),
+    )
+
+    const firstService = new ProjectScopeService({ readGrantProvider })
+    await runWithWindowScope(1, async () => {
+      await firstService.registerProjectRoot(root)
+      await firstService.approvePendingExternalReadRoots()
+    })
+
+    const reloadedService = new ProjectScopeService({ readGrantProvider })
+    await runWithWindowScope(2, async () => {
+      await reloadedService.registerProjectRoot(root)
+      await expect(reloadedService.listPendingExternalReadRoots()).resolves.toEqual([])
+      await expect(reloadedService.requestProjectPathAccess(sourceFile)).resolves.toBe(
+        sourceFile,
+      )
+    })
+  })
+
+  it('never offers a project ancestor as an external read root', async () => {
+    const ancestor = await createTempDir('ecos-project-parent-')
+    const root = join(ancestor, 'workspace')
+    const siblingFile = join(ancestor, 'ecos-private.txt')
+    await mkdir(join(root, 'home'), { recursive: true })
+    await writeFile(siblingFile, 'private')
+    await writeFile(
+      join(root, 'home', 'parameters.json'),
+      JSON.stringify({
+        'Design Tool': 'frontend',
+        sim_soc_root: ancestor,
+      }),
+    )
+
+    const service = new ProjectScopeService()
+    await runWithWindowScope(1, async () => {
+      await service.registerProjectRoot(root)
+      await expect(service.listPendingExternalReadRoots()).resolves.toEqual([])
+      await expect(service.requestProjectPathAccess(siblingFile)).rejects.toThrow(
+        'outside current project root',
       )
     })
   })

--- a/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.ts
@@ -23,6 +23,15 @@ interface ProjectReadScope {
   workspaceRoots: string[]
 }
 
+export interface ProjectReadGrantProvider {
+  get(projectRoot: string): Promise<string[]>
+  set(projectRoot: string, roots: string[]): Promise<void>
+}
+
+export interface ProjectScopeServiceOptions {
+  readGrantProvider?: ProjectReadGrantProvider
+}
+
 async function canonicalizeExistingPath(path: string): Promise<string> {
   return await realpath(path)
 }
@@ -46,6 +55,20 @@ function isNodeErrorWithCode(error: unknown, code: string): boolean {
 
 function pathsEqual(leftPath: string, rightPath: string): boolean {
   return relative(resolve(leftPath), resolve(rightPath)) === ''
+}
+
+function uniquePaths(paths: string[]): string[] {
+  const unique: string[] = []
+  for (const path of paths) {
+    if (!unique.some((candidate) => pathsEqual(candidate, path))) unique.push(path)
+  }
+  return unique
+}
+
+function isSafeExternalReadRoot(path: string, projectRoot: string): boolean {
+  // An external source root must not contain the workspace itself. This rejects
+  // filesystem roots, home directories, and other overly broad ancestors.
+  return !isPathWithinRoot(projectRoot, path)
 }
 
 async function canonicalizePotentialPathWithinRoot(
@@ -184,6 +207,13 @@ export class ProjectScopeService {
   private readonly rootsByWindowId = new Map<number, string>()
   private readonly readScopesByWindowId = new Map<number, ProjectReadScope>()
   private readonly extraRootsByWindowId = new Map<number, string[]>()
+  private readonly pendingExtraRootsByWindowId = new Map<number, string[]>()
+  private readonly approvedExtraRootsByProject = new Map<string, string[]>()
+  private readonly readGrantProvider: ProjectReadGrantProvider | undefined
+
+  constructor(options: ProjectScopeServiceOptions = {}) {
+    this.readGrantProvider = options.readGrantProvider
+  }
 
   async resolveProjectRoot(path: string): Promise<string> {
     return await canonicalizeExistingDirectory(path)
@@ -201,11 +231,51 @@ export class ProjectScopeService {
   async registerProjectRoot(path: string): Promise<string> {
     const windowId = requireWindowScopeId()
     const canonicalPath = await this.resolveProjectRoot(path)
-    const extraRoots = await detectFrontendExtraRoots(canonicalPath)
+    const candidateExtraRoots = (await detectFrontendExtraRoots(canonicalPath)).filter(
+      (root) => isSafeExternalReadRoot(root, canonicalPath),
+    )
+    const persistedRoots = await this.readGrantProvider?.get(canonicalPath)
+    const approvedRoots = uniquePaths([
+      ...(this.approvedExtraRootsByProject.get(canonicalPath) ?? []),
+      ...(persistedRoots ?? []),
+    ]).filter((root) =>
+      candidateExtraRoots.some((candidate) => pathsEqual(candidate, root)),
+    )
+    const pendingRoots = candidateExtraRoots.filter(
+      (candidate) => !approvedRoots.some((root) => pathsEqual(candidate, root)),
+    )
+
     this.rootsByWindowId.set(windowId, canonicalPath)
-    this.extraRootsByWindowId.set(windowId, extraRoots)
+    this.extraRootsByWindowId.set(windowId, approvedRoots)
+    this.pendingExtraRootsByWindowId.set(windowId, pendingRoots)
+    this.approvedExtraRootsByProject.set(canonicalPath, approvedRoots)
     this.readScopesByWindowId.delete(windowId)
     return canonicalPath
+  }
+
+  async listPendingExternalReadRoots(): Promise<string[]> {
+    return [...(this.pendingExtraRootsByWindowId.get(requireWindowScopeId()) ?? [])]
+  }
+
+  async approvePendingExternalReadRoots(): Promise<string[]> {
+    const windowId = requireWindowScopeId()
+    const projectRoot = this.rootsByWindowId.get(windowId)
+    if (!projectRoot) {
+      throw new Error('Project root is not registered')
+    }
+
+    const pendingRoots = this.pendingExtraRootsByWindowId.get(windowId) ?? []
+    if (pendingRoots.length === 0) return []
+
+    const approvedRoots = uniquePaths([
+      ...(this.extraRootsByWindowId.get(windowId) ?? []),
+      ...pendingRoots,
+    ])
+    this.extraRootsByWindowId.set(windowId, approvedRoots)
+    this.pendingExtraRootsByWindowId.set(windowId, [])
+    this.approvedExtraRootsByProject.set(projectRoot, approvedRoots)
+    await this.readGrantProvider?.set(projectRoot, approvedRoots)
+    return [...pendingRoots]
   }
 
   /**
@@ -262,12 +332,14 @@ export class ProjectScopeService {
     const windowId = requireWindowScopeId()
     this.rootsByWindowId.delete(windowId)
     this.extraRootsByWindowId.delete(windowId)
+    this.pendingExtraRootsByWindowId.delete(windowId)
     this.readScopesByWindowId.delete(windowId)
   }
 
   clearWindow(windowId: number): void {
     this.rootsByWindowId.delete(windowId)
     this.extraRootsByWindowId.delete(windowId)
+    this.pendingExtraRootsByWindowId.delete(windowId)
     this.readScopesByWindowId.delete(windowId)
   }
 

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -1371,6 +1371,73 @@ describe('ResourceManagerService', () => {
     })
   })
 
+  it('marks installed tools as invalid when an executable marker is unusable', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const registryPath = join(root, 'registry.json')
+    const resourcesDir = join(root, 'state', 'resources')
+    const toolsDir = join(root, 'data', 'tools')
+    const eccFeRoot = join(toolsDir, 'ecc-fe', 'latest')
+    await mkdir(join(eccFeRoot, 'bin', 'ecc-fe'), { recursive: true })
+    await mkdir(join(eccFeRoot, 'fecompiler'), { recursive: true })
+    await mkdir(resourcesDir, { recursive: true })
+    await writeFile(
+      registryPath,
+      JSON.stringify({ schema_version: 2, tools: [], pdks: [] }),
+      'utf8',
+    )
+    await writeFile(
+      join(resourcesDir, 'manifest.json'),
+      JSON.stringify({
+        schema_version: 1,
+        installed: {
+          'tool:ecc-fe': {
+            type: 'tool',
+            name: 'ecc-fe',
+            version: 'latest',
+            path: eccFeRoot,
+            executable: 'bin/ecc-fe',
+            detected_executables: ['bin/ecc-fe'],
+            active: true,
+            managed: true,
+          },
+        },
+      }),
+      'utf8',
+    )
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir,
+      toolsDir,
+      pdksDir: join(root, 'data', 'pdks'),
+    })
+
+    await expect(service.getResource('tool:ecc-fe')).resolves.toMatchObject({
+      id: 'tool:ecc-fe',
+      status: 'invalid',
+      active: false,
+      error: 'Installed resource is missing required files: bin/ecc-fe',
+      health: expect.objectContaining({
+        status: 'invalid',
+        missing_markers: ['bin/ecc-fe'],
+      }),
+    })
+
+    if (process.platform !== 'win32') {
+      await rm(join(eccFeRoot, 'bin', 'ecc-fe'), { recursive: true })
+      await writeFile(join(eccFeRoot, 'bin', 'ecc-fe'), '#!/bin/sh\n', 'utf8')
+      await chmod(join(eccFeRoot, 'bin', 'ecc-fe'), 0o644)
+
+      await expect(service.getResource('tool:ecc-fe')).resolves.toMatchObject({
+        status: 'invalid',
+        active: false,
+        health: expect.objectContaining({
+          status: 'invalid',
+          missing_markers: ['bin/ecc-fe'],
+        }),
+      })
+    }
+  })
+
   it('marks the RISC-V toolchain invalid when objdump is missing', async () => {
     const root = await createTempDir('ecos-resources-')
     const registryPath = join(root, 'registry.json')
@@ -2573,9 +2640,9 @@ describe('ResourceManagerService', () => {
     const sourceRoot = join(root, 'incomplete-ecc-fe-source')
     const sourceDir = join(sourceRoot, 'ecc-fe-runtime')
     const archivePath = join(root, 'incomplete-ecc-fe.tar')
-    await mkdir(join(sourceDir, 'bin'), { recursive: true })
-    await writeFile(join(sourceDir, 'bin', 'ecc-fe'), '#!/bin/sh\n', 'utf8')
-    await chmod(join(sourceDir, 'bin', 'ecc-fe'), 0o755)
+    await mkdir(join(sourceDir, 'bin', 'ecc-fe'), { recursive: true })
+    await mkdir(join(sourceDir, 'fecompiler'), { recursive: true })
+    await writeFile(join(sourceDir, 'fecompiler', '__init__.py'), '', 'utf8')
     await runFixtureCommand('tar', [
       '-cf',
       archivePath,
@@ -2649,7 +2716,7 @@ describe('ResourceManagerService', () => {
     })
 
     await expect(service.updateResource('tool:ecc-fe')).rejects.toThrow(
-      'Extracted ecc-fe archive failed health validation: fecompiler',
+      'Extracted ecc-fe archive failed health validation: bin/ecc-fe',
     )
     await expect(
       readFile(join(destination, 'previous-version.txt'), 'utf8'),

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.test.ts
@@ -2964,6 +2964,117 @@ describe('ResourceManagerService', () => {
     )
   })
 
+  it('cancels the whole install chain from the parent resource row', async () => {
+    const root = await createTempDir('ecos-resources-')
+    const registryPath = join(root, 'registry.json')
+    await writeFile(
+      registryPath,
+      JSON.stringify({
+        schema_version: 2,
+        tools: [
+          {
+            name: 'ecc-fe',
+            display_name: 'Parent Tool',
+            description: 'Depends on another tool',
+            category: 'frontend',
+            homepage: '',
+            versions: [
+              {
+                version: '1.0.0',
+                platforms: {
+                  'all-platform': {
+                    url: 'https://example.com/ecc-fe.tar',
+                    sha256: 'parent-sha',
+                    size: 9,
+                  },
+                },
+                requires: ['tool:ecc-fe-soc-ysyx-am'],
+              },
+            ],
+          },
+          {
+            name: 'ecc-fe-soc-ysyx-am',
+            display_name: 'Dependency Tool',
+            description: 'Blocking dependency download',
+            category: 'frontend',
+            homepage: '',
+            versions: [
+              {
+                version: '1.0.0',
+                platforms: {
+                  'all-platform': {
+                    url: 'https://example.com/ecc-fe-soc-ysyx-am.tar',
+                    sha256: 'dependency-sha',
+                    size: 9,
+                  },
+                },
+                requires: [],
+              },
+            ],
+          },
+        ],
+        pdks: [],
+      }),
+      'utf8',
+    )
+    let downloadController: ReadableStreamDefaultController<Uint8Array> | null = null
+    let dependencyStarted = false
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe('https://example.com/ecc-fe-soc-ysyx-am.tar')
+      init?.signal?.addEventListener('abort', () => {
+        downloadController?.error(
+          new DOMException('The operation was aborted.', 'AbortError'),
+        )
+      })
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            dependencyStarted = true
+            downloadController = controller
+            controller.enqueue(new Uint8Array([1, 2, 3]))
+          },
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+    const service = new ResourceManagerService({
+      registryUrl: `file://${registryPath}`,
+      resourcesDir: join(root, 'state', 'resources'),
+      toolsDir: join(root, 'data', 'tools'),
+      pdksDir: join(root, 'data', 'pdks'),
+      fetchImpl,
+    })
+    const progress = vi.fn()
+
+    const install = service.installResource('tool:ecc-fe', '1.0.0', progress)
+    await vi.waitFor(() => {
+      expect(dependencyStarted).toBe(true)
+    })
+
+    await expect(service.cancelResource('tool:ecc-fe')).resolves.toEqual({
+      status: 'cancelled',
+      resource_id: 'tool:ecc-fe',
+    })
+    await expect(install).rejects.toThrow('Cancelled installation for tool:ecc-fe')
+    expect(progress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource_id: 'tool:ecc-fe-soc-ysyx-am',
+        phase: 'cancelled',
+      }),
+    )
+    expect(progress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource_id: 'tool:ecc-fe',
+        phase: 'cancelled',
+        message: 'Cancelled installation for tool:ecc-fe',
+      }),
+    )
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    await expect(service.cancelResource('tool:ecc-fe')).rejects.toThrow(
+      'No active job for tool:ecc-fe',
+    )
+  })
+
   it('updates healthy managed dependencies whose registry lock has changed', async () => {
     const root = await createTempDir('ecos-resources-')
     const archive = await createEccFeArchive(root)

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -3524,6 +3524,7 @@ async function isUsableExecutable(
   platform: NodeJS.Platform,
 ): Promise<boolean> {
   try {
+    if (!(await stat(path)).isFile()) return false
     await access(path, platform === 'win32' ? constants.F_OK : constants.X_OK)
     return true
   } catch {
@@ -3884,7 +3885,9 @@ async function assertStagedToolHealth(
 async function checkToolEntryHealth(
   entry: ToolInventoryEntry,
 ): Promise<ToolHealthStatus> {
-  const requiredMarkers = requiredToolMarkers(normalizeToolName(entry.name))
+  const normalizedName = normalizeToolName(entry.name)
+  const requiredMarkers = requiredToolMarkers(normalizedName)
+  const executableMarkers = requiredToolExecutableMarkers(normalizedName)
   const rootExists = await isExistingDirectory(entry.path)
   if (!rootExists) {
     return {
@@ -3897,7 +3900,11 @@ async function checkToolEntryHealth(
 
   const missingMarkers: string[] = []
   for (const marker of requiredMarkers) {
-    if (!(await pathExists(join(entry.path, marker)))) {
+    const markerPath = join(entry.path, marker)
+    const isValid = executableMarkers.has(marker)
+      ? await isUsableExecutable(markerPath, process.platform)
+      : await pathExists(markerPath)
+    if (!isValid) {
       missingMarkers.push(marker)
     }
   }
@@ -3983,6 +3990,24 @@ function requiredToolMarkers(normalizedName: string): string[] {
     return ['index.html', 'integration.js', 'surfer.js', 'surfer_bg.wasm']
   }
   return []
+}
+
+function requiredToolExecutableMarkers(normalizedName: string): ReadonlySet<string> {
+  if (normalizedName === 'verilator') {
+    return new Set(['bin/verilator', 'bin/verilator_bin'])
+  }
+  if (normalizedName === 'riscv-toolchain') {
+    return new Set([
+      'bin/riscv64-unknown-elf-gcc',
+      'bin/riscv64-unknown-elf-ld',
+      'bin/riscv64-unknown-elf-objdump',
+      'bin/riscv64-unknown-elf-objcopy',
+    ])
+  }
+  if (normalizedName === 'ecc-fe') {
+    return new Set(['bin/ecc-fe'])
+  }
+  return new Set()
 }
 
 function executableHealthMarkers(entry: ToolInventoryEntry): string[] {

--- a/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/resourceManagerService.ts
@@ -338,6 +338,11 @@ interface ActiveResourceJob {
   listener?: (event: ResourceJob) => void
 }
 
+interface ResourceInstallContext {
+  controller: AbortController
+  rootResourceId: string
+}
+
 export interface ResourceManagerServiceOptions {
   archiveExtractor?: ArchiveExtractor
   cacheDir?: string
@@ -694,6 +699,7 @@ export class ResourceManagerService {
     action: ResourceAction,
     listener: ((event: ResourceJob) => void) | undefined,
     visiting: Set<string>,
+    context?: ResourceInstallContext,
   ): Promise<ResourceOperationResult> {
     if (visiting.has(resourceId)) {
       throw new Error(`Resource dependency cycle detected at ${resourceId}`)
@@ -708,7 +714,27 @@ export class ResourceManagerService {
         progress: 0,
         message: `Waiting for active job: ${resourceNameFromAnyId(resourceId)}...`,
       })
-      return await existingOperation
+      return context
+        ? await waitForOperationWithAbort(existingOperation, context.controller.signal)
+        : await existingOperation
+    }
+
+    const ownsContext = context === undefined
+    const installContext =
+      context ??
+      ({
+        controller: new AbortController(),
+        rootResourceId: resourceId,
+      } satisfies ResourceInstallContext)
+    if (ownsContext) {
+      if (this.activeJobs.has(resourceId)) {
+        throw new Error(`Job already active for ${resourceId}`)
+      }
+      this.activeJobs.set(resourceId, {
+        action,
+        controller: installContext.controller,
+        listener,
+      })
     }
 
     const operation = this.runInstallResourceWithDependencies(
@@ -717,13 +743,41 @@ export class ResourceManagerService {
       action,
       listener,
       visiting,
+      installContext,
     )
     this.resourceOperationPromises.set(resourceId, operation)
     try {
       return await operation
+    } catch (error) {
+      if (!ownsContext || !installContext.controller.signal.aborted) throw error
+
+      const originalMessage = error instanceof Error ? error.message : String(error)
+      if (
+        originalMessage === `Cancelled download for ${resourceId}` ||
+        originalMessage === `Cancelled installation for ${resourceId}`
+      ) {
+        throw error
+      }
+
+      const cancelMessage = `Cancelled installation for ${resourceId}`
+      this.publish(listener, {
+        resource_id: resourceId,
+        action,
+        phase: 'cancelled',
+        progress: 0,
+        message: cancelMessage,
+        error: cancelMessage,
+      })
+      throw new Error(cancelMessage, { cause: error })
     } finally {
       if (this.resourceOperationPromises.get(resourceId) === operation) {
         this.resourceOperationPromises.delete(resourceId)
+      }
+      if (
+        ownsContext &&
+        this.activeJobs.get(resourceId)?.controller === installContext.controller
+      ) {
+        this.activeJobs.delete(resourceId)
       }
     }
   }
@@ -734,10 +788,13 @@ export class ResourceManagerService {
     action: ResourceAction,
     listener: ((event: ResourceJob) => void) | undefined,
     visiting: Set<string>,
+    context: ResourceInstallContext,
   ): Promise<ResourceOperationResult> {
     visiting.add(resourceId)
     try {
+      throwIfAborted(context.controller.signal)
       const state = await this.fetchRegistry()
+      throwIfAborted(context.controller.signal)
       const manifest = await this.readManifest()
       const toolHealth = await checkInstalledToolHealth(getInstalledTools(manifest))
       const dependencies = this.registryRequiresForResource(
@@ -765,6 +822,7 @@ export class ResourceManagerService {
       }
 
       for (const [index, dependencyId] of unsatisfiedDependencies.entries()) {
+        throwIfAborted(context.controller.signal)
         const latestManifest = await this.readManifest()
         const latestToolHealth = await checkInstalledToolHealth(
           getInstalledTools(latestManifest),
@@ -803,15 +861,19 @@ export class ResourceManagerService {
           dependencyAction,
           listener,
           visiting,
+          context,
         )
+        throwIfAborted(context.controller.signal)
       }
 
+      throwIfAborted(context.controller.signal)
       if (resourceId.startsWith('tool:')) {
         return await this.installTool(
           resourceId.slice('tool:'.length),
           version,
           action,
           listener,
+          context,
         )
       }
       if (resourceId.startsWith('pdk:')) {
@@ -820,6 +882,7 @@ export class ResourceManagerService {
           version,
           action,
           listener,
+          context,
         )
       }
       if (resourceId.startsWith('mpc:')) {
@@ -828,6 +891,7 @@ export class ResourceManagerService {
           version,
           action,
           listener,
+          context,
         )
       }
       throw new Error(`Install is not implemented for ${resourceId}`)
@@ -1280,18 +1344,42 @@ export class ResourceManagerService {
     )
   }
 
+  private trackInstallLeaf(
+    resourceId: string,
+    action: ResourceAction,
+    listener: ((event: ResourceJob) => void) | undefined,
+    context: ResourceInstallContext,
+  ): () => void {
+    const existingJob = this.activeJobs.get(resourceId)
+    if (existingJob) {
+      if (existingJob.controller !== context.controller) {
+        throw new Error(`Job already active for ${resourceId}`)
+      }
+      return () => undefined
+    }
+
+    this.activeJobs.set(resourceId, {
+      action,
+      controller: context.controller,
+      listener,
+    })
+    return () => {
+      if (this.activeJobs.get(resourceId)?.controller === context.controller) {
+        this.activeJobs.delete(resourceId)
+      }
+    }
+  }
+
   private async installTool(
     name: string,
     requestedVersion: string | undefined,
     action: ResourceAction,
-    listener?: (event: ResourceJob) => void,
+    listener: ((event: ResourceJob) => void) | undefined,
+    context: ResourceInstallContext,
   ): Promise<ResourceOperationResult> {
     const resourceId = `tool:${name}`
-    if (this.activeJobs.has(resourceId)) {
-      throw new Error(`Job already active for ${resourceId}`)
-    }
-    const controller = new AbortController()
-    this.activeJobs.set(resourceId, { action, controller, listener })
+    const releaseActiveJob = this.trackInstallLeaf(resourceId, action, listener, context)
+    const controller = context.controller
     let tempArchive = ''
     let partialArchive = ''
     let tempExtract = ''
@@ -1457,7 +1545,7 @@ export class ResourceManagerService {
       })
       throw error
     } finally {
-      this.activeJobs.delete(resourceId)
+      releaseActiveJob()
       if (tempArchive) await rm(tempArchive, { force: true }).catch(() => undefined)
       if (tempExtract)
         await rm(tempExtract, { force: true, recursive: true }).catch(() => undefined)
@@ -1468,14 +1556,12 @@ export class ResourceManagerService {
     pdkId: string,
     requestedVersion: string | undefined,
     action: ResourceAction,
-    listener?: (event: ResourceJob) => void,
+    listener: ((event: ResourceJob) => void) | undefined,
+    context: ResourceInstallContext,
   ): Promise<ResourceOperationResult> {
     const resourceId = `pdk:${pdkId}`
-    if (this.activeJobs.has(resourceId)) {
-      throw new Error(`Job already active for ${resourceId}`)
-    }
-    const controller = new AbortController()
-    this.activeJobs.set(resourceId, { action, controller, listener })
+    const releaseActiveJob = this.trackInstallLeaf(resourceId, action, listener, context)
+    const controller = context.controller
     let tempArchive = ''
     let partialArchive = ''
     let tempExtract = ''
@@ -1733,7 +1819,7 @@ export class ResourceManagerService {
       })
       throw error
     } finally {
-      this.activeJobs.delete(resourceId)
+      releaseActiveJob()
       if (tempArchive) await rm(tempArchive, { force: true }).catch(() => undefined)
       if (tempExtract)
         await rm(tempExtract, { force: true, recursive: true }).catch(() => undefined)
@@ -1744,14 +1830,12 @@ export class ResourceManagerService {
     mpcId: string,
     requestedVersion: string | undefined,
     action: ResourceAction,
-    listener?: (event: ResourceJob) => void,
+    listener: ((event: ResourceJob) => void) | undefined,
+    context: ResourceInstallContext,
   ): Promise<ResourceOperationResult> {
     const resourceId = `mpc:${mpcId}`
-    if (this.activeJobs.has(resourceId)) {
-      throw new Error(`Job already active for ${resourceId}`)
-    }
-    const controller = new AbortController()
-    this.activeJobs.set(resourceId, { action, controller, listener })
+    const releaseActiveJob = this.trackInstallLeaf(resourceId, action, listener, context)
+    const controller = context.controller
     let tempArchive = ''
     let partialArchive = ''
     let tempExtract = ''
@@ -1888,7 +1972,7 @@ export class ResourceManagerService {
       })
       throw error
     } finally {
-      this.activeJobs.delete(resourceId)
+      releaseActiveJob()
       if (tempArchive) await rm(tempArchive, { force: true }).catch(() => undefined)
       if (tempExtract)
         await rm(tempExtract, { force: true, recursive: true }).catch(() => undefined)
@@ -4509,6 +4593,21 @@ function isAbortError(error: unknown): boolean {
 function throwIfAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) return
   throw new DOMException('The operation was aborted.', 'AbortError')
+}
+
+async function waitForOperationWithAbort<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  throwIfAborted(signal)
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () =>
+      reject(new DOMException('The operation was aborted.', 'AbortError'))
+    signal.addEventListener('abort', abort, { once: true })
+    operation.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', abort)
+    })
+  })
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/ecos/gui/apps/desktop-electron/electron/services/surferProtocolService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/surferProtocolService.ts
@@ -93,7 +93,7 @@ export class SurferProtocolService {
   }
 
   async authorizeWaveform(path: string): Promise<string> {
-    const canonicalPath = await this.resolveWaveformFile(path)
+    const canonicalPath = await this.resolveWaveformPath(path)
     this.pruneWaveformGrants()
     const token = randomUUID()
     this.waveformGrants.set(token, {
@@ -101,6 +101,10 @@ export class SurferProtocolService {
       expiresAt: Date.now() + WAVEFORM_GRANT_TTL_MS,
     })
     return surferWaveformUrl(canonicalPath, token)
+  }
+
+  async resolveWaveformPath(path: string): Promise<string> {
+    return await this.resolveWaveformFile(path)
   }
 
   private async handleRequest(request: Request): Promise<Response> {

--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceService.ts
@@ -37,9 +37,11 @@ import type {
 } from '@ecos-studio/shared'
 
 export interface ProjectScopeProvider {
+  approvePendingExternalReadRoots?(): Promise<string[]>
   clearProjectRoot(): Promise<void>
   getProjectRoot(): Promise<string>
   isProjectDirectory(path: string): Promise<boolean>
+  listPendingExternalReadRoots?(): Promise<string[]>
   requestProjectPathAccess(path: string): Promise<string>
   requestWritableProjectPathAccess(path: string): Promise<string>
   registerProjectReadRoot(path: string): Promise<string>
@@ -397,6 +399,14 @@ export class WorkspaceService {
 
   async registerProjectRoot(path: string): Promise<string> {
     return await this.projectScopeProvider.registerProjectRoot(path)
+  }
+
+  async listPendingExternalReadRoots(): Promise<string[]> {
+    return (await this.projectScopeProvider.listPendingExternalReadRoots?.()) ?? []
+  }
+
+  async approvePendingExternalReadRoots(): Promise<string[]> {
+    return (await this.projectScopeProvider.approvePendingExternalReadRoots?.()) ?? []
   }
 
   async registerProjectReadRoot(path: string): Promise<string> {

--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.desktop-ipc.test.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.desktop-ipc.test.ts
@@ -20,6 +20,44 @@ function restoreWindow() {
   delete (globalThis as { window?: unknown }).window
 }
 
+function validCatalog() {
+  return {
+    version: 1,
+    defaults: {
+      core_id: 'cpu',
+      soc_harness_id: 'soc',
+      toolchain_id: 'toolchain',
+      test_suite_id: 'tests',
+    },
+    cores: [catalogEntry('cpu')],
+    soc_harnesses: [catalogEntry('soc')],
+    toolchains: [catalogEntry('toolchain')],
+    test_suites: [catalogEntry('tests')],
+    compatibility: [
+      {
+        core_id: 'cpu',
+        soc_harness_id: 'soc',
+        can_create_workspace: true,
+        support_level: 'supported',
+        status: 'ready',
+        summary: 'Ready',
+        supported_test_suites: ['tests'],
+        issues: [],
+        requires_cpu_filelist: false,
+      },
+    ],
+  }
+}
+
+function catalogEntry(id: string) {
+  return {
+    id,
+    name: id,
+    description: `${id} description`,
+    status: 'stable',
+  }
+}
+
 describe('frontend catalog desktop bridge', () => {
   afterEach(() => {
     restoreWindow()
@@ -70,5 +108,78 @@ describe('frontend catalog desktop bridge', () => {
       test_suite_id: 'cpu-tests',
       toolchain_id: 'riscv32-unknown-elf',
     })
+  })
+
+  it('accepts the supported frontend catalog schema from the desktop runtime', async () => {
+    const catalog = vi.fn(async () => ({
+      ...validCatalog(),
+      message: ['frontend catalog list loaded'],
+      response: 'success',
+    }))
+    setWindow({ ecosDesktop: { runtime: { frontend: { catalog } } } })
+
+    const { listFrontendCatalogApi } = await import('./frontendCatalog')
+    await expect(listFrontendCatalogApi()).resolves.toMatchObject({
+      data: {
+        version: 1,
+        defaults: { core_id: 'cpu' },
+        cores: [{ id: 'cpu' }],
+      },
+      message: ['frontend catalog list loaded'],
+      response: 'success',
+    })
+  })
+
+  it('rejects unsupported frontend catalog versions', async () => {
+    setWindow({
+      ecosDesktop: {
+        runtime: {
+          frontend: {
+            catalog: async () => ({ ...validCatalog(), version: 2 }),
+          },
+        },
+      },
+    })
+
+    const { listFrontendCatalogApi } = await import('./frontendCatalog')
+    await expect(listFrontendCatalogApi()).rejects.toThrow(
+      'Invalid frontend catalog: unsupported version 2; expected 1.',
+    )
+  })
+
+  it.each([
+    {
+      label: 'a malformed catalog collection',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        const malformed = catalog as unknown as { cores: unknown }
+        malformed.cores = { id: 'cpu' }
+      },
+      message: 'Invalid frontend catalog: cores must be an array.',
+    },
+    {
+      label: 'an unknown default resource id',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        catalog.defaults.core_id = 'missing'
+      },
+      message:
+        'Invalid frontend catalog: defaults.core_id references unknown id missing.',
+    },
+    {
+      label: 'an invalid compatibility reference',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        catalog.compatibility[0].supported_test_suites = ['missing']
+      },
+      message:
+        'Invalid frontend catalog: compatibility[0].supported_test_suites references unknown id missing.',
+    },
+  ])('rejects $label', async ({ mutate, message }) => {
+    const payload = validCatalog()
+    mutate(payload)
+    setWindow({
+      ecosDesktop: { runtime: { frontend: { catalog: async () => payload } } },
+    })
+
+    const { listFrontendCatalogApi } = await import('./frontendCatalog')
+    await expect(listFrontendCatalogApi()).rejects.toThrow(message)
   })
 })

--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
@@ -117,15 +117,85 @@ export interface FrontendValidationResult {
   issues: FrontendValidationIssue[]
 }
 
-export function listFrontendCatalogApi() {
-  return getDesktopApi()
-    .runtime.frontend.catalog()
-    .then((data) => ({
-      cmd: CMDEnum.catalog_list,
-      data: data as unknown as FrontendCatalogPayload,
-      message: Array.isArray(data.message) ? (data.message as string[]) : [],
-      response: String(data.response ?? ResponseEnum.success),
-    })) as Promise<ResponseData<FrontendCatalogPayload>>
+const FRONTEND_CATALOG_VERSION = 1
+const CATALOG_ENTRY_ARRAYS = [
+  'cores',
+  'soc_harnesses',
+  'toolchains',
+  'test_suites',
+] as const
+const CATALOG_ENTRY_OPTIONAL_STRINGS = [
+  'integration_level',
+  'required_cpu_top_module',
+  'cpu_reset_vector',
+  'sim_program_link_base',
+  'default_program_link_base',
+  'bootloader_payload_link_base',
+] as const
+const COMPATIBILITY_SUPPORT_LEVELS = new Set(['supported', 'experimental', 'unsupported'])
+const CPU_PORT_DIRECTIONS = new Set(['input', 'output', 'inout'])
+
+export function parseFrontendCatalogPayload(value: unknown): FrontendCatalogPayload {
+  const record = catalogRecord(value, 'catalog')
+  if (record.version !== FRONTEND_CATALOG_VERSION) {
+    throw invalidCatalog(
+      `unsupported version ${String(record.version)}; expected ${FRONTEND_CATALOG_VERSION}`,
+    )
+  }
+
+  const defaultsRecord = catalogRecord(record.defaults, 'defaults')
+  const defaults = {
+    core_id: catalogText(defaultsRecord, 'core_id', 'defaults'),
+    soc_harness_id: catalogText(defaultsRecord, 'soc_harness_id', 'defaults'),
+    toolchain_id: catalogText(defaultsRecord, 'toolchain_id', 'defaults'),
+    test_suite_id: catalogText(defaultsRecord, 'test_suite_id', 'defaults'),
+  }
+  const collections = Object.fromEntries(
+    CATALOG_ENTRY_ARRAYS.map((key) => [key, parseCatalogEntries(record[key], key)]),
+  ) as Record<(typeof CATALOG_ENTRY_ARRAYS)[number], FrontendCatalogEntry[]>
+
+  const ids = {
+    cores: catalogIds(collections.cores, 'cores'),
+    soc_harnesses: catalogIds(collections.soc_harnesses, 'soc_harnesses'),
+    toolchains: catalogIds(collections.toolchains, 'toolchains'),
+    test_suites: catalogIds(collections.test_suites, 'test_suites'),
+  }
+  requireCatalogReference(ids.cores, defaults.core_id, 'defaults.core_id')
+  requireCatalogReference(
+    ids.soc_harnesses,
+    defaults.soc_harness_id,
+    'defaults.soc_harness_id',
+  )
+  requireCatalogReference(ids.toolchains, defaults.toolchain_id, 'defaults.toolchain_id')
+  requireCatalogReference(
+    ids.test_suites,
+    defaults.test_suite_id,
+    'defaults.test_suite_id',
+  )
+
+  const compatibility =
+    record.compatibility === undefined
+      ? undefined
+      : parseCompatibilityEntries(record.compatibility, ids)
+
+  return {
+    version: FRONTEND_CATALOG_VERSION,
+    defaults,
+    ...collections,
+    ...(compatibility ? { compatibility } : {}),
+  }
+}
+
+export async function listFrontendCatalogApi(): Promise<
+  ResponseData<FrontendCatalogPayload>
+> {
+  const data = await getDesktopApi().runtime.frontend.catalog()
+  return {
+    cmd: CMDEnum.catalog_list,
+    data: parseFrontendCatalogPayload(data),
+    message: responseMessages(data.message),
+    response: responseStatus(data.response),
+  }
 }
 
 export function validateFrontendConfigApi(config: FrontendValidationRequest) {
@@ -137,4 +207,217 @@ export function validateFrontendConfigApi(config: FrontendValidationRequest) {
       message: Array.isArray(data.message) ? (data.message as string[]) : [],
       response: String(data.response ?? ResponseEnum.success),
     })) as Promise<ResponseData<FrontendValidationResult>>
+}
+
+function parseCatalogEntries(value: unknown, path: string): FrontendCatalogEntry[] {
+  if (!Array.isArray(value)) throw invalidCatalog(`${path} must be an array`)
+  return value.map((item, index) => parseCatalogEntry(item, `${path}[${index}]`))
+}
+
+function parseCatalogEntry(value: unknown, path: string): FrontendCatalogEntry {
+  const record = catalogRecord(value, path)
+  const entry: FrontendCatalogEntry = {
+    ...record,
+    id: catalogText(record, 'id', path),
+    name: catalogText(record, 'name', path),
+    description: catalogString(record, 'description', path),
+    status: catalogText(record, 'status', path),
+  }
+
+  for (const key of CATALOG_ENTRY_OPTIONAL_STRINGS) {
+    const field = optionalCatalogString(record, key, path)
+    if (field !== undefined) entry[key] = field
+  }
+  const isa = optionalCatalogStringArray(record, 'isa', path)
+  if (isa) entry.isa = isa
+  const tags = optionalCatalogStringArray(record, 'tags', path)
+  if (tags) entry.tags = tags
+  const ports = optionalCpuPortContract(record.required_cpu_top_port_contract, path)
+  if (ports) entry.required_cpu_top_port_contract = ports
+  return entry
+}
+
+function optionalCpuPortContract(
+  value: unknown,
+  path: string,
+): FrontendCpuPortContract[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    throw invalidCatalog(`${path}.required_cpu_top_port_contract must be an array`)
+  }
+
+  const names = new Set<string>()
+  return value.map((item, index) => {
+    const portPath = `${path}.required_cpu_top_port_contract[${index}]`
+    const record = catalogRecord(item, portPath)
+    const name = catalogText(record, 'name', portPath)
+    const direction = catalogText(record, 'direction', portPath)
+    if (!CPU_PORT_DIRECTIONS.has(direction)) {
+      throw invalidCatalog(`${portPath}.direction is invalid`)
+    }
+    if (!Number.isSafeInteger(record.width) || Number(record.width) < 1) {
+      throw invalidCatalog(`${portPath}.width must be a positive integer`)
+    }
+    if (names.has(name)) throw invalidCatalog(`${portPath}.name duplicates ${name}`)
+    names.add(name)
+    return {
+      name,
+      direction: direction as FrontendCpuPortContract['direction'],
+      width: Number(record.width),
+    }
+  })
+}
+
+function catalogIds(entries: FrontendCatalogEntry[], path: string): Set<string> {
+  const ids = new Set<string>()
+  for (const entry of entries) {
+    if (ids.has(entry.id))
+      throw invalidCatalog(`${path} contains duplicate id ${entry.id}`)
+    ids.add(entry.id)
+  }
+  return ids
+}
+
+function parseCompatibilityEntries(
+  value: unknown,
+  ids: Record<(typeof CATALOG_ENTRY_ARRAYS)[number], Set<string>>,
+): FrontendCompatibilityEntry[] {
+  if (!Array.isArray(value)) throw invalidCatalog('compatibility must be an array')
+  const pairs = new Set<string>()
+  return value.map((item, index) => {
+    const path = `compatibility[${index}]`
+    const record = catalogRecord(item, path)
+    const coreId = catalogText(record, 'core_id', path)
+    const socHarnessId = catalogText(record, 'soc_harness_id', path)
+    requireCatalogReference(ids.cores, coreId, `${path}.core_id`)
+    requireCatalogReference(ids.soc_harnesses, socHarnessId, `${path}.soc_harness_id`)
+    const pair = `${coreId}\0${socHarnessId}`
+    if (pairs.has(pair))
+      throw invalidCatalog(`${path} duplicates ${coreId}/${socHarnessId}`)
+    pairs.add(pair)
+
+    const supportLevel = catalogText(record, 'support_level', path)
+    if (!COMPATIBILITY_SUPPORT_LEVELS.has(supportLevel)) {
+      throw invalidCatalog(`${path}.support_level is invalid`)
+    }
+    const supportedTestSuites = catalogStringArray(record, 'supported_test_suites', path)
+    for (const testSuiteId of supportedTestSuites) {
+      requireCatalogReference(
+        ids.test_suites,
+        testSuiteId,
+        `${path}.supported_test_suites`,
+      )
+    }
+    if (!Array.isArray(record.issues))
+      throw invalidCatalog(`${path}.issues must be an array`)
+    const issues = record.issues.map((issue, issueIndex) => {
+      const issuePath = `${path}.issues[${issueIndex}]`
+      const issueRecord = catalogRecord(issue, issuePath)
+      return {
+        code: catalogText(issueRecord, 'code', issuePath),
+        message: catalogText(issueRecord, 'message', issuePath),
+      }
+    })
+
+    return {
+      core_id: coreId,
+      soc_harness_id: socHarnessId,
+      can_create_workspace: catalogBoolean(record, 'can_create_workspace', path),
+      support_level: supportLevel as FrontendCompatibilityEntry['support_level'],
+      status: catalogText(record, 'status', path),
+      summary: catalogText(record, 'summary', path),
+      supported_test_suites: supportedTestSuites,
+      issues,
+      requires_cpu_filelist: catalogBoolean(record, 'requires_cpu_filelist', path),
+    }
+  })
+}
+
+function requireCatalogReference(ids: Set<string>, id: string, path: string): void {
+  if (!ids.has(id)) throw invalidCatalog(`${path} references unknown id ${id}`)
+}
+
+function catalogRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw invalidCatalog(`${path} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function catalogString(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string {
+  if (typeof record[key] !== 'string') {
+    throw invalidCatalog(`${path}.${key} must be a string`)
+  }
+  return record[key]
+}
+
+function catalogText(record: Record<string, unknown>, key: string, path: string): string {
+  const value = catalogString(record, key, path).trim()
+  if (!value) throw invalidCatalog(`${path}.${key} must not be empty`)
+  return value
+}
+
+function optionalCatalogString(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | undefined {
+  return record[key] === undefined ? undefined : catalogString(record, key, path)
+}
+
+function catalogStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] {
+  const value = record[key]
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw invalidCatalog(`${path}.${key} must be an array of strings`)
+  }
+  return value.map((item) => item.trim()).filter(Boolean)
+}
+
+function optionalCatalogStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] | undefined {
+  return record[key] === undefined ? undefined : catalogStringArray(record, key, path)
+}
+
+function catalogBoolean(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): boolean {
+  if (typeof record[key] !== 'boolean') {
+    throw invalidCatalog(`${path}.${key} must be a boolean`)
+  }
+  return record[key]
+}
+
+function responseMessages(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((message): message is string => typeof message === 'string')
+    : []
+}
+
+function responseStatus(value: unknown): ResponseEnum {
+  switch (value) {
+    case ResponseEnum.error:
+    case ResponseEnum.failed:
+    case ResponseEnum.success:
+    case ResponseEnum.warning:
+      return value
+    default:
+      return ResponseEnum.success
+  }
+}
+
+function invalidCatalog(detail: string): Error {
+  return new Error(`Invalid frontend catalog: ${detail}.`)
 }

--- a/ecos/gui/apps/renderer/src/composables/useDesktopRuntime.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesktopRuntime.test.ts
@@ -102,6 +102,7 @@ const desktopBridge = {
     clearProjectRoot: async () => undefined,
     requestProjectPathAccess: async (path: string) => path,
     authorizeWaveform: async (path: string) => path,
+    openWaveformExternal: async (_path: string) => undefined,
     readProjectTextFile: async () => '',
     readOptionalProjectTextFile: async () => null,
     readProjectTextFileTail: async () => null,

--- a/ecos/gui/apps/renderer/src/composables/usePdkManager.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/usePdkManager.test.ts
@@ -137,6 +137,7 @@ const desktopBridge = {
     clearProjectRoot: async () => undefined,
     requestProjectPathAccess: async (path: string) => path,
     authorizeWaveform: async (path: string) => path,
+    openWaveformExternal: async (_path: string) => undefined,
     readProjectTextFile: async () => '',
     readOptionalProjectTextFile: async () => null,
     readProjectTextFileTail: async () => null,

--- a/ecos/gui/apps/renderer/src/composables/useVersion.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useVersion.test.ts
@@ -70,6 +70,7 @@ function createDesktopBridge(getVersions: DesktopApi['app']['getVersions']) {
       clearProjectRoot: async () => undefined,
       requestProjectPathAccess: async (path: string) => path,
       authorizeWaveform: async (path: string) => path,
+      openWaveformExternal: async (_path: string) => undefined,
       readProjectTextFile: async () => '',
       readOptionalProjectTextFile: async () => null,
       readProjectTextFileTail: async () => null,

--- a/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.sim-layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.sim-layout.test.ts
@@ -73,4 +73,11 @@ describe('FrontendWorkspaceView simulation layout', () => {
     expect(frontendWorkspaceViewSource).toContain('...loadedDetail,')
     expect(frontendWorkspaceViewSource).not.toContain('...detail.value,\n      cases:')
   })
+
+  it('opens waveform files through the scoped desktop path API', () => {
+    expect(frontendWorkspaceViewSource).toContain(
+      'getDesktopApi().workspace.openWaveformExternal(path)',
+    )
+    expect(frontendWorkspaceViewSource).not.toContain('pathToFileUrl')
+  })
 })

--- a/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.sim-layout.test.ts
+++ b/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.sim-layout.test.ts
@@ -62,4 +62,15 @@ describe('FrontendWorkspaceView simulation layout', () => {
       '...liveRuntimeStepOverrides.get(step.name.trim().toLowerCase())',
     )
   })
+
+  it('does not apply waveform case fallbacks from a stale detail request', () => {
+    expect(frontendWorkspaceViewSource).toContain(
+      'await hydrateWaveCasesFromWorkspaceResources(loadedDetail, isCurrentRequest)',
+    )
+    expect(frontendWorkspaceViewSource).toContain(
+      'if (!isCurrentRequest() || detail.value !== loadedDetail) return',
+    )
+    expect(frontendWorkspaceViewSource).toContain('...loadedDetail,')
+    expect(frontendWorkspaceViewSource).not.toContain('...detail.value,\n      cases:')
+  })
 })

--- a/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.vue
+++ b/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.vue
@@ -4514,7 +4514,7 @@ function waveRouteQuery(path: string, caseName?: string): Record<string, string>
 
 async function openWaveExternal(path: string): Promise<void> {
   try {
-    await getDesktopApi().system.openExternal(pathToFileUrl(path))
+    await getDesktopApi().workspace.openWaveformExternal(path)
   } catch {
     showToast({
       severity: 'error',
@@ -4523,11 +4523,6 @@ async function openWaveExternal(path: string): Promise<void> {
       life: 5000,
     })
   }
-}
-
-function pathToFileUrl(path: string): string {
-  const normalized = path.startsWith('/') ? path : `/${path}`
-  return `file://${normalized.split('/').map(encodeURIComponent).join('/')}`
 }
 
 function handleSurferFrameChange(frame: HTMLIFrameElement | null): void {

--- a/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.vue
+++ b/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.vue
@@ -3854,8 +3854,9 @@ async function loadDetail(context?: DetailLoadContext): Promise<void> {
       detail.value = null
       return
     }
-    detail.value = info as unknown as FrontendStepDetail
-    await hydrateWaveCasesFromWorkspaceResources()
+    const loadedDetail = info as unknown as FrontendStepDetail
+    detail.value = loadedDetail
+    await hydrateWaveCasesFromWorkspaceResources(loadedDetail, isCurrentRequest)
     if (!isCurrentRequest()) return
     const previousCaseName = selectedCase.value?.name || ''
     selectedCase.value =
@@ -3917,25 +3918,37 @@ async function loadSelectedLog(): Promise<void> {
   }
 }
 
-async function hydrateWaveCasesFromWorkspaceResources(): Promise<void> {
-  if (!isGlobalWaveView.value || detailWaveItems.value.length > 0) return
+async function hydrateWaveCasesFromWorkspaceResources(
+  loadedDetail: FrontendStepDetail,
+  isCurrentRequest: () => boolean,
+): Promise<void> {
+  if (
+    !isCurrentRequest() ||
+    detail.value !== loadedDetail ||
+    !isGlobalWaveView.value ||
+    detailWaveItems.value.length > 0
+  )
+    return
 
   try {
     const response = await resolveWorkspaceStepInfoApi({
       step: 'sim',
       id: InfoEnum.frontend_detail,
     })
+    if (!isCurrentRequest() || detail.value !== loadedDetail) return
     if (response.response !== 'available') return
     const fallbackCases = Array.isArray(response.info?.cases)
       ? (response.info.cases as SimCase[])
       : []
-    if (!fallbackCases.some((testCase) => Boolean(testCase.wave)) || !detail.value) return
+    if (!fallbackCases.some((testCase) => Boolean(testCase.wave))) return
     detail.value = {
-      ...detail.value,
+      ...loadedDetail,
       cases: fallbackCases,
     }
   } catch (err) {
-    console.warn('Failed to load waveform cases from workspace resources:', err)
+    if (isCurrentRequest() && detail.value === loadedDetail) {
+      console.warn('Failed to load waveform cases from workspace resources:', err)
+    }
   }
 }
 

--- a/ecos/gui/packages/shared/src/constants/ipcChannels.ts
+++ b/ecos/gui/packages/shared/src/constants/ipcChannels.ts
@@ -32,6 +32,7 @@ export const desktopApiIpcChannels = {
   workspaceClearProjectRoot: 'workspace:clear-project-root',
   workspaceRequestProjectPathAccess: 'workspace:request-project-path-access',
   workspaceAuthorizeWaveform: 'workspace:authorize-waveform',
+  workspaceOpenWaveformExternal: 'workspace:open-waveform-external',
   workspaceReadProjectTextFile: 'workspace:read-project-text-file',
   workspaceReadOptionalProjectTextFile: 'workspace:read-optional-project-text-file',
   workspaceReadProjectTextFileTail: 'workspace:read-project-text-file-tail',

--- a/ecos/gui/packages/shared/src/contracts/desktopApi.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopApi.ts
@@ -271,6 +271,7 @@ export interface DesktopApi {
     clearProjectRoot(): Promise<void>
     requestProjectPathAccess(path: string): Promise<string>
     authorizeWaveform(path: string): Promise<string>
+    openWaveformExternal(path: string): Promise<void>
     readProjectTextFile(path: string): Promise<string>
     readOptionalProjectTextFile(path: string): Promise<string | null>
     readProjectTextFileTail(path: string, maxChars: number): Promise<string | null>


### PR DESCRIPTION
## Context

This PR is a focused follow-up to the code review of commit `f5e9af0f536878f804ef51887e5f5ab734388a24`, which introduced the ECC-FE frontend workflow.

It addresses six concrete correctness, security, lifecycle, and cross-platform findings from that review. Each remediation is isolated in its own commit and was validated before moving to the next finding.

## Review findings addressed

### 1. Require explicit approval for external project reads

**Finding:** Registering a frontend workspace could implicitly authorize source locations outside the project root. A workspace could therefore expand its read scope without an explicit user decision.

**Changes:**

- External source roots are collected as pending instead of being granted automatically.
- The main process displays a native warning dialog that lists the requested external locations.
- Access remains blocked when the user selects **Not Now**.
- Approved roots are persisted per canonical project root in a versioned grant store.
- Grant writes are serialized and replaced atomically.
- Previously approved roots can be restored for the same project without widening another project scope.

**Result:** External frontend sources remain usable, but project read scope now fails closed and only expands after native user approval.

### 2. Propagate parent cancellation through resource dependencies

**Finding:** Cancelling a parent Resource Manager installation while one of its dependencies was installing did not reliably stop the dependency operation. The parent could remain active or report a state inconsistent with the actual download.

**Changes:**

- A shared installation context and `AbortController` now span the root resource and its dependency chain.
- Parent and dependency jobs are tracked against the same cancellation context.
- Cancellation interrupts dependency waits and is checked between dependency and install phases.
- Root cancellation is reported consistently even when the active work is currently owned by a dependency.
- Existing shared dependency operations remain reusable while callers can independently stop waiting.

**Result:** Cancelling a parent resource now terminates the in-flight dependency path and cleans up job state consistently.

### 3. Prevent stale waveform case hydration

**Finding:** An asynchronous fallback request for simulation cases could complete after the active workspace, step, or detail request had changed. Its stale result could overwrite the current waveform detail.

**Changes:**

- Waveform fallback hydration is bound to the detail object and request identity that initiated it.
- Request validity is checked before the fallback request, after the await, and before error reporting.
- Fallback cases are merged into the captured detail rather than whichever detail happens to be active later.

**Result:** Slow responses from an old workspace or selection can no longer replace the current simulation case and waveform state.

### 4. Validate frontend catalog responses at runtime

**Finding:** The frontend catalog RPC response was cast directly to the TypeScript contract. Malformed or incompatible runtime data could reach the wizard and fail later in less predictable UI code.

**Changes:**

- Added a runtime parser for catalog schema version 1.
- Required collections, entry fields, optional strings, string arrays, and booleans are validated.
- Duplicate entry IDs and duplicate compatibility pairs are rejected.
- Default IDs and compatibility references must resolve to known catalog entries.
- CPU port contracts validate unique names, supported directions, and positive integer widths.
- Compatibility support levels, issue records, and supported test suite references are validated.
- Response messages and status values are normalized at the IPC boundary.

**Result:** Invalid or unsupported catalog payloads are rejected immediately with a precise error instead of corrupting wizard state.

### 5. Validate required tool executables, not only marker existence

**Finding:** Resource health checks treated required binary paths as healthy when they merely existed. A directory or a non-executable file could therefore be recorded and displayed as an installed tool.

**Changes:**

- Executable candidates must be regular files.
- POSIX executable candidates must have execute permission.
- Required executable markers are enforced for ECC-FE, Verilator, and the RISC-V toolchain.
- The same health validation is used for staged archives, installed resource status, and runtime executable resolution.
- A failed replacement archive leaves the previous installation and manifest entry intact.

**Result:** Broken tool archives are rejected before activation, and existing unusable tools are reported as invalid instead of installed.

### 6. Open waveform files correctly across platforms

**Finding:** The renderer manually converted waveform paths into `file://` URLs and passed them to `shell.openExternal`. This corrupted Windows drive-letter and backslash paths.

**Changes:**

- Added a narrow, workspace-scoped `openWaveformExternal` IPC operation.
- The main process reuses Surfer waveform validation for project scope, extension, canonical path, and regular-file checks.
- Validated native paths are passed directly to Electron `shell.openPath`.
- Operating-system association errors are returned through the normal IPC error contract.
- Removed renderer-side `file://` URL construction.

**Result:** Windows paths such as `C:\work\cpu\trace.vcd` remain intact, while Linux and macOS continue to use native path opening.

## Verification

### Automated

The complete GUI validation suite passes:

```text
pnpm run check

Infrastructure:       7 passed
Shared package:      63 passed
Desktop Electron:   589 passed
Renderer:          1158 passed
Total:             1817 passed
```

This includes focused regression coverage for:

- native approval and denial of external source roots;
- persisted project-scoped read grants;
- parent and dependency cancellation;
- stale waveform detail responses;
- malformed catalog schemas and references;
- unusable executable markers and failed replacement rollback;
- Windows waveform path passthrough, preload routing, scoped IPC validation, and OS open errors.

### Manual GUI verification

All six fixes were tested incrementally in the desktop GUI before their commits were pushed:

1. External source access approval and denial behavior was verified.
2. Resource installation cancellation behavior was verified.
3. Waveform selection remained correct across asynchronous detail loading.
4. Frontend catalog-backed workspace setup continued to work with a valid catalog.
5. Healthy installed resources continued to display **Installed** after refresh.
6. The Wave workspace **Open** action successfully opened the selected waveform externally.

## Scope

This PR contains only the six code review remediations above. The existing local `ecc` and `ecc-fe` submodule worktrees are not part of the PR.