### PR TITLE
fix(gui): validate frontend catalog responses

### DIFF
--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.desktop-ipc.test.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.desktop-ipc.test.ts
@@ -20,6 +20,44 @@ function restoreWindow() {
   delete (globalThis as { window?: unknown }).window
 }
 
+function validCatalog() {
+  return {
+    version: 1,
+    defaults: {
+      core_id: 'cpu',
+      soc_harness_id: 'soc',
+      toolchain_id: 'toolchain',
+      test_suite_id: 'tests',
+    },
+    cores: [catalogEntry('cpu')],
+    soc_harnesses: [catalogEntry('soc')],
+    toolchains: [catalogEntry('toolchain')],
+    test_suites: [catalogEntry('tests')],
+    compatibility: [
+      {
+        core_id: 'cpu',
+        soc_harness_id: 'soc',
+        can_create_workspace: true,
+        support_level: 'supported',
+        status: 'ready',
+        summary: 'Ready',
+        supported_test_suites: ['tests'],
+        issues: [],
+        requires_cpu_filelist: false,
+      },
+    ],
+  }
+}
+
+function catalogEntry(id: string) {
+  return {
+    id,
+    name: id,
+    description: `${id} description`,
+    status: 'stable',
+  }
+}
+
 describe('frontend catalog desktop bridge', () => {
   afterEach(() => {
     restoreWindow()
@@ -70,5 +108,78 @@ describe('frontend catalog desktop bridge', () => {
       test_suite_id: 'cpu-tests',
       toolchain_id: 'riscv32-unknown-elf',
     })
+  })
+
+  it('accepts the supported frontend catalog schema from the desktop runtime', async () => {
+    const catalog = vi.fn(async () => ({
+      ...validCatalog(),
+      message: ['frontend catalog list loaded'],
+      response: 'success',
+    }))
+    setWindow({ ecosDesktop: { runtime: { frontend: { catalog } } } })
+
+    const { listFrontendCatalogApi } = await import('./frontendCatalog')
+    await expect(listFrontendCatalogApi()).resolves.toMatchObject({
+      data: {
+        version: 1,
+        defaults: { core_id: 'cpu' },
+        cores: [{ id: 'cpu' }],
+      },
+      message: ['frontend catalog list loaded'],
+      response: 'success',
+    })
+  })
+
+  it('rejects unsupported frontend catalog versions', async () => {
+    setWindow({
+      ecosDesktop: {
+        runtime: {
+          frontend: {
+            catalog: async () => ({ ...validCatalog(), version: 2 }),
+          },
+        },
+      },
+    })
+
+    const { listFrontendCatalogApi } = await import('./frontendCatalog')
+    await expect(listFrontendCatalogApi()).rejects.toThrow(
+      'Invalid frontend catalog: unsupported version 2; expected 1.',
+    )
+  })
+
+  it.each([
+    {
+      label: 'a malformed catalog collection',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        const malformed = catalog as unknown as { cores: unknown }
+        malformed.cores = { id: 'cpu' }
+      },
+      message: 'Invalid frontend catalog: cores must be an array.',
+    },
+    {
+      label: 'an unknown default resource id',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        catalog.defaults.core_id = 'missing'
+      },
+      message:
+        'Invalid frontend catalog: defaults.core_id references unknown id missing.',
+    },
+    {
+      label: 'an invalid compatibility reference',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        catalog.compatibility[0].supported_test_suites = ['missing']
+      },
+      message:
+        'Invalid frontend catalog: compatibility[0].supported_test_suites references unknown id missing.',
+    },
+  ])('rejects $label', async ({ mutate, message }) => {
+    const payload = validCatalog()
+    mutate(payload)
+    setWindow({
+      ecosDesktop: { runtime: { frontend: { catalog: async () => payload } } },
+    })
+
+    const { listFrontendCatalogApi } = await import('./frontendCatalog')
+    await expect(listFrontendCatalogApi()).rejects.toThrow(message)
   })
 })

--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.desktop-ipc.test.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.desktop-ipc.test.ts
@@ -130,6 +130,29 @@ describe('frontend catalog desktop bridge', () => {
     })
   })
 
+  it('defaults a missing response status to success for older runtimes', async () => {
+    const catalog = vi.fn(async () => validCatalog())
+    setWindow({ ecosDesktop: { runtime: { frontend: { catalog } } } })
+
+    const { listFrontendCatalogApi } = await import('./frontendCatalog')
+    await expect(listFrontendCatalogApi()).resolves.toMatchObject({
+      response: 'success',
+    })
+  })
+
+  it('fails closed for an unknown non-null response status', async () => {
+    const catalog = vi.fn(async () => ({
+      ...validCatalog(),
+      response: 'cancelled',
+    }))
+    setWindow({ ecosDesktop: { runtime: { frontend: { catalog } } } })
+
+    const { listFrontendCatalogApi } = await import('./frontendCatalog')
+    await expect(listFrontendCatalogApi()).resolves.toMatchObject({
+      response: 'failed',
+    })
+  })
+
   it('rejects unsupported frontend catalog versions', async () => {
     setWindow({
       ecosDesktop: {

--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.desktop-ipc.test.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.desktop-ipc.test.ts
@@ -29,8 +29,14 @@ function validCatalog() {
       toolchain_id: 'toolchain',
       test_suite_id: 'tests',
     },
-    cores: [catalogEntry('cpu')],
-    soc_harnesses: [catalogEntry('soc')],
+    cores: [
+      {
+        ...catalogEntry('cpu'),
+        cpu_filelist: '/rtl/cpu.f',
+        requires_filelist: false,
+      },
+    ],
+    soc_harnesses: [{ ...catalogEntry('soc'), variant: 'soc1' }],
     toolchains: [catalogEntry('toolchain')],
     test_suites: [catalogEntry('tests')],
     compatibility: [
@@ -123,7 +129,8 @@ describe('frontend catalog desktop bridge', () => {
       data: {
         version: 1,
         defaults: { core_id: 'cpu' },
-        cores: [{ id: 'cpu' }],
+        cores: [{ id: 'cpu', cpu_filelist: '/rtl/cpu.f', requires_filelist: false }],
+        soc_harnesses: [{ id: 'soc', variant: 'soc1' }],
       },
       message: ['frontend catalog list loaded'],
       response: 'success',
@@ -194,6 +201,46 @@ describe('frontend catalog desktop bridge', () => {
       },
       message:
         'Invalid frontend catalog: compatibility[0].supported_test_suites references unknown id missing.',
+    },
+    {
+      label: 'a malformed SoC variant',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        const malformed = catalog.soc_harnesses[0] as unknown as { variant: unknown }
+        malformed.variant = { unexpected: true }
+      },
+      message: 'Invalid frontend catalog: soc_harnesses[0].variant must be a string.',
+    },
+    {
+      label: 'a malformed CPU filelist requirement',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        const malformed = catalog.cores[0] as unknown as { requires_filelist: unknown }
+        malformed.requires_filelist = 'false'
+      },
+      message: 'Invalid frontend catalog: cores[0].requires_filelist must be a boolean.',
+    },
+    {
+      label: 'a blank compatibility test suite id',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        catalog.compatibility[0].supported_test_suites = ['tests', '  ']
+      },
+      message:
+        'Invalid frontend catalog: compatibility[0].supported_test_suites[1] must not be empty.',
+    },
+    {
+      label: 'a duplicate compatibility test suite id',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        catalog.compatibility[0].supported_test_suites = ['tests', ' tests ']
+      },
+      message:
+        'Invalid frontend catalog: compatibility[0].supported_test_suites[1] duplicates tests.',
+    },
+    {
+      label: 'a creatable compatibility pair without test suites',
+      mutate: (catalog: ReturnType<typeof validCatalog>) => {
+        catalog.compatibility[0].supported_test_suites = []
+      },
+      message:
+        'Invalid frontend catalog: compatibility[0].supported_test_suites must not be empty when can_create_workspace is true.',
     },
   ])('rejects $label', async ({ mutate, message }) => {
     const payload = validCatalog()

--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
@@ -117,15 +117,85 @@ export interface FrontendValidationResult {
   issues: FrontendValidationIssue[]
 }
 
-export function listFrontendCatalogApi() {
-  return getDesktopApi()
-    .runtime.frontend.catalog()
-    .then((data) => ({
-      cmd: CMDEnum.catalog_list,
-      data: data as unknown as FrontendCatalogPayload,
-      message: Array.isArray(data.message) ? (data.message as string[]) : [],
-      response: String(data.response ?? ResponseEnum.success),
-    })) as Promise<ResponseData<FrontendCatalogPayload>>
+const FRONTEND_CATALOG_VERSION = 1
+const CATALOG_ENTRY_ARRAYS = [
+  'cores',
+  'soc_harnesses',
+  'toolchains',
+  'test_suites',
+] as const
+const CATALOG_ENTRY_OPTIONAL_STRINGS = [
+  'integration_level',
+  'required_cpu_top_module',
+  'cpu_reset_vector',
+  'sim_program_link_base',
+  'default_program_link_base',
+  'bootloader_payload_link_base',
+] as const
+const COMPATIBILITY_SUPPORT_LEVELS = new Set(['supported', 'experimental', 'unsupported'])
+const CPU_PORT_DIRECTIONS = new Set(['input', 'output', 'inout'])
+
+export function parseFrontendCatalogPayload(value: unknown): FrontendCatalogPayload {
+  const record = catalogRecord(value, 'catalog')
+  if (record.version !== FRONTEND_CATALOG_VERSION) {
+    throw invalidCatalog(
+      `unsupported version ${String(record.version)}; expected ${FRONTEND_CATALOG_VERSION}`,
+    )
+  }
+
+  const defaultsRecord = catalogRecord(record.defaults, 'defaults')
+  const defaults = {
+    core_id: catalogText(defaultsRecord, 'core_id', 'defaults'),
+    soc_harness_id: catalogText(defaultsRecord, 'soc_harness_id', 'defaults'),
+    toolchain_id: catalogText(defaultsRecord, 'toolchain_id', 'defaults'),
+    test_suite_id: catalogText(defaultsRecord, 'test_suite_id', 'defaults'),
+  }
+  const collections = Object.fromEntries(
+    CATALOG_ENTRY_ARRAYS.map((key) => [key, parseCatalogEntries(record[key], key)]),
+  ) as Record<(typeof CATALOG_ENTRY_ARRAYS)[number], FrontendCatalogEntry[]>
+
+  const ids = {
+    cores: catalogIds(collections.cores, 'cores'),
+    soc_harnesses: catalogIds(collections.soc_harnesses, 'soc_harnesses'),
+    toolchains: catalogIds(collections.toolchains, 'toolchains'),
+    test_suites: catalogIds(collections.test_suites, 'test_suites'),
+  }
+  requireCatalogReference(ids.cores, defaults.core_id, 'defaults.core_id')
+  requireCatalogReference(
+    ids.soc_harnesses,
+    defaults.soc_harness_id,
+    'defaults.soc_harness_id',
+  )
+  requireCatalogReference(ids.toolchains, defaults.toolchain_id, 'defaults.toolchain_id')
+  requireCatalogReference(
+    ids.test_suites,
+    defaults.test_suite_id,
+    'defaults.test_suite_id',
+  )
+
+  const compatibility =
+    record.compatibility === undefined
+      ? undefined
+      : parseCompatibilityEntries(record.compatibility, ids)
+
+  return {
+    version: FRONTEND_CATALOG_VERSION,
+    defaults,
+    ...collections,
+    ...(compatibility ? { compatibility } : {}),
+  }
+}
+
+export async function listFrontendCatalogApi(): Promise<
+  ResponseData<FrontendCatalogPayload>
+> {
+  const data = await getDesktopApi().runtime.frontend.catalog()
+  return {
+    cmd: CMDEnum.catalog_list,
+    data: parseFrontendCatalogPayload(data),
+    message: responseMessages(data.message),
+    response: responseStatus(data.response),
+  }
 }
 
 export function validateFrontendConfigApi(config: FrontendValidationRequest) {
@@ -137,4 +207,217 @@ export function validateFrontendConfigApi(config: FrontendValidationRequest) {
       message: Array.isArray(data.message) ? (data.message as string[]) : [],
       response: String(data.response ?? ResponseEnum.success),
     })) as Promise<ResponseData<FrontendValidationResult>>
+}
+
+function parseCatalogEntries(value: unknown, path: string): FrontendCatalogEntry[] {
+  if (!Array.isArray(value)) throw invalidCatalog(`${path} must be an array`)
+  return value.map((item, index) => parseCatalogEntry(item, `${path}[${index}]`))
+}
+
+function parseCatalogEntry(value: unknown, path: string): FrontendCatalogEntry {
+  const record = catalogRecord(value, path)
+  const entry: FrontendCatalogEntry = {
+    ...record,
+    id: catalogText(record, 'id', path),
+    name: catalogText(record, 'name', path),
+    description: catalogString(record, 'description', path),
+    status: catalogText(record, 'status', path),
+  }
+
+  for (const key of CATALOG_ENTRY_OPTIONAL_STRINGS) {
+    const field = optionalCatalogString(record, key, path)
+    if (field !== undefined) entry[key] = field
+  }
+  const isa = optionalCatalogStringArray(record, 'isa', path)
+  if (isa) entry.isa = isa
+  const tags = optionalCatalogStringArray(record, 'tags', path)
+  if (tags) entry.tags = tags
+  const ports = optionalCpuPortContract(record.required_cpu_top_port_contract, path)
+  if (ports) entry.required_cpu_top_port_contract = ports
+  return entry
+}
+
+function optionalCpuPortContract(
+  value: unknown,
+  path: string,
+): FrontendCpuPortContract[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    throw invalidCatalog(`${path}.required_cpu_top_port_contract must be an array`)
+  }
+
+  const names = new Set<string>()
+  return value.map((item, index) => {
+    const portPath = `${path}.required_cpu_top_port_contract[${index}]`
+    const record = catalogRecord(item, portPath)
+    const name = catalogText(record, 'name', portPath)
+    const direction = catalogText(record, 'direction', portPath)
+    if (!CPU_PORT_DIRECTIONS.has(direction)) {
+      throw invalidCatalog(`${portPath}.direction is invalid`)
+    }
+    if (!Number.isSafeInteger(record.width) || Number(record.width) < 1) {
+      throw invalidCatalog(`${portPath}.width must be a positive integer`)
+    }
+    if (names.has(name)) throw invalidCatalog(`${portPath}.name duplicates ${name}`)
+    names.add(name)
+    return {
+      name,
+      direction: direction as FrontendCpuPortContract['direction'],
+      width: Number(record.width),
+    }
+  })
+}
+
+function catalogIds(entries: FrontendCatalogEntry[], path: string): Set<string> {
+  const ids = new Set<string>()
+  for (const entry of entries) {
+    if (ids.has(entry.id))
+      throw invalidCatalog(`${path} contains duplicate id ${entry.id}`)
+    ids.add(entry.id)
+  }
+  return ids
+}
+
+function parseCompatibilityEntries(
+  value: unknown,
+  ids: Record<(typeof CATALOG_ENTRY_ARRAYS)[number], Set<string>>,
+): FrontendCompatibilityEntry[] {
+  if (!Array.isArray(value)) throw invalidCatalog('compatibility must be an array')
+  const pairs = new Set<string>()
+  return value.map((item, index) => {
+    const path = `compatibility[${index}]`
+    const record = catalogRecord(item, path)
+    const coreId = catalogText(record, 'core_id', path)
+    const socHarnessId = catalogText(record, 'soc_harness_id', path)
+    requireCatalogReference(ids.cores, coreId, `${path}.core_id`)
+    requireCatalogReference(ids.soc_harnesses, socHarnessId, `${path}.soc_harness_id`)
+    const pair = `${coreId}\0${socHarnessId}`
+    if (pairs.has(pair))
+      throw invalidCatalog(`${path} duplicates ${coreId}/${socHarnessId}`)
+    pairs.add(pair)
+
+    const supportLevel = catalogText(record, 'support_level', path)
+    if (!COMPATIBILITY_SUPPORT_LEVELS.has(supportLevel)) {
+      throw invalidCatalog(`${path}.support_level is invalid`)
+    }
+    const supportedTestSuites = catalogStringArray(record, 'supported_test_suites', path)
+    for (const testSuiteId of supportedTestSuites) {
+      requireCatalogReference(
+        ids.test_suites,
+        testSuiteId,
+        `${path}.supported_test_suites`,
+      )
+    }
+    if (!Array.isArray(record.issues))
+      throw invalidCatalog(`${path}.issues must be an array`)
+    const issues = record.issues.map((issue, issueIndex) => {
+      const issuePath = `${path}.issues[${issueIndex}]`
+      const issueRecord = catalogRecord(issue, issuePath)
+      return {
+        code: catalogText(issueRecord, 'code', issuePath),
+        message: catalogText(issueRecord, 'message', issuePath),
+      }
+    })
+
+    return {
+      core_id: coreId,
+      soc_harness_id: socHarnessId,
+      can_create_workspace: catalogBoolean(record, 'can_create_workspace', path),
+      support_level: supportLevel as FrontendCompatibilityEntry['support_level'],
+      status: catalogText(record, 'status', path),
+      summary: catalogText(record, 'summary', path),
+      supported_test_suites: supportedTestSuites,
+      issues,
+      requires_cpu_filelist: catalogBoolean(record, 'requires_cpu_filelist', path),
+    }
+  })
+}
+
+function requireCatalogReference(ids: Set<string>, id: string, path: string): void {
+  if (!ids.has(id)) throw invalidCatalog(`${path} references unknown id ${id}`)
+}
+
+function catalogRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw invalidCatalog(`${path} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function catalogString(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string {
+  if (typeof record[key] !== 'string') {
+    throw invalidCatalog(`${path}.${key} must be a string`)
+  }
+  return record[key]
+}
+
+function catalogText(record: Record<string, unknown>, key: string, path: string): string {
+  const value = catalogString(record, key, path).trim()
+  if (!value) throw invalidCatalog(`${path}.${key} must not be empty`)
+  return value
+}
+
+function optionalCatalogString(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | undefined {
+  return record[key] === undefined ? undefined : catalogString(record, key, path)
+}
+
+function catalogStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] {
+  const value = record[key]
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw invalidCatalog(`${path}.${key} must be an array of strings`)
+  }
+  return value.map((item) => item.trim()).filter(Boolean)
+}
+
+function optionalCatalogStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] | undefined {
+  return record[key] === undefined ? undefined : catalogStringArray(record, key, path)
+}
+
+function catalogBoolean(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): boolean {
+  if (typeof record[key] !== 'boolean') {
+    throw invalidCatalog(`${path}.${key} must be a boolean`)
+  }
+  return record[key]
+}
+
+function responseMessages(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((message): message is string => typeof message === 'string')
+    : []
+}
+
+function responseStatus(value: unknown): ResponseEnum {
+  switch (value) {
+    case ResponseEnum.error:
+    case ResponseEnum.failed:
+    case ResponseEnum.success:
+    case ResponseEnum.warning:
+      return value
+    default:
+      return ResponseEnum.success
+  }
+}
+
+function invalidCatalog(detail: string): Error {
+  return new Error(`Invalid frontend catalog: ${detail}.`)
 }

--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
@@ -204,8 +204,8 @@ export function validateFrontendConfigApi(config: FrontendValidationRequest) {
     .then((data) => ({
       cmd: CMDEnum.validate_frontend_config,
       data: data as unknown as FrontendValidationResult,
-      message: Array.isArray(data.message) ? (data.message as string[]) : [],
-      response: String(data.response ?? ResponseEnum.success),
+      message: responseMessages(data.message),
+      response: responseStatus(data.response),
     })) as Promise<ResponseData<FrontendValidationResult>>
 }
 
@@ -407,6 +407,7 @@ function responseMessages(value: unknown): string[] {
 }
 
 function responseStatus(value: unknown): ResponseEnum {
+  if (value === null || value === undefined) return ResponseEnum.success
   switch (value) {
     case ResponseEnum.error:
     case ResponseEnum.failed:
@@ -414,7 +415,7 @@ function responseStatus(value: unknown): ResponseEnum {
     case ResponseEnum.warning:
       return value
     default:
-      return ResponseEnum.success
+      return ResponseEnum.failed
   }
 }
 

--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
@@ -16,13 +16,18 @@ export interface FrontendCatalogEntry {
   integration_level?: string
   isa?: string[]
   tags?: string[]
+  variant?: string
+  cpu_filelist?: string
+  requires_filelist?: boolean
+  top_module?: string
+  cpu_wrapper_top?: string
+  supports_difftest?: boolean
   required_cpu_top_module?: string
   required_cpu_top_port_contract?: FrontendCpuPortContract[]
   cpu_reset_vector?: string
   sim_program_link_base?: string
   default_program_link_base?: string
   bootloader_payload_link_base?: string
-  [key: string]: unknown
 }
 
 export interface FrontendCatalogPayload {
@@ -126,11 +131,19 @@ const CATALOG_ENTRY_ARRAYS = [
 ] as const
 const CATALOG_ENTRY_OPTIONAL_STRINGS = [
   'integration_level',
+  'variant',
+  'cpu_filelist',
+  'top_module',
+  'cpu_wrapper_top',
   'required_cpu_top_module',
   'cpu_reset_vector',
   'sim_program_link_base',
   'default_program_link_base',
   'bootloader_payload_link_base',
+] as const
+const CATALOG_ENTRY_OPTIONAL_BOOLEANS = [
+  'requires_filelist',
+  'supports_difftest',
 ] as const
 const COMPATIBILITY_SUPPORT_LEVELS = new Set(['supported', 'experimental', 'unsupported'])
 const CPU_PORT_DIRECTIONS = new Set(['input', 'output', 'inout'])
@@ -217,7 +230,6 @@ function parseCatalogEntries(value: unknown, path: string): FrontendCatalogEntry
 function parseCatalogEntry(value: unknown, path: string): FrontendCatalogEntry {
   const record = catalogRecord(value, path)
   const entry: FrontendCatalogEntry = {
-    ...record,
     id: catalogText(record, 'id', path),
     name: catalogText(record, 'name', path),
     description: catalogString(record, 'description', path),
@@ -226,6 +238,10 @@ function parseCatalogEntry(value: unknown, path: string): FrontendCatalogEntry {
 
   for (const key of CATALOG_ENTRY_OPTIONAL_STRINGS) {
     const field = optionalCatalogString(record, key, path)
+    if (field !== undefined) entry[key] = field
+  }
+  for (const key of CATALOG_ENTRY_OPTIONAL_BOOLEANS) {
+    const field = optionalCatalogBoolean(record, key, path)
     if (field !== undefined) entry[key] = field
   }
   const isa = optionalCatalogStringArray(record, 'isa', path)
@@ -300,7 +316,13 @@ function parseCompatibilityEntries(
     if (!COMPATIBILITY_SUPPORT_LEVELS.has(supportLevel)) {
       throw invalidCatalog(`${path}.support_level is invalid`)
     }
-    const supportedTestSuites = catalogStringArray(record, 'supported_test_suites', path)
+    const canCreateWorkspace = catalogBoolean(record, 'can_create_workspace', path)
+    const supportedTestSuites = catalogReferenceIds(record, 'supported_test_suites', path)
+    if (canCreateWorkspace && supportedTestSuites.length === 0) {
+      throw invalidCatalog(
+        `${path}.supported_test_suites must not be empty when can_create_workspace is true`,
+      )
+    }
     for (const testSuiteId of supportedTestSuites) {
       requireCatalogReference(
         ids.test_suites,
@@ -322,7 +344,7 @@ function parseCompatibilityEntries(
     return {
       core_id: coreId,
       soc_harness_id: socHarnessId,
-      can_create_workspace: catalogBoolean(record, 'can_create_workspace', path),
+      can_create_workspace: canCreateWorkspace,
       support_level: supportLevel as FrontendCompatibilityEntry['support_level'],
       status: catalogText(record, 'status', path),
       summary: catalogText(record, 'summary', path),
@@ -389,6 +411,29 @@ function optionalCatalogStringArray(
   return record[key] === undefined ? undefined : catalogStringArray(record, key, path)
 }
 
+function catalogReferenceIds(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] {
+  const value = record[key]
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw invalidCatalog(`${path}.${key} must be an array of strings`)
+  }
+
+  const ids: string[] = []
+  const seen = new Set<string>()
+  for (const [index, item] of value.entries()) {
+    const id = item.trim()
+    const itemPath = `${path}.${key}[${index}]`
+    if (!id) throw invalidCatalog(`${itemPath} must not be empty`)
+    if (seen.has(id)) throw invalidCatalog(`${itemPath} duplicates ${id}`)
+    seen.add(id)
+    ids.push(id)
+  }
+  return ids
+}
+
 function catalogBoolean(
   record: Record<string, unknown>,
   key: string,
@@ -398,6 +443,14 @@ function catalogBoolean(
     throw invalidCatalog(`${path}.${key} must be a boolean`)
   }
   return record[key]
+}
+
+function optionalCatalogBoolean(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): boolean | undefined {
+  return record[key] === undefined ? undefined : catalogBoolean(record, key, path)
 }
 
 function responseMessages(value: unknown): string[] {

--- a/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
+++ b/ecos/gui/apps/renderer/src/api/frontendCatalog.ts
@@ -407,13 +407,18 @@ function responseMessages(value: unknown): string[] {
 }
 
 function responseStatus(value: unknown): ResponseEnum {
-  if (value === null || value === undefined) return ResponseEnum.success
   switch (value) {
+    case null:
+    case undefined:
+      return ResponseEnum.success
     case ResponseEnum.error:
+      return ResponseEnum.error
     case ResponseEnum.failed:
+      return ResponseEnum.failed
     case ResponseEnum.success:
+      return ResponseEnum.success
     case ResponseEnum.warning:
-      return value
+      return ResponseEnum.warning
     default:
       return ResponseEnum.failed
   }

--- a/ecos/gui/apps/renderer/src/components/FrontendProjectWizard.vue
+++ b/ecos/gui/apps/renderer/src/components/FrontendProjectWizard.vue
@@ -1434,7 +1434,10 @@ function sortedCatalogEntries(entries: FrontendCatalogEntry[]): FrontendCatalogE
   })
 }
 
-function stringField(entry: FrontendCatalogEntry | null, field: string): string {
+function stringField(
+  entry: FrontendCatalogEntry | null,
+  field: keyof FrontendCatalogEntry,
+): string {
   const value = entry?.[field]
   return typeof value === 'string' ? value : ''
 }


### PR DESCRIPTION
## Context

This is remediation 4 of 6 extracted from the code review follow-up in #182. It addresses the unchecked frontend catalog RPC boundary found during review of `f5e9af0f536878f804ef51887e5f5ab734388a24`.

## Finding

The renderer accepted the frontend catalog response through a direct TypeScript cast. Malformed or internally inconsistent registry data could therefore reach project setup as if it were valid.

## Changes

- Add runtime parsing for frontend catalog schema version 1.
- Validate required collections, identifiers, fields, and optional value types.
- Reject duplicate IDs and duplicate compatibility pairs.
- Verify that default and compatibility references resolve to declared catalog entries.
- Validate CPU port contracts, including direction, width, and unique port names.
- Normalize response status and message fields before exposing catalog data to the UI.
- Add focused parser coverage for valid and invalid catalog responses.

## Result

Frontend project setup now consumes only catalog data that satisfies the declared contract. Invalid registry responses fail at the RPC boundary with actionable validation errors instead of corrupting later UI state.

## Verification

- Cherry-picked independently onto the latest `main`.
- Complete `pnpm run check` passed on this single-fix branch.
- Catalog-backed frontend setup behavior was manually verified before submission.

## Review lineage

- Combined review follow-up: #182
- Original remediation commit: `dfbfcc7`
- Independent branch commit: `16458a2`