### PR TITLE
fix(gui): require approval for external project reads

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/main/index.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/index.ts
@@ -34,6 +34,7 @@ import {
   registerApplicationMenu,
 } from '../services/menuService'
 import { ProjectScopeService } from '../services/projectScopeService'
+import { ProjectReadGrantStore } from '../services/projectReadGrantStore'
 import { ProjectManifestService } from '../services/projectManifestService'
 import { ProjectManagementReadService } from '../services/projectManagementReadService'
 import { ResourceManagerService } from '../services/resourceManagerService'
@@ -123,7 +124,12 @@ function getDesktopServices() {
   const settingsStore = new SettingsStore({
     filePath: join(app.getPath('userData'), 'settings.json'),
   })
-  projectScopeService = new ProjectScopeService()
+  const projectReadGrantStore = new ProjectReadGrantStore({
+    filePath: join(app.getPath('userData'), 'project-read-grants.json'),
+  })
+  projectScopeService = new ProjectScopeService({
+    readGrantProvider: projectReadGrantStore,
+  })
   const eccRuntimeOptions = {
     appPath: app.getAppPath(),
     cwd: process.cwd(),

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
@@ -332,7 +332,7 @@ describe('registerIpc', () => {
     )
     expect(
       services.workspaceService.approvePendingExternalReadRoots,
-    ).toHaveBeenCalledOnce()
+    ).toHaveBeenCalledWith('/tmp/project', ['/tmp/external-rtl'])
   })
 
   it('keeps external frontend roots blocked when native confirmation is denied', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.test.ts
@@ -18,6 +18,7 @@ const {
   fromWebContents,
   getAllWindows,
   openExternal,
+  showMessageBox,
   showOpenDialog,
   showSaveDialog,
   mkdirMock,
@@ -27,6 +28,7 @@ const {
   getAllWindows: vi.fn<() => MockBrowserWindow[]>(() => []),
   mkdirMock: vi.fn(),
   openExternal: vi.fn(),
+  showMessageBox: vi.fn(),
   showOpenDialog: vi.fn(),
   showSaveDialog: vi.fn(),
   statMock: vi.fn(),
@@ -47,6 +49,7 @@ vi.mock('electron', () => ({
     getAllWindows,
   },
   dialog: {
+    showMessageBox,
     showOpenDialog,
     showSaveDialog,
   },
@@ -107,8 +110,10 @@ function registerHandlers(
       readWorkspaceTexts: vi.fn(),
     },
     workspaceService: {
+      approvePendingExternalReadRoots: vi.fn(),
       clearProjectRoot: vi.fn(),
       isProjectDirectory: vi.fn(),
+      listPendingExternalReadRoots: vi.fn(),
       readProjectBinaryFile: vi.fn(),
       readOptionalProjectTextFile: vi.fn(),
       readOptionalProjectTextFileChunk: vi.fn(),
@@ -267,6 +272,7 @@ describe('registerIpc', () => {
     executeWorkspaceRerunMock.mockReset()
     prepareWorkspaceRerunMock.mockReset()
     showOpenDialog.mockReset()
+    showMessageBox.mockReset()
     showSaveDialog.mockReset()
     mkdirMock.mockReset()
     setMenuActionEnabled.mockReset()
@@ -294,6 +300,59 @@ describe('registerIpc', () => {
     expect(Array.from(handlers.keys()).sort()).toEqual(
       Object.values(desktopApiIpcChannels).sort(),
     )
+  })
+
+  it('requires native confirmation before approving external frontend roots', async () => {
+    const { handlers, services } = registerHandlers()
+    const event = { sender: { id: 7 } }
+    const windowDouble = createWindowDouble(false)
+    fromWebContents.mockReturnValue(windowDouble)
+    services.workspaceService.registerProjectRoot.mockResolvedValue('/tmp/project')
+    services.workspaceService.listPendingExternalReadRoots.mockResolvedValue([
+      '/tmp/external-rtl',
+    ])
+    showMessageBox.mockResolvedValue({ response: 1 })
+
+    await expect(
+      handlers.get(desktopApiIpcChannels.workspaceRegisterProjectRoot)?.(
+        event,
+        '/tmp/project',
+      ),
+    ).resolves.toBe('/tmp/project')
+
+    expect(showMessageBox).toHaveBeenCalledWith(
+      windowDouble,
+      expect.objectContaining({
+        buttons: ['Not Now', 'Allow Access'],
+        cancelId: 0,
+        defaultId: 0,
+        detail: expect.stringContaining('/tmp/external-rtl'),
+        type: 'warning',
+      }),
+    )
+    expect(
+      services.workspaceService.approvePendingExternalReadRoots,
+    ).toHaveBeenCalledOnce()
+  })
+
+  it('keeps external frontend roots blocked when native confirmation is denied', async () => {
+    const { handlers, services } = registerHandlers()
+    const event = { sender: { id: 7 } }
+    fromWebContents.mockReturnValue(createWindowDouble(false))
+    services.workspaceService.registerProjectRoot.mockResolvedValue('/tmp/project')
+    services.workspaceService.listPendingExternalReadRoots.mockResolvedValue([
+      '/tmp/external-rtl',
+    ])
+    showMessageBox.mockResolvedValue({ response: 0 })
+
+    await handlers.get(desktopApiIpcChannels.workspaceRegisterProjectRoot)?.(
+      event,
+      '/tmp/project',
+    )
+
+    expect(
+      services.workspaceService.approvePendingExternalReadRoots,
+    ).not.toHaveBeenCalled()
   })
 
   it('rejects a renderer-supplied rerun contract without a main-process token', async () => {

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
@@ -160,7 +160,10 @@ export interface DesktopBridgeServices {
     ): Promise<DesktopProjectManagementWorkspaceTextsResult>
   }
   workspaceService: {
-    approvePendingExternalReadRoots?(): Promise<string[]>
+    approvePendingExternalReadRoots?(
+      expectedProjectRoot: string,
+      expectedRoots: string[],
+    ): Promise<string[]>
     clearProjectRoot(): Promise<void>
     isProjectDirectory(path: string): Promise<boolean>
     readProjectBinaryFile(path: string): Promise<Uint8Array>
@@ -1310,7 +1313,10 @@ export function registerIpc(
     })
     if (result.response === 1) {
       try {
-        await services.workspaceService.approvePendingExternalReadRoots?.()
+        await services.workspaceService.approvePendingExternalReadRoots?.(
+          projectRoot,
+          pendingRoots,
+        )
       } catch (error) {
         electronLogger.warn(
           '[workspace] Failed to persist external source approval: %s',

--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
@@ -160,6 +160,7 @@ export interface DesktopBridgeServices {
     ): Promise<DesktopProjectManagementWorkspaceTextsResult>
   }
   workspaceService: {
+    approvePendingExternalReadRoots?(): Promise<string[]>
     clearProjectRoot(): Promise<void>
     isProjectDirectory(path: string): Promise<boolean>
     readProjectBinaryFile(path: string): Promise<Uint8Array>
@@ -180,6 +181,7 @@ export interface DesktopBridgeServices {
       fromOffsetBytes: number,
       maxBytes: number,
     ): Promise<DesktopProjectTextFileChunk | null>
+    listPendingExternalReadRoots?(): Promise<string[]>
     subscribeProjectLogTail(
       path: string,
       options: {
@@ -1279,7 +1281,44 @@ export function registerIpc(
   })
 
   handle(desktopApiIpcChannels.workspaceRegisterProjectRoot, async (_event, path) => {
-    return await services.workspaceService.registerProjectRoot(path as string)
+    const projectRoot = await services.workspaceService.registerProjectRoot(
+      path as string,
+    )
+    const pendingRoots =
+      (await services.workspaceService.listPendingExternalReadRoots?.()) ?? []
+    if (pendingRoots.length === 0) return projectRoot
+
+    const visibleRoots = pendingRoots.slice(0, 8)
+    const hiddenCount = pendingRoots.length - visibleRoots.length
+    const detail = [
+      'This frontend workspace references files outside its project directory:',
+      '',
+      ...visibleRoots.map((root) => `- ${root}`),
+      ...(hiddenCount > 0 ? [`- ...and ${hiddenCount} more`] : []),
+      '',
+      'Allow read-only access to these locations?',
+    ].join('\n')
+    const result = await dialog.showMessageBox(getEventWindow(_event), {
+      type: 'warning',
+      title: 'External Frontend Sources',
+      message: 'Allow this workspace to read external source locations?',
+      detail,
+      buttons: ['Not Now', 'Allow Access'],
+      defaultId: 0,
+      cancelId: 0,
+      noLink: true,
+    })
+    if (result.response === 1) {
+      try {
+        await services.workspaceService.approvePendingExternalReadRoots?.()
+      } catch (error) {
+        electronLogger.warn(
+          '[workspace] Failed to persist external source approval: %s',
+          error instanceof Error ? error.message : String(error),
+        )
+      }
+    }
+    return projectRoot
   })
 
   handle(desktopApiIpcChannels.workspaceRegisterProjectReadRoot, async (_event, path) => {

--- a/ecos/gui/apps/desktop-electron/electron/services/projectReadGrantStore.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectReadGrantStore.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ProjectReadGrantStore } from './projectReadGrantStore'
+
+const tempDirectories: string[] = []
+
+async function createStore(): Promise<{
+  directory: string
+  filePath: string
+  store: ProjectReadGrantStore
+}> {
+  const directory = await mkdtemp(join(tmpdir(), 'ecos-project-read-grants-'))
+  tempDirectories.push(directory)
+  const filePath = join(directory, 'project-read-grants.json')
+  return {
+    directory,
+    filePath,
+    store: new ProjectReadGrantStore({ filePath }),
+  }
+}
+
+describe('ProjectReadGrantStore', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirectories
+        .splice(0)
+        .map((directory) => rm(directory, { force: true, recursive: true })),
+    )
+  })
+
+  it('persists grants independently for each project', async () => {
+    const { filePath, store } = await createStore()
+    await store.set('/work/project-a', ['/work/rtl-a', '/work/rtl-a'])
+    await store.set('/work/project-b', ['/work/rtl-b'])
+
+    const reloaded = new ProjectReadGrantStore({ filePath })
+    await expect(reloaded.get('/work/project-a')).resolves.toEqual(['/work/rtl-a'])
+    await expect(reloaded.get('/work/project-b')).resolves.toEqual(['/work/rtl-b'])
+  })
+
+  it('treats malformed state as empty instead of granting access', async () => {
+    const { filePath, store } = await createStore()
+    await writeFile(filePath, '{not-json', 'utf8')
+
+    await expect(store.get('/work/project')).resolves.toEqual([])
+    expect(await readFile(filePath, 'utf8')).toBe('{not-json')
+  })
+})

--- a/ecos/gui/apps/desktop-electron/electron/services/projectReadGrantStore.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectReadGrantStore.ts
@@ -1,0 +1,96 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+interface ProjectReadGrantRecord {
+  project_root: string
+  roots: string[]
+}
+
+interface ProjectReadGrantFile {
+  version: 1
+  projects: ProjectReadGrantRecord[]
+}
+
+export interface ProjectReadGrantStoreOptions {
+  filePath: string
+}
+
+function emptyGrantFile(): ProjectReadGrantFile {
+  return { version: 1, projects: [] }
+}
+
+function parseGrantFile(value: unknown): ProjectReadGrantFile {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return emptyGrantFile()
+  }
+
+  const record = value as Record<string, unknown>
+  if (record.version !== 1 || !Array.isArray(record.projects)) {
+    return emptyGrantFile()
+  }
+
+  const projects = record.projects.flatMap((entry) => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return []
+    const candidate = entry as Record<string, unknown>
+    if (typeof candidate.project_root !== 'string' || !Array.isArray(candidate.roots)) {
+      return []
+    }
+    const roots = candidate.roots.filter(
+      (root): root is string => typeof root === 'string' && root.length > 0,
+    )
+    return [{ project_root: candidate.project_root, roots }]
+  })
+
+  return { version: 1, projects }
+}
+
+export class ProjectReadGrantStore {
+  private readonly filePath: string
+  private writeChain: Promise<void> = Promise.resolve()
+
+  constructor(options: ProjectReadGrantStoreOptions) {
+    this.filePath = options.filePath
+  }
+
+  async get(projectRoot: string): Promise<string[]> {
+    await this.writeChain
+    const grants = await this.read()
+    return [
+      ...(grants.projects.find((entry) => entry.project_root === projectRoot)?.roots ??
+        []),
+    ]
+  }
+
+  async set(projectRoot: string, roots: string[]): Promise<void> {
+    const operation = this.writeChain.then(async () => {
+      const grants = await this.read()
+      const projects = grants.projects.filter(
+        (entry) => entry.project_root !== projectRoot,
+      )
+      projects.push({ project_root: projectRoot, roots: [...new Set(roots)] })
+      await this.write({ version: 1, projects })
+    })
+    this.writeChain = operation.then(
+      () => undefined,
+      () => undefined,
+    )
+    await operation
+  }
+
+  private async read(): Promise<ProjectReadGrantFile> {
+    try {
+      return parseGrantFile(JSON.parse(await readFile(this.filePath, 'utf8')) as unknown)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return emptyGrantFile()
+      if (error instanceof SyntaxError) return emptyGrantFile()
+      throw error
+    }
+  }
+
+  private async write(grants: ProjectReadGrantFile): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true })
+    const temporaryPath = `${this.filePath}.tmp`
+    await writeFile(temporaryPath, `${JSON.stringify(grants, null, 2)}\n`, 'utf8')
+    await rename(temporaryPath, this.filePath)
+  }
+}

--- a/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.test.ts
@@ -209,7 +209,7 @@ describe('ProjectScopeService', () => {
     })
   })
 
-  it('allows frontend source roots declared by workspace parameters', async () => {
+  it('requires explicit approval before allowing frontend source roots', async () => {
     const root = await createTempDir('ecos-project-root-')
     const sourceRoot = await createTempDir('ecos-frontend-source-')
     const sourceFile = join(sourceRoot, 'rtl', 'cpu.sv')
@@ -232,6 +232,15 @@ describe('ProjectScopeService', () => {
     await runWithWindowScope(1, async () => {
       await service.registerProjectRoot(root)
 
+      await expect(service.requestProjectPathAccess(sourceFile)).rejects.toThrow(
+        'outside current project root',
+      )
+      await expect(service.listPendingExternalReadRoots()).resolves.toEqual([
+        join(sourceRoot, 'rtl'),
+      ])
+      await expect(service.approvePendingExternalReadRoots()).resolves.toEqual([
+        join(sourceRoot, 'rtl'),
+      ])
       await expect(service.requestProjectPathAccess(sourceFile)).resolves.toBe(sourceFile)
       await expect(service.requestProjectPathAccess(outsideFile)).rejects.toThrow(
         'outside current project scope',
@@ -263,10 +272,73 @@ describe('ProjectScopeService', () => {
     const service = new ProjectScopeService()
     await runWithWindowScope(1, async () => {
       await service.registerProjectRoot(root)
+      await service.approvePendingExternalReadRoots()
 
       await expect(service.requestProjectPathAccess(sourceFile)).resolves.toBe(sourceFile)
       await expect(service.requestProjectPathAccess(siblingFile)).rejects.toThrow(
         'outside current project scope',
+      )
+    })
+  })
+
+  it('reuses persisted approval only for roots still declared by the project', async () => {
+    const root = await createTempDir('ecos-project-root-')
+    const sourceRoot = await createTempDir('ecos-frontend-source-')
+    const sourceFile = join(sourceRoot, 'cpu.sv')
+    const storedGrants = new Map<string, string[]>()
+    const readGrantProvider = {
+      get: async (projectRoot: string) => storedGrants.get(projectRoot) ?? [],
+      set: async (projectRoot: string, roots: string[]) => {
+        storedGrants.set(projectRoot, roots)
+      },
+    }
+    await mkdir(join(root, 'home'), { recursive: true })
+    await writeFile(sourceFile, 'module cpu; endmodule')
+    await writeFile(join(sourceRoot, 'filelist.cpu.f'), 'cpu.sv')
+    await writeFile(
+      join(root, 'home', 'parameters.json'),
+      JSON.stringify({
+        'Design Tool': 'frontend',
+        cpu_filelist: join(sourceRoot, 'filelist.cpu.f'),
+      }),
+    )
+
+    const firstService = new ProjectScopeService({ readGrantProvider })
+    await runWithWindowScope(1, async () => {
+      await firstService.registerProjectRoot(root)
+      await firstService.approvePendingExternalReadRoots()
+    })
+
+    const reloadedService = new ProjectScopeService({ readGrantProvider })
+    await runWithWindowScope(2, async () => {
+      await reloadedService.registerProjectRoot(root)
+      await expect(reloadedService.listPendingExternalReadRoots()).resolves.toEqual([])
+      await expect(reloadedService.requestProjectPathAccess(sourceFile)).resolves.toBe(
+        sourceFile,
+      )
+    })
+  })
+
+  it('never offers a project ancestor as an external read root', async () => {
+    const ancestor = await createTempDir('ecos-project-parent-')
+    const root = join(ancestor, 'workspace')
+    const siblingFile = join(ancestor, 'ecos-private.txt')
+    await mkdir(join(root, 'home'), { recursive: true })
+    await writeFile(siblingFile, 'private')
+    await writeFile(
+      join(root, 'home', 'parameters.json'),
+      JSON.stringify({
+        'Design Tool': 'frontend',
+        sim_soc_root: ancestor,
+      }),
+    )
+
+    const service = new ProjectScopeService()
+    await runWithWindowScope(1, async () => {
+      await service.registerProjectRoot(root)
+      await expect(service.listPendingExternalReadRoots()).resolves.toEqual([])
+      await expect(service.requestProjectPathAccess(siblingFile)).rejects.toThrow(
+        'outside current project root',
       )
     })
   })

--- a/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.test.ts
@@ -238,9 +238,9 @@ describe('ProjectScopeService', () => {
       await expect(service.listPendingExternalReadRoots()).resolves.toEqual([
         join(sourceRoot, 'rtl'),
       ])
-      await expect(service.approvePendingExternalReadRoots()).resolves.toEqual([
-        join(sourceRoot, 'rtl'),
-      ])
+      await expect(
+        service.approvePendingExternalReadRoots(root, [join(sourceRoot, 'rtl')]),
+      ).resolves.toEqual([join(sourceRoot, 'rtl')])
       await expect(service.requestProjectPathAccess(sourceFile)).resolves.toBe(sourceFile)
       await expect(service.requestProjectPathAccess(outsideFile)).rejects.toThrow(
         'outside current project scope',
@@ -272,7 +272,7 @@ describe('ProjectScopeService', () => {
     const service = new ProjectScopeService()
     await runWithWindowScope(1, async () => {
       await service.registerProjectRoot(root)
-      await service.approvePendingExternalReadRoots()
+      await service.approvePendingExternalReadRoots(root, [rtlDir])
 
       await expect(service.requestProjectPathAccess(sourceFile)).resolves.toBe(sourceFile)
       await expect(service.requestProjectPathAccess(siblingFile)).rejects.toThrow(
@@ -306,7 +306,7 @@ describe('ProjectScopeService', () => {
     const firstService = new ProjectScopeService({ readGrantProvider })
     await runWithWindowScope(1, async () => {
       await firstService.registerProjectRoot(root)
-      await firstService.approvePendingExternalReadRoots()
+      await firstService.approvePendingExternalReadRoots(root, [sourceRoot])
     })
 
     const reloadedService = new ProjectScopeService({ readGrantProvider })
@@ -315,6 +315,43 @@ describe('ProjectScopeService', () => {
       await expect(reloadedService.listPendingExternalReadRoots()).resolves.toEqual([])
       await expect(reloadedService.requestProjectPathAccess(sourceFile)).resolves.toBe(
         sourceFile,
+      )
+    })
+  })
+
+  it('rejects an approval snapshot after the active project changes', async () => {
+    const rootA = await createTempDir('ecos-project-root-a-')
+    const rootB = await createTempDir('ecos-project-root-b-')
+    const sourceRootA = await createTempDir('ecos-frontend-source-a-')
+    const sourceRootB = await createTempDir('ecos-frontend-source-b-')
+    const sourceFileB = join(sourceRootB, 'cpu.sv')
+    for (const [root, sourceRoot] of [
+      [rootA, sourceRootA],
+      [rootB, sourceRootB],
+    ]) {
+      await mkdir(join(root, 'home'), { recursive: true })
+      await writeFile(join(sourceRoot, 'cpu.sv'), 'module cpu; endmodule')
+      await writeFile(join(sourceRoot, 'filelist.cpu.f'), 'cpu.sv')
+      await writeFile(
+        join(root, 'home', 'parameters.json'),
+        JSON.stringify({
+          'Design Tool': 'frontend',
+          cpu_filelist: join(sourceRoot, 'filelist.cpu.f'),
+        }),
+      )
+    }
+
+    const service = new ProjectScopeService()
+    await runWithWindowScope(1, async () => {
+      await service.registerProjectRoot(rootA)
+      const pendingRootsA = await service.listPendingExternalReadRoots()
+
+      await service.registerProjectRoot(rootB)
+      await expect(
+        service.approvePendingExternalReadRoots(rootA, pendingRootsA),
+      ).rejects.toThrow('no longer matches the active project')
+      await expect(service.requestProjectPathAccess(sourceFileB)).rejects.toThrow(
+        'outside current project root',
       )
     })
   })

--- a/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.ts
@@ -23,6 +23,15 @@ interface ProjectReadScope {
   workspaceRoots: string[]
 }
 
+export interface ProjectReadGrantProvider {
+  get(projectRoot: string): Promise<string[]>
+  set(projectRoot: string, roots: string[]): Promise<void>
+}
+
+export interface ProjectScopeServiceOptions {
+  readGrantProvider?: ProjectReadGrantProvider
+}
+
 async function canonicalizeExistingPath(path: string): Promise<string> {
   return await realpath(path)
 }
@@ -46,6 +55,20 @@ function isNodeErrorWithCode(error: unknown, code: string): boolean {
 
 function pathsEqual(leftPath: string, rightPath: string): boolean {
   return relative(resolve(leftPath), resolve(rightPath)) === ''
+}
+
+function uniquePaths(paths: string[]): string[] {
+  const unique: string[] = []
+  for (const path of paths) {
+    if (!unique.some((candidate) => pathsEqual(candidate, path))) unique.push(path)
+  }
+  return unique
+}
+
+function isSafeExternalReadRoot(path: string, projectRoot: string): boolean {
+  // An external source root must not contain the workspace itself. This rejects
+  // filesystem roots, home directories, and other overly broad ancestors.
+  return !isPathWithinRoot(projectRoot, path)
 }
 
 async function canonicalizePotentialPathWithinRoot(
@@ -184,6 +207,13 @@ export class ProjectScopeService {
   private readonly rootsByWindowId = new Map<number, string>()
   private readonly readScopesByWindowId = new Map<number, ProjectReadScope>()
   private readonly extraRootsByWindowId = new Map<number, string[]>()
+  private readonly pendingExtraRootsByWindowId = new Map<number, string[]>()
+  private readonly approvedExtraRootsByProject = new Map<string, string[]>()
+  private readonly readGrantProvider: ProjectReadGrantProvider | undefined
+
+  constructor(options: ProjectScopeServiceOptions = {}) {
+    this.readGrantProvider = options.readGrantProvider
+  }
 
   async resolveProjectRoot(path: string): Promise<string> {
     return await canonicalizeExistingDirectory(path)
@@ -201,11 +231,51 @@ export class ProjectScopeService {
   async registerProjectRoot(path: string): Promise<string> {
     const windowId = requireWindowScopeId()
     const canonicalPath = await this.resolveProjectRoot(path)
-    const extraRoots = await detectFrontendExtraRoots(canonicalPath)
+    const candidateExtraRoots = (await detectFrontendExtraRoots(canonicalPath)).filter(
+      (root) => isSafeExternalReadRoot(root, canonicalPath),
+    )
+    const persistedRoots = await this.readGrantProvider?.get(canonicalPath)
+    const approvedRoots = uniquePaths([
+      ...(this.approvedExtraRootsByProject.get(canonicalPath) ?? []),
+      ...(persistedRoots ?? []),
+    ]).filter((root) =>
+      candidateExtraRoots.some((candidate) => pathsEqual(candidate, root)),
+    )
+    const pendingRoots = candidateExtraRoots.filter(
+      (candidate) => !approvedRoots.some((root) => pathsEqual(candidate, root)),
+    )
+
     this.rootsByWindowId.set(windowId, canonicalPath)
-    this.extraRootsByWindowId.set(windowId, extraRoots)
+    this.extraRootsByWindowId.set(windowId, approvedRoots)
+    this.pendingExtraRootsByWindowId.set(windowId, pendingRoots)
+    this.approvedExtraRootsByProject.set(canonicalPath, approvedRoots)
     this.readScopesByWindowId.delete(windowId)
     return canonicalPath
+  }
+
+  async listPendingExternalReadRoots(): Promise<string[]> {
+    return [...(this.pendingExtraRootsByWindowId.get(requireWindowScopeId()) ?? [])]
+  }
+
+  async approvePendingExternalReadRoots(): Promise<string[]> {
+    const windowId = requireWindowScopeId()
+    const projectRoot = this.rootsByWindowId.get(windowId)
+    if (!projectRoot) {
+      throw new Error('Project root is not registered')
+    }
+
+    const pendingRoots = this.pendingExtraRootsByWindowId.get(windowId) ?? []
+    if (pendingRoots.length === 0) return []
+
+    const approvedRoots = uniquePaths([
+      ...(this.extraRootsByWindowId.get(windowId) ?? []),
+      ...pendingRoots,
+    ])
+    this.extraRootsByWindowId.set(windowId, approvedRoots)
+    this.pendingExtraRootsByWindowId.set(windowId, [])
+    this.approvedExtraRootsByProject.set(projectRoot, approvedRoots)
+    await this.readGrantProvider?.set(projectRoot, approvedRoots)
+    return [...pendingRoots]
   }
 
   /**
@@ -262,12 +332,14 @@ export class ProjectScopeService {
     const windowId = requireWindowScopeId()
     this.rootsByWindowId.delete(windowId)
     this.extraRootsByWindowId.delete(windowId)
+    this.pendingExtraRootsByWindowId.delete(windowId)
     this.readScopesByWindowId.delete(windowId)
   }
 
   clearWindow(windowId: number): void {
     this.rootsByWindowId.delete(windowId)
     this.extraRootsByWindowId.delete(windowId)
+    this.pendingExtraRootsByWindowId.delete(windowId)
     this.readScopesByWindowId.delete(windowId)
   }
 

--- a/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/projectScopeService.ts
@@ -257,15 +257,29 @@ export class ProjectScopeService {
     return [...(this.pendingExtraRootsByWindowId.get(requireWindowScopeId()) ?? [])]
   }
 
-  async approvePendingExternalReadRoots(): Promise<string[]> {
+  async approvePendingExternalReadRoots(
+    expectedProjectRoot: string,
+    expectedRoots: string[],
+  ): Promise<string[]> {
     const windowId = requireWindowScopeId()
     const projectRoot = this.rootsByWindowId.get(windowId)
     if (!projectRoot) {
       throw new Error('Project root is not registered')
     }
+    if (!pathsEqual(projectRoot, expectedProjectRoot)) {
+      throw new Error('External read approval no longer matches the active project')
+    }
 
     const pendingRoots = this.pendingExtraRootsByWindowId.get(windowId) ?? []
     if (pendingRoots.length === 0) return []
+    if (
+      pendingRoots.length !== expectedRoots.length ||
+      pendingRoots.some(
+        (root) => !expectedRoots.some((expectedRoot) => pathsEqual(root, expectedRoot)),
+      )
+    ) {
+      throw new Error('External read approval no longer matches the pending roots')
+    }
 
     const approvedRoots = uniquePaths([
       ...(this.extraRootsByWindowId.get(windowId) ?? []),

--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceService.ts
@@ -37,9 +37,11 @@ import type {
 } from '@ecos-studio/shared'
 
 export interface ProjectScopeProvider {
+  approvePendingExternalReadRoots?(): Promise<string[]>
   clearProjectRoot(): Promise<void>
   getProjectRoot(): Promise<string>
   isProjectDirectory(path: string): Promise<boolean>
+  listPendingExternalReadRoots?(): Promise<string[]>
   requestProjectPathAccess(path: string): Promise<string>
   requestWritableProjectPathAccess(path: string): Promise<string>
   registerProjectReadRoot(path: string): Promise<string>
@@ -397,6 +399,14 @@ export class WorkspaceService {
 
   async registerProjectRoot(path: string): Promise<string> {
     return await this.projectScopeProvider.registerProjectRoot(path)
+  }
+
+  async listPendingExternalReadRoots(): Promise<string[]> {
+    return (await this.projectScopeProvider.listPendingExternalReadRoots?.()) ?? []
+  }
+
+  async approvePendingExternalReadRoots(): Promise<string[]> {
+    return (await this.projectScopeProvider.approvePendingExternalReadRoots?.()) ?? []
   }
 
   async registerProjectReadRoot(path: string): Promise<string> {

--- a/ecos/gui/apps/desktop-electron/electron/services/workspaceService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/workspaceService.ts
@@ -37,7 +37,10 @@ import type {
 } from '@ecos-studio/shared'
 
 export interface ProjectScopeProvider {
-  approvePendingExternalReadRoots?(): Promise<string[]>
+  approvePendingExternalReadRoots?(
+    expectedProjectRoot: string,
+    expectedRoots: string[],
+  ): Promise<string[]>
   clearProjectRoot(): Promise<void>
   getProjectRoot(): Promise<string>
   isProjectDirectory(path: string): Promise<boolean>
@@ -405,8 +408,16 @@ export class WorkspaceService {
     return (await this.projectScopeProvider.listPendingExternalReadRoots?.()) ?? []
   }
 
-  async approvePendingExternalReadRoots(): Promise<string[]> {
-    return (await this.projectScopeProvider.approvePendingExternalReadRoots?.()) ?? []
+  async approvePendingExternalReadRoots(
+    expectedProjectRoot: string,
+    expectedRoots: string[],
+  ): Promise<string[]> {
+    return (
+      (await this.projectScopeProvider.approvePendingExternalReadRoots?.(
+        expectedProjectRoot,
+        expectedRoots,
+      )) ?? []
+    )
   }
 
   async registerProjectReadRoot(path: string): Promise<string> {


### PR DESCRIPTION
## Context

This is remediation 1 of 6 extracted from the code review follow-up in #182. It addresses the external project read authorization finding from the review of `f5e9af0f536878f804ef51887e5f5ab734388a24`.

## Finding

Registering an ECC-FE workspace could implicitly authorize source locations outside the project root. A workspace could therefore widen renderer read access without an explicit user decision.

## Changes

- Collect external source roots as pending instead of granting them automatically.
- Show a native main-process warning dialog listing the requested locations.
- Keep the roots blocked when the user selects **Not Now**.
- Persist approved roots per canonical project root in a versioned grant store.
- Serialize grant writes and replace the grant file atomically.
- Restore previously approved roots only for the same project.
- Add main-process, project-scope, and grant-store regression tests.

## Security behavior

Project access now fails closed. External frontend sources remain supported, but the active project read scope expands only after explicit native approval.

## Verification

- Cherry-picked independently onto the latest `main`.
- Full `pnpm run check` passed on this single-fix branch.
- Native approval and denial behavior was manually verified in the desktop GUI before submission.

## Review lineage

- Combined review follow-up: #182
- Original remediation commit: `1cca1c2`
- Independent branch commit: `aeb3c50`