### PR TITLE
feat(ci): add macOS and Windows desktop builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,3 +224,127 @@ jobs:
           retention-days: 14
           path: |
             build/**/*.AppImage
+
+  build-macos:
+    name: Build macOS App
+    needs: [changes, check-version, gui-checks, chip-viewer-rust]
+    if: >-
+      ${{
+        always() &&
+        (needs.changes.outputs.gui == 'true' ||
+         needs.changes.outputs.chip_viewer == 'true' ||
+         needs.changes.outputs.version == 'true' ||
+         needs.changes.outputs.build == 'true' ||
+         needs.changes.outputs.ci == 'true') &&
+        needs.check-version.result != 'failure' &&
+        needs.gui-checks.result != 'failure' &&
+        needs.chip-viewer-rust.result != 'failure'
+      }}
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          workspaces: ecos/chip-viewer
+
+      - name: Build chip-viewer-native
+        working-directory: ecos/chip-viewer
+        run: cargo build --release -p chip-viewer-native
+
+      - name: Stage resources
+        run: |
+          mkdir -p ecos/gui/apps/desktop-electron/resources/binaries
+          mkdir -p ecos/gui/apps/desktop-electron/resources/agent
+          cp ecos/chip-viewer/target/release/chip-viewer-native \
+             ecos/gui/apps/desktop-electron/resources/binaries/
+
+      - name: Install GUI dependencies
+        working-directory: ecos/gui
+        run: pnpm install --frozen-lockfile
+
+      - name: Build renderer
+        working-directory: ecos/gui
+        run: pnpm --filter @ecos-studio/desktop-electron run build
+
+      - name: Package macOS app
+        working-directory: ecos/gui/apps/desktop-electron
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          GH_TOKEN: ${{ github.token }}
+        run: pnpm exec electron-builder --config electron-builder.yml
+
+      - name: Upload CI macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ecos-studio-macos-${{ github.run_number }}
+          if-no-files-found: error
+          retention-days: 14
+          path: ecos/gui/apps/desktop-electron/release/**/*.dmg
+
+  build-windows:
+    name: Build Windows App
+    needs: [changes, check-version, gui-checks, chip-viewer-rust]
+    if: >-
+      ${{
+        always() &&
+        (needs.changes.outputs.gui == 'true' ||
+         needs.changes.outputs.chip_viewer == 'true' ||
+         needs.changes.outputs.version == 'true' ||
+         needs.changes.outputs.build == 'true' ||
+         needs.changes.outputs.ci == 'true') &&
+        needs.check-version.result != 'failure' &&
+        needs.gui-checks.result != 'failure' &&
+        needs.chip-viewer-rust.result != 'failure'
+      }}
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          workspaces: ecos/chip-viewer
+
+      - name: Build chip-viewer-native
+        working-directory: ecos/chip-viewer
+        run: cargo build --release -p chip-viewer-native
+
+      - name: Stage resources
+        shell: bash
+        run: |
+          mkdir -p ecos/gui/apps/desktop-electron/resources/binaries
+          mkdir -p ecos/gui/apps/desktop-electron/resources/agent
+          cp ecos/chip-viewer/target/release/chip-viewer-native.exe \
+             ecos/gui/apps/desktop-electron/resources/binaries/
+
+      - name: Install GUI dependencies
+        working-directory: ecos/gui
+        run: pnpm install --frozen-lockfile
+
+      - name: Build renderer
+        working-directory: ecos/gui
+        run: pnpm --filter @ecos-studio/desktop-electron run build
+
+      - name: Package Windows app
+        working-directory: ecos/gui/apps/desktop-electron
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pnpm exec electron-builder --config electron-builder.yml
+
+      - name: Upload CI Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ecos-studio-windows-${{ github.run_number }}
+          if-no-files-found: error
+          retention-days: 14
+          path: ecos/gui/apps/desktop-electron/release/**/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           expected_tag: ${{ github.event.inputs.tag_name || github.ref_name }}
 
   build:
-    name: Build AppImage
+    name: Build Linux AppImage
     needs: check-version
     runs-on: ubuntu-22.04
     steps:
@@ -99,14 +99,116 @@ jobs:
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ecos-studio-release
+          name: ecos-studio-release-linux
           if-no-files-found: error
           path: |
             build/**/*.AppImage
 
+  build-macos:
+    name: Build macOS App
+    needs: check-version
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag_name || github.ref }}
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          workspaces: ecos/chip-viewer
+
+      - name: Build chip-viewer-native
+        working-directory: ecos/chip-viewer
+        run: cargo build --release -p chip-viewer-native
+
+      - name: Stage resources
+        run: |
+          mkdir -p ecos/gui/apps/desktop-electron/resources/binaries
+          mkdir -p ecos/gui/apps/desktop-electron/resources/agent
+          cp ecos/chip-viewer/target/release/chip-viewer-native \
+             ecos/gui/apps/desktop-electron/resources/binaries/
+
+      - name: Install GUI dependencies
+        working-directory: ecos/gui
+        run: pnpm install --frozen-lockfile
+
+      - name: Build renderer
+        working-directory: ecos/gui
+        run: pnpm --filter @ecos-studio/desktop-electron run build
+
+      - name: Package macOS app
+        working-directory: ecos/gui/apps/desktop-electron
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          GH_TOKEN: ${{ github.token }}
+        run: pnpm exec electron-builder --config electron-builder.yml
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ecos-studio-release-macos
+          if-no-files-found: error
+          path: ecos/gui/apps/desktop-electron/release/**/*.dmg
+
+  build-windows:
+    name: Build Windows App
+    needs: check-version
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag_name || github.ref }}
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          workspaces: ecos/chip-viewer
+
+      - name: Build chip-viewer-native
+        working-directory: ecos/chip-viewer
+        run: cargo build --release -p chip-viewer-native
+
+      - name: Stage resources
+        shell: bash
+        run: |
+          mkdir -p ecos/gui/apps/desktop-electron/resources/binaries
+          mkdir -p ecos/gui/apps/desktop-electron/resources/agent
+          cp ecos/chip-viewer/target/release/chip-viewer-native.exe \
+             ecos/gui/apps/desktop-electron/resources/binaries/
+
+      - name: Install GUI dependencies
+        working-directory: ecos/gui
+        run: pnpm install --frozen-lockfile
+
+      - name: Build renderer
+        working-directory: ecos/gui
+        run: pnpm --filter @ecos-studio/desktop-electron run build
+
+      - name: Package Windows app
+        working-directory: ecos/gui/apps/desktop-electron
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pnpm exec electron-builder --config electron-builder.yml
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ecos-studio-release-windows
+          if-no-files-found: error
+          path: ecos/gui/apps/desktop-electron/release/**/*.exe
+
   release:
     name: Create Release
-    needs: [check-version, build]
+    needs: [check-version, build, build-macos, build-windows]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -118,8 +220,9 @@ jobs:
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ecos-studio-release
+          pattern: ecos-studio-release-*
           path: build/release
+          merge-multiple: true
 
       - name: Determine tag version
         id: version
@@ -145,7 +248,7 @@ jobs:
         run: |
           {
             echo "> [!WARNING]"
-            echo "> **ECOS Studio** is still under rapid development. You can download the latest version from the [release page](https://github.com/openecos-projects/ecos-studio/releases) to try it out (The current release builds are produced on **Ubuntu 22.04**, so using an older Linux system may lead to compatibility issues. Additionally, ECOS Studio currently only supports the **x86_64** Linux platform.)."
+            echo "> **ECOS Studio** is still under rapid development. The EDA flow (Yosys, ECC-Tools, KLayout) runs on **Linux x86_64** only. macOS and Windows builds include the GUI and chip viewer; EDA tool execution is not yet supported on those platforms."
             echo ">"
             echo ""
             cat release-changelog.md
@@ -156,7 +259,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mapfile -t ASSETS < <(find build/release -type f -name '*.AppImage' | sort)
+          mapfile -t ASSETS < <(find build/release -type f \( -name '*.AppImage' -o -name '*.dmg' -o -name '*.exe' \) | sort)
           gh release create "${{ steps.version.outputs.full_tag }}" \
             --title "ECOS Studio ${{ steps.version.outputs.full_tag }}" \
             --notes-file release-notes.md \

--- a/ecos/gui/apps/desktop-electron/electron-builder.yml
+++ b/ecos/gui/apps/desktop-electron/electron-builder.yml
@@ -21,3 +21,15 @@ linux:
   target:
     - AppImage
     - deb
+
+mac:
+  artifactName: ECOS-Studio_${version}_${arch}.${ext}
+  executableName: ecos-studio
+  category: public.app-category.developer-tools
+  target:
+    - dmg
+
+win:
+  artifactName: ECOS-Studio_${version}_${arch}.${ext}
+  target:
+    - nsis


### PR DESCRIPTION
Currently CI only produces a Linux AppImage. This PR extends the build to macOS (arm64, macos-14 runner) and Windows (x64, windows-2022 runner).

Each platform job:

1. Checks out the repo (no submodules - EDA backend not needed).
2. Builds `chip-viewer-native` natively with Cargo.
3. Stages it into `resources/binaries/` alongside an empty `resources/agent/` directory.
4. Runs `electron-builder` on the native runner to produce a `.dmg` (macOS) or NSIS `.exe` (Windows).

The release workflow is extended in the same way - both `build-macos` and `build-windows` jobs feed their artifacts into the release job, which uploads all three platform packages together.

A note on scope: the EDA flow (Yosys, ECC-Tools, KLayout, DreamPlace) compiles only on Linux x86_64. The macOS/Windows packages include the GUI and chip-viewer-native; EDA tool execution is not supported on those platforms. The release notes are updated to reflect this.

The `afterPack` hook (`after-pack-linux-sandbox.mjs`) already guards on `electronPlatformName !== 'linux'` and exits early, so no sandbox wrapping or ECC validation runs for macOS/Windows.