### PR TITLE
feat: add the ability to export design summary 

### DIFF
--- a/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
+++ b/ecos/gui/apps/desktop-electron/electron/main/registerIpc.ts
@@ -7,7 +7,7 @@ import {
   type IpcMainInvokeEvent,
 } from 'electron'
 import { randomUUID } from 'node:crypto'
-import { mkdir, stat } from 'node:fs/promises'
+import { mkdir, stat, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import {
   desktopApiEventChannels,
@@ -534,14 +534,20 @@ async function saveFile(
   event: IpcMainInvokeEvent,
   options?: DesktopSaveFileDialogOptions,
 ): Promise<string | null> {
-  const { ensureDirectory, ...dialogOptions } = options ?? {}
+  const { ensureDirectory, content, ...dialogOptions } = options ?? {}
   if (ensureDirectory && dialogOptions.defaultPath) {
     await mkdir(dirname(dialogOptions.defaultPath), { recursive: true })
   }
 
   const result = await dialog.showSaveDialog(getEventWindow(event), dialogOptions)
+  if (result.canceled || !result.filePath) return null
 
-  return result.canceled ? null : (result.filePath ?? null)
+  if (typeof content === 'string') {
+    await mkdir(dirname(result.filePath), { recursive: true })
+    await writeFile(result.filePath, content, 'utf8')
+  }
+
+  return result.filePath
 }
 
 async function classifyLocalPaths(paths: string[]): Promise<PickedRtlSources> {

--- a/ecos/gui/apps/desktop-electron/electron/services/eccRpc/workspaceRuntimeCommands.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/eccRpc/workspaceRuntimeCommands.ts
@@ -193,7 +193,11 @@ export class WorkspaceRuntimeCommands {
     return this.workspaceCall(
       'workspace.export_signoff',
       request,
-      (workspaceId) => ({ outputPath: request.outputPath, workspaceId }),
+      (workspaceId) => ({
+        additionalFiles: request.additionalFiles,
+        outputPath: request.outputPath,
+        workspaceId,
+      }),
       { timeoutMs: 0 },
     )
   }

--- a/ecos/gui/apps/desktop-electron/electron/services/menuService.test.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/menuService.test.ts
@@ -81,6 +81,9 @@ describe('menuService', () => {
     const exportSignoffPackage = fileMenu?.submenu?.find(
       (item) => item.label === 'Export Signoff Package...',
     )
+    const exportDesignSummary = fileMenu?.submenu?.find(
+      (item) => item.label === 'Export Design Summary...',
+    )
     const documentation = helpMenu?.submenu?.find(
       (item) => item.label === 'Documentation',
     )
@@ -102,6 +105,10 @@ describe('menuService', () => {
     expect(exportSignoffPackage).toMatchObject({
       enabled: false,
       id: desktopMenuEventIds.exportSignoffPackage,
+    })
+    expect(exportDesignSummary).toMatchObject({
+      enabled: false,
+      id: desktopMenuEventIds.exportDesignSummary,
     })
     const designMenu = capturedTemplate.find((item) => item.label === 'Design')
     const manageRtl = designMenu?.submenu?.find(
@@ -126,6 +133,7 @@ describe('menuService', () => {
     newWorkspace?.click?.()
     reconfigureWorkspace?.click?.()
     exportSignoffPackage?.click?.()
+    exportDesignSummary?.click?.()
     documentation?.click?.()
     about?.click?.()
 
@@ -148,10 +156,15 @@ describe('menuService', () => {
     expect(send).toHaveBeenNthCalledWith(
       4,
       desktopApiEventChannels.menuAction,
-      desktopMenuEventIds.documentation,
+      desktopMenuEventIds.exportDesignSummary,
     )
     expect(send).toHaveBeenNthCalledWith(
       5,
+      desktopApiEventChannels.menuAction,
+      desktopMenuEventIds.documentation,
+    )
+    expect(send).toHaveBeenNthCalledWith(
+      6,
       desktopApiEventChannels.menuAction,
       desktopMenuEventIds.about,
     )

--- a/ecos/gui/apps/desktop-electron/electron/services/menuService.ts
+++ b/ecos/gui/apps/desktop-electron/electron/services/menuService.ts
@@ -22,6 +22,7 @@ export const workspaceDependentMenuActions: DesktopMenuEventId[] = [
   appMenuActionIds.reconfigureWorkspace,
   appMenuActionIds.manageDesignFiles,
   appMenuActionIds.exportSignoffPackage,
+  appMenuActionIds.exportDesignSummary,
 ]
 
 const menuStateByWindowId = new Map<number, Map<DesktopMenuEventId, boolean>>()
@@ -157,6 +158,12 @@ export function registerApplicationMenu(options: ApplicationMenuOptions = {}): v
         createMenuAction(
           'Export Signoff Package...',
           appMenuActionIds.exportSignoffPackage,
+          undefined,
+          false,
+        ),
+        createMenuAction(
+          'Export Design Summary...',
+          appMenuActionIds.exportDesignSummary,
           undefined,
           false,
         ),

--- a/ecos/gui/apps/renderer/src/App.design-report-export.test.ts
+++ b/ecos/gui/apps/renderer/src/App.design-report-export.test.ts
@@ -7,7 +7,9 @@ describe('App design report export wiring', () => {
     expect(appSource).toContain('DesignReportExportDialog')
     expect(appSource).toContain('openDesignReportExport')
     expect(appSource).toContain('exportDesignSummary: openDesignReportExport')
-    expect(appSource).toContain(':design-report-export-enabled="designReportExportEnabled"')
+    expect(appSource).toContain(
+      ':design-report-export-enabled="designReportExportEnabled"',
+    )
   })
 
   it('mounts DesignReportExportDialog with full handlers and bindings', () => {

--- a/ecos/gui/apps/renderer/src/App.design-report-export.test.ts
+++ b/ecos/gui/apps/renderer/src/App.design-report-export.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import appSource from './App.vue?raw'
+
+describe('App design report export wiring', () => {
+  it('wires useDesignReportExport composable and menu action in App.vue', () => {
+    expect(appSource).toContain('useDesignReportExport')
+    expect(appSource).toContain('DesignReportExportDialog')
+    expect(appSource).toContain('openDesignReportExport')
+    expect(appSource).toContain('exportDesignSummary: openDesignReportExport')
+    expect(appSource).toContain(':design-report-export-enabled="designReportExportEnabled"')
+  })
+
+  it('mounts DesignReportExportDialog with full handlers and bindings', () => {
+    expect(appSource).toContain('<DesignReportExportDialog')
+    expect(appSource).toContain(':content="generatedDesignReportContent"')
+    expect(appSource).toContain(':error="designReportError"')
+    expect(appSource).toContain(':loading="designReportLoading"')
+    expect(appSource).toContain(':options="designReportExportOptions"')
+    expect(appSource).toContain(':report-data="designReportData"')
+    expect(appSource).toContain(':selected-format="selectedDesignReportFormat"')
+    expect(appSource).toContain(':visible="showDesignReportDialog"')
+    expect(appSource).toContain('@close="closeDesignReportExport"')
+    expect(appSource).toContain('@copy="copyDesignReport"')
+    expect(appSource).toContain('@refresh="refreshDesignReportData"')
+    expect(appSource).toContain('@save-all="exportAllDesignReportFormats"')
+    expect(appSource).toContain('@save-current="saveDesignReport"')
+  })
+
+  it('mounts SignoffPackageReviewDialog with export and refresh handlers', () => {
+    expect(appSource).toContain('<SignoffPackageReviewDialog')
+    expect(appSource).toContain('@export="confirmSignoffPackageExport"')
+    expect(appSource).toContain('@refresh="refreshSignoffPackageReview"')
+  })
+})

--- a/ecos/gui/apps/renderer/src/App.vue
+++ b/ecos/gui/apps/renderer/src/App.vue
@@ -7,6 +7,7 @@
         :project-name="isWelcome ? null : currentProject?.name"
         :has-workspace="Boolean(currentProject?.path)"
         :signoff-package-export-enabled="signoffPackageExportEnabled"
+        :design-report-export-enabled="designReportExportEnabled"
         @menu-action="handleMenuAction"
         @step-config="showStepConfigDialog = true"
       />
@@ -109,6 +110,23 @@
       @refresh="refreshSignoffPackageReview"
     />
 
+    <DesignReportExportDialog
+      :content="generatedDesignReportContent"
+      :error="designReportError"
+      :loading="designReportLoading"
+      :options="designReportExportOptions"
+      :report-data="designReportData"
+      :selected-format="selectedDesignReportFormat"
+      :visible="showDesignReportDialog"
+      @close="closeDesignReportExport"
+      @copy="copyDesignReport"
+      @refresh="refreshDesignReportData"
+      @save-all="exportAllDesignReportFormats"
+      @save-current="saveDesignReport"
+      @update:options="Object.assign(designReportExportOptions, $event)"
+      @update:selected-format="selectedDesignReportFormat = $event"
+    />
+
     <DesignFilesManageDialog v-model="showManageDialog" />
 
     <Dialog
@@ -163,6 +181,7 @@ import { useAgentShellStore } from '@/stores/agentShellStore'
 import { useAppMenuActions } from '@/composables/useAppMenuActions'
 import { useAppWindowClose } from '@/composables/useAppWindowClose'
 import { useSignoffPackageExport } from '@/composables/useSignoffPackageExport'
+import { useDesignReportExport } from '@/composables/useDesignReportExport'
 import { useWorkspace } from '@/composables/useWorkspace'
 import { usePdkManager } from '@/composables/usePdkManager'
 import { useVersion } from '@/composables/useVersion'
@@ -178,6 +197,7 @@ import StatusBar from '@/components/StatusBar.vue'
 import ECOSTerminal from '@/components/ECOSTerminal.vue'
 import AboutDialog from '@/components/AboutDialog.vue'
 import SignoffPackageReviewDialog from '@/components/SignoffPackageReviewDialog.vue'
+import DesignReportExportDialog from '@/components/DesignReportExportDialog.vue'
 import Toast from 'primevue/toast'
 import Dialog from 'primevue/dialog'
 import NewProjectWizard from '@/components/NewProjectWizard.vue'
@@ -246,6 +266,25 @@ const {
   showToast,
   workspaceSession,
 })
+const {
+  closeDesignReportExport,
+  copyToClipboard: copyDesignReport,
+  designReportExportEnabled,
+  dialogVisible: showDesignReportDialog,
+  error: designReportError,
+  exportAllFormats: exportAllDesignReportFormats,
+  exportOptions: designReportExportOptions,
+  generatedContent: generatedDesignReportContent,
+  loadWorkspaceReportData: refreshDesignReportData,
+  loading: designReportLoading,
+  openDesignReportExport,
+  reportData: designReportData,
+  saveCurrentReport: saveDesignReport,
+  selectedFormat: selectedDesignReportFormat,
+} = useDesignReportExport({
+  currentProject,
+  showToast,
+})
 const desktopApi = ref<DesktopApi | null>(getOptionalDesktopApi())
 
 watch(
@@ -258,6 +297,7 @@ watch(
         await Promise.all([
           api.menu.setActionEnabled(appMenuActionIds.reconfigureWorkspace, hasWorkspace),
           api.menu.setActionEnabled(appMenuActionIds.manageDesignFiles, hasWorkspace),
+          api.menu.setActionEnabled(appMenuActionIds.exportDesignMetrics, hasWorkspace),
         ])
       } catch (error) {
         console.warn('[App] Failed to sync workspace menu availability:', error)
@@ -966,6 +1006,8 @@ const { handleMenuAction } = useAppMenuActions({
   showNewProjectWizard: showCreateWorkspaceWizard,
   reconfigureWorkspace: openWorkspaceReconfigureWizard,
   exportSignoffPackage,
+  exportDesignSummary: openDesignReportExport,
+  exportDesignMetrics: openDesignReportExport,
   manageDesignFiles: openManageDialog,
   adjustZoom,
 })

--- a/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.test.ts
+++ b/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.test.ts
@@ -2,29 +2,27 @@ import { describe, expect, it } from 'vitest'
 import source from './DesignReportExportDialog.vue?raw'
 
 describe('DesignReportExportDialog', () => {
-  it('renders format tabs for LaTeX, Markdown, CSV, and Plain Text', () => {
+  it('renders format tabs for LaTeX, Markdown, Typst, CSV, and Plain Text', () => {
     expect(source).toContain('header="Export Design Summary"')
-    expect(source).toContain('LaTeX Paper')
-    expect(source).toContain('Markdown Docs')
-    expect(source).toContain('CSV Table')
-    expect(source).toContain('Plain Text Log')
-    expect(source).toContain('.tex')
-    expect(source).toContain('.md')
-    expect(source).toContain('.csv')
-    expect(source).toContain('.txt')
+    expect(source).toContain("label: 'LaTeX'")
+    expect(source).toContain("label: 'Markdown'")
+    expect(source).toContain("label: 'Typst'")
+    expect(source).toContain("label: 'CSV'")
+    expect(source).toContain("label: 'Text'")
   })
 
-  it('renders configuration options for multi-corner, stage breakdown, and standalone LaTeX without provenance or manual verification toggle', () => {
+  it('renders configuration options for multi-corner, stage breakdown, and standalone LaTeX/Typst without provenance or manual verification toggle', () => {
     expect(source).toContain('Multi-Corner Timing')
     expect(source).toContain('Stage Execution Breakdown')
     expect(source).toContain('Standalone Document (IEEEtran)')
+    expect(source).toContain('Standalone Document')
     expect(source).not.toContain('Physical Verification Details')
     expect(source).not.toContain('Provenance Traceability')
   })
 
   it('provides accessible copy, save single format, and batch export actions', () => {
     expect(source).toContain('Copy to Clipboard')
-    expect(source).toContain('Export All Formats (4 Files)')
+    expect(source).toContain('Export All Formats (5 Files)')
     expect(source).toContain('Save .{{ formatExt(selectedFormat) }}')
     expect(source).toContain('@click="emit(\'copy\')"')
     expect(source).toContain('@click="emit(\'saveAll\')"')

--- a/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.test.ts
+++ b/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.test.ts
@@ -8,10 +8,10 @@ describe('DesignReportExportDialog', () => {
     expect(source).toContain('Markdown Docs')
     expect(source).toContain('CSV Table')
     expect(source).toContain('Plain Text Log')
-    expect(source).toContain(".tex")
-    expect(source).toContain(".md")
-    expect(source).toContain(".csv")
-    expect(source).toContain(".txt")
+    expect(source).toContain('.tex')
+    expect(source).toContain('.md')
+    expect(source).toContain('.csv')
+    expect(source).toContain('.txt')
   })
 
   it('renders configuration options for multi-corner, stage breakdown, and standalone LaTeX without provenance or manual verification toggle', () => {

--- a/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.test.ts
+++ b/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import source from './DesignReportExportDialog.vue?raw'
+
+describe('DesignReportExportDialog', () => {
+  it('renders format tabs for LaTeX, Markdown, CSV, and Plain Text', () => {
+    expect(source).toContain('header="Export Design Summary"')
+    expect(source).toContain('LaTeX Paper')
+    expect(source).toContain('Markdown Docs')
+    expect(source).toContain('CSV Table')
+    expect(source).toContain('Plain Text Log')
+    expect(source).toContain(".tex")
+    expect(source).toContain(".md")
+    expect(source).toContain(".csv")
+    expect(source).toContain(".txt")
+  })
+
+  it('renders configuration options for multi-corner, stage breakdown, and standalone LaTeX without provenance or manual verification toggle', () => {
+    expect(source).toContain('Multi-Corner Timing')
+    expect(source).toContain('Stage Execution Breakdown')
+    expect(source).toContain('Standalone Document (IEEEtran)')
+    expect(source).not.toContain('Physical Verification Details')
+    expect(source).not.toContain('Provenance Traceability')
+  })
+
+  it('provides accessible copy, save single format, and batch export actions', () => {
+    expect(source).toContain('Copy to Clipboard')
+    expect(source).toContain('Export All Formats (4 Files)')
+    expect(source).toContain('Save .{{ formatExt(selectedFormat) }}')
+    expect(source).toContain('@click="emit(\'copy\')"')
+    expect(source).toContain('@click="emit(\'saveAll\')"')
+    expect(source).toContain('@click="emit(\'saveCurrent\')"')
+    expect(source).toContain('@click="emit(\'close\')"')
+  })
+
+  it('includes preformatted code preview with line and byte counts', () => {
+    expect(source).toContain('class="preview-code"')
+    expect(source).toContain('preview-lang-tag')
+    expect(source).toContain('preview-size-tag')
+    expect(source).toContain('lineCount')
+    expect(source).toContain('charCount')
+  })
+})

--- a/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.vue
+++ b/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.vue
@@ -1,0 +1,570 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    header="Export Design Summary"
+    :style="{ width: 'min(980px, calc(100vw - 32px))' }"
+    :closable="!loading"
+    :draggable="false"
+    class="design-report-export-dialog"
+    @update:visible="handleVisibilityChange"
+  >
+    <div class="design-report-export-content">
+      <!-- Top format tabs -->
+      <div class="format-tabs-bar">
+        <div class="format-tabs" role="tablist" aria-label="Export Format">
+          <button
+            v-for="fmt in formats"
+            :key="fmt.id"
+            type="button"
+            role="tab"
+            :aria-selected="selectedFormat === fmt.id"
+            class="format-tab-btn"
+            :class="{ active: selectedFormat === fmt.id }"
+            @click="emit('update:selectedFormat', fmt.id)"
+          >
+            <i :class="fmt.icon" aria-hidden="true" />
+            <span class="tab-label">{{ fmt.label }}</span>
+            <span class="tab-badge">{{ fmt.ext }}</span>
+          </button>
+        </div>
+
+        <div class="export-actions-quick">
+          <button
+            type="button"
+            class="quick-action-btn"
+            title="Copy current format to clipboard"
+            :disabled="loading || Boolean(error) || !content"
+            @click="emit('copy')"
+          >
+            <i class="ri-file-copy-line" aria-hidden="true" />
+            <span>Copy</span>
+          </button>
+          <button
+            type="button"
+            class="quick-action-btn"
+            title="Refresh workspace metrics"
+            :disabled="loading"
+            @click="emit('refresh')"
+          >
+            <i class="ri-refresh-line" :class="{ 'animate-spin': loading }" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      <!-- Config options bar -->
+      <div class="options-bar">
+        <label class="option-checkbox">
+          <input
+            type="checkbox"
+            :checked="options.includeMultiCorner"
+            @change="updateOption('includeMultiCorner', ($event.target as HTMLInputElement).checked)"
+          />
+          <span>Multi-Corner Timing</span>
+        </label>
+        <label class="option-checkbox">
+          <input
+            type="checkbox"
+            :checked="options.includeStageBreakdown"
+            @change="updateOption('includeStageBreakdown', ($event.target as HTMLInputElement).checked)"
+          />
+          <span>Stage Execution Breakdown</span>
+        </label>
+
+        <label v-if="selectedFormat === 'latex'" class="option-checkbox">
+          <input
+            type="checkbox"
+            :checked="options.latexStandalone"
+            @change="updateOption('latexStandalone', ($event.target as HTMLInputElement).checked)"
+          />
+          <span>Standalone Document (IEEEtran)</span>
+        </label>
+      </div>
+
+      <!-- Main Preview Area -->
+      <div class="preview-container">
+        <div v-if="loading" class="preview-loading" role="status">
+          <i class="ri-loader-4-line animate-spin" aria-hidden="true" />
+          <span>Extracting design metrics from workspace...</span>
+        </div>
+
+        <div v-else-if="error" class="preview-error" role="alert">
+          <i class="ri-error-warning-line" aria-hidden="true" />
+          <div class="error-details">
+            <strong>Failed to generate design report</strong>
+            <p>{{ error }}</p>
+          </div>
+          <button type="button" class="retry-btn" @click="emit('refresh')">
+            Retry
+          </button>
+        </div>
+
+        <div v-else-if="content" class="preview-code-wrap">
+          <div class="preview-header-info">
+            <span class="preview-lang-tag">{{ formatLabel(selectedFormat) }}</span>
+            <span class="preview-size-tag">{{ lineCount }} lines ({{ charCount }} bytes)</span>
+          </div>
+          <pre class="preview-code" tabindex="0"><code>{{ content }}</code></pre>
+        </div>
+
+        <div v-else class="preview-empty">
+          <i class="ri-file-text-line" aria-hidden="true" />
+          <span>No report data available for the current workspace.</span>
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="design-report-export-footer">
+        <div class="footer-actions">
+          <button
+            type="button"
+            class="dialog-btn dialog-btn-secondary"
+            @click="emit('close')"
+          >
+            Close
+          </button>
+          <button
+            type="button"
+            class="dialog-btn dialog-btn-secondary"
+            :disabled="loading || Boolean(error) || !content"
+            @click="emit('copy')"
+          >
+            <i class="ri-clipboard-line" aria-hidden="true" />
+            Copy to Clipboard
+          </button>
+          <button
+            type="button"
+            class="dialog-btn dialog-btn-secondary"
+            :disabled="loading || Boolean(error) || !content"
+            @click="emit('saveAll')"
+          >
+            <i class="ri-folder-zip-line" aria-hidden="true" />
+            Export All Formats (4 Files)
+          </button>
+          <button
+            type="button"
+            class="dialog-btn dialog-btn-primary"
+            :disabled="loading || Boolean(error) || !content"
+            @click="emit('saveCurrent')"
+          >
+            <i class="ri-download-2-line" aria-hidden="true" />
+            Save .{{ formatExt(selectedFormat) }}
+          </button>
+        </div>
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type {
+  DesignReportData,
+  DesignReportExportOptions,
+  DesignReportFormat,
+} from '@ecos-studio/shared'
+import Dialog from 'primevue/dialog'
+
+const props = defineProps<{
+  content: string
+  error: string
+  loading: boolean
+  options: DesignReportExportOptions
+  reportData: DesignReportData | null
+  selectedFormat: DesignReportFormat
+  visible: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  copy: []
+  refresh: []
+  saveAll: []
+  saveCurrent: []
+  'update:options': [options: DesignReportExportOptions]
+  'update:selectedFormat': [format: DesignReportFormat]
+}>()
+
+const formats: Array<{ id: DesignReportFormat; label: string; ext: string; icon: string }> = [
+  { id: 'latex', label: 'LaTeX Paper', ext: '.tex', icon: 'ri-brackets-line' },
+  { id: 'markdown', label: 'Markdown Docs', ext: '.md', icon: 'ri-markdown-line' },
+  { id: 'csv', label: 'CSV Table', ext: '.csv', icon: 'ri-table-line' },
+  { id: 'text', label: 'Plain Text Log', ext: '.txt', icon: 'ri-file-text-line' },
+]
+
+const lineCount = computed(() => {
+  if (!props.content) return 0
+  return props.content.split('\n').length
+})
+
+const charCount = computed(() => {
+  return props.content ? props.content.length : 0
+})
+
+function formatLabel(format: DesignReportFormat): string {
+  switch (format) {
+    case 'latex':
+      return 'LaTeX (booktabs / siunitx)'
+    case 'markdown':
+      return 'GitHub Flavored Markdown'
+    case 'csv':
+      return 'RFC 4180 CSV Data'
+    case 'text':
+      return 'ASCII Table Log'
+  }
+}
+
+function formatExt(format: DesignReportFormat): string {
+  switch (format) {
+    case 'latex':
+      return 'tex'
+    case 'markdown':
+      return 'md'
+    case 'csv':
+      return 'csv'
+    case 'text':
+      return 'txt'
+  }
+}
+
+function updateOption<K extends keyof DesignReportExportOptions>(
+  key: K,
+  value: DesignReportExportOptions[K],
+): void {
+  emit('update:options', {
+    ...props.options,
+    [key]: value,
+  })
+}
+
+function handleVisibilityChange(nextVisible: boolean): void {
+  if (!nextVisible) emit('close')
+}
+</script>
+
+<style>
+.design-report-export-dialog.p-dialog {
+  background: var(--bg-primary) !important;
+  border: 1px solid var(--border-color) !important;
+  border-radius: 8px !important;
+  color: var(--text-primary) !important;
+}
+
+.design-report-export-dialog .p-dialog-header,
+.design-report-export-dialog .p-dialog-content,
+.design-report-export-dialog .p-dialog-footer {
+  background: transparent;
+  color: var(--text-primary);
+}
+
+.design-report-export-dialog .p-dialog-header {
+  padding: 18px 20px 10px;
+}
+
+.design-report-export-dialog .p-dialog-content {
+  padding: 10px 20px;
+}
+
+.design-report-export-dialog .p-dialog-footer {
+  padding: 12px 20px 18px;
+}
+</style>
+
+<style scoped>
+.design-report-export-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.format-tabs-bar {
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 10px;
+}
+
+.format-tabs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.format-tab-btn {
+  align-items: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 13px;
+  gap: 6px;
+  padding: 6px 12px;
+  transition: all 0.15s ease;
+}
+
+.format-tab-btn:hover {
+  background: color-mix(in srgb, var(--accent-color) 12%, var(--bg-secondary));
+  color: var(--text-primary);
+}
+
+.format-tab-btn.active {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+  color: #ffffff;
+  font-weight: 500;
+}
+
+.tab-badge {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 11px;
+  padding: 1px 5px;
+}
+
+.format-tab-btn.active .tab-badge {
+  background: rgba(255, 255, 255, 0.25);
+  color: #ffffff;
+}
+
+.export-actions-quick {
+  display: flex;
+  gap: 6px;
+}
+
+.quick-action-btn {
+  align-items: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 12px;
+  gap: 5px;
+  padding: 6px 10px;
+}
+
+.quick-action-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-color) 10%, var(--bg-secondary));
+  color: var(--text-primary);
+}
+
+.quick-action-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.options-bar {
+  align-items: center;
+  background: color-mix(in srgb, var(--bg-secondary) 60%, transparent);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 8px 12px;
+}
+
+.option-checkbox {
+  align-items: center;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 12px;
+  gap: 6px;
+  user-select: none;
+}
+
+.option-checkbox:hover {
+  color: var(--text-primary);
+}
+
+.option-checkbox input[type='checkbox'] {
+  accent-color: var(--accent-color);
+  cursor: pointer;
+}
+
+.preview-container {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  min-height: 380px;
+  max-height: min(56vh, 520px);
+  position: relative;
+}
+
+.preview-loading,
+.preview-empty {
+  align-items: center;
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  height: 380px;
+  justify-content: center;
+}
+
+.preview-loading i,
+.preview-empty i {
+  font-size: 28px;
+}
+
+.preview-error {
+  align-items: center;
+  color: var(--danger-color);
+  display: flex;
+  gap: 14px;
+  height: 380px;
+  justify-content: center;
+  padding: 24px;
+}
+
+.preview-error i {
+  font-size: 32px;
+}
+
+.error-details strong {
+  display: block;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.error-details p {
+  color: var(--text-secondary);
+  font-size: 12px;
+  margin: 0;
+}
+
+.retry-btn {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 6px 12px;
+}
+
+.preview-code-wrap {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.preview-header-info {
+  align-items: center;
+  background: color-mix(in srgb, var(--bg-primary) 70%, transparent);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  font-size: 11px;
+  justify-content: space-between;
+  padding: 6px 12px;
+}
+
+.preview-lang-tag {
+  color: var(--accent-color);
+  font-weight: 600;
+}
+
+.preview-size-tag {
+  color: var(--text-secondary);
+  font-family: monospace;
+}
+
+.preview-code {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 0;
+  overflow: auto;
+  padding: 12px 14px;
+  white-space: pre;
+}
+
+.design-report-export-footer {
+  align-items: center;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  padding-top: 12px;
+  width: 100%;
+}
+
+.footer-meta {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.footer-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.dialog-btn {
+  align-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 13px;
+  gap: 6px;
+  min-height: 32px;
+  padding: 0 12px;
+  transition: all 0.15s ease;
+}
+
+.dialog-btn-secondary {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+}
+
+.dialog-btn-secondary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-color) 12%, var(--bg-secondary));
+}
+
+.dialog-btn-primary {
+  background: var(--accent-color);
+  border: 1px solid var(--accent-color);
+  color: #ffffff;
+  font-weight: 500;
+}
+
+.dialog-btn-primary:hover:not(:disabled) {
+  opacity: 0.92;
+}
+
+.dialog-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+@media (max-width: 760px) {
+  .format-tabs-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .options-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .design-report-export-footer {
+    flex-direction: column;
+    gap: 10px;
+    align-items: flex-end;
+  }
+  .footer-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.vue
+++ b/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.vue
@@ -47,7 +47,11 @@
             :disabled="loading"
             @click="emit('refresh')"
           >
-            <i class="ri-refresh-line" :class="{ 'animate-spin': loading }" aria-hidden="true" />
+            <i
+              class="ri-refresh-line"
+              :class="{ 'animate-spin': loading }"
+              aria-hidden="true"
+            />
           </button>
         </div>
       </div>
@@ -58,7 +62,12 @@
           <input
             type="checkbox"
             :checked="options.includeMultiCorner"
-            @change="updateOption('includeMultiCorner', ($event.target as HTMLInputElement).checked)"
+            @change="
+              updateOption(
+                'includeMultiCorner',
+                ($event.target as HTMLInputElement).checked,
+              )
+            "
           />
           <span>Multi-Corner Timing</span>
         </label>
@@ -66,7 +75,12 @@
           <input
             type="checkbox"
             :checked="options.includeStageBreakdown"
-            @change="updateOption('includeStageBreakdown', ($event.target as HTMLInputElement).checked)"
+            @change="
+              updateOption(
+                'includeStageBreakdown',
+                ($event.target as HTMLInputElement).checked,
+              )
+            "
           />
           <span>Stage Execution Breakdown</span>
         </label>
@@ -75,7 +89,9 @@
           <input
             type="checkbox"
             :checked="options.latexStandalone"
-            @change="updateOption('latexStandalone', ($event.target as HTMLInputElement).checked)"
+            @change="
+              updateOption('latexStandalone', ($event.target as HTMLInputElement).checked)
+            "
           />
           <span>Standalone Document (IEEEtran)</span>
         </label>
@@ -94,15 +110,15 @@
             <strong>Failed to generate design report</strong>
             <p>{{ error }}</p>
           </div>
-          <button type="button" class="retry-btn" @click="emit('refresh')">
-            Retry
-          </button>
+          <button type="button" class="retry-btn" @click="emit('refresh')">Retry</button>
         </div>
 
         <div v-else-if="content" class="preview-code-wrap">
           <div class="preview-header-info">
             <span class="preview-lang-tag">{{ formatLabel(selectedFormat) }}</span>
-            <span class="preview-size-tag">{{ lineCount }} lines ({{ charCount }} bytes)</span>
+            <span class="preview-size-tag"
+              >{{ lineCount }} lines ({{ charCount }} bytes)</span
+            >
           </div>
           <pre class="preview-code" tabindex="0"><code>{{ content }}</code></pre>
         </div>
@@ -186,7 +202,12 @@ const emit = defineEmits<{
   'update:selectedFormat': [format: DesignReportFormat]
 }>()
 
-const formats: Array<{ id: DesignReportFormat; label: string; ext: string; icon: string }> = [
+const formats: Array<{
+  id: DesignReportFormat
+  label: string
+  ext: string
+  icon: string
+}> = [
   { id: 'latex', label: 'LaTeX Paper', ext: '.tex', icon: 'ri-brackets-line' },
   { id: 'markdown', label: 'Markdown Docs', ext: '.md', icon: 'ri-markdown-line' },
   { id: 'csv', label: 'CSV Table', ext: '.csv', icon: 'ri-table-line' },

--- a/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.vue
+++ b/ecos/gui/apps/renderer/src/components/DesignReportExportDialog.vue
@@ -25,7 +25,6 @@
           >
             <i :class="fmt.icon" aria-hidden="true" />
             <span class="tab-label">{{ fmt.label }}</span>
-            <span class="tab-badge">{{ fmt.ext }}</span>
           </button>
         </div>
 
@@ -95,6 +94,17 @@
           />
           <span>Standalone Document (IEEEtran)</span>
         </label>
+
+        <label v-if="selectedFormat === 'typst'" class="option-checkbox">
+          <input
+            type="checkbox"
+            :checked="options.typstStandalone"
+            @change="
+              updateOption('typstStandalone', ($event.target as HTMLInputElement).checked)
+            "
+          />
+          <span>Standalone Document</span>
+        </label>
       </div>
 
       <!-- Main Preview Area -->
@@ -156,7 +166,7 @@
             @click="emit('saveAll')"
           >
             <i class="ri-folder-zip-line" aria-hidden="true" />
-            Export All Formats (4 Files)
+            Export All Formats (5 Files)
           </button>
           <button
             type="button"
@@ -208,10 +218,11 @@ const formats: Array<{
   ext: string
   icon: string
 }> = [
-  { id: 'latex', label: 'LaTeX Paper', ext: '.tex', icon: 'ri-brackets-line' },
-  { id: 'markdown', label: 'Markdown Docs', ext: '.md', icon: 'ri-markdown-line' },
-  { id: 'csv', label: 'CSV Table', ext: '.csv', icon: 'ri-table-line' },
-  { id: 'text', label: 'Plain Text Log', ext: '.txt', icon: 'ri-file-text-line' },
+  { id: 'latex', label: 'LaTeX', ext: '.tex', icon: 'ri-brackets-line' },
+  { id: 'markdown', label: 'Markdown', ext: '.md', icon: 'ri-markdown-line' },
+  { id: 'typst', label: 'Typst', ext: '.typ', icon: 'ri-article-line' },
+  { id: 'csv', label: 'CSV', ext: '.csv', icon: 'ri-table-line' },
+  { id: 'text', label: 'Text', ext: '.txt', icon: 'ri-file-text-line' },
 ]
 
 const lineCount = computed(() => {
@@ -226,13 +237,15 @@ const charCount = computed(() => {
 function formatLabel(format: DesignReportFormat): string {
   switch (format) {
     case 'latex':
-      return 'LaTeX (booktabs / siunitx)'
+      return 'LaTeX'
     case 'markdown':
-      return 'GitHub Flavored Markdown'
+      return 'Markdown'
+    case 'typst':
+      return 'Typst'
     case 'csv':
-      return 'RFC 4180 CSV Data'
+      return 'CSV'
     case 'text':
-      return 'ASCII Table Log'
+      return 'Plain Text'
   }
 }
 
@@ -242,6 +255,8 @@ function formatExt(format: DesignReportFormat): string {
       return 'tex'
     case 'markdown':
       return 'md'
+    case 'typst':
+      return 'typ'
     case 'csv':
       return 'csv'
     case 'text':

--- a/ecos/gui/apps/renderer/src/components/SignoffPackageReviewDialog.vue
+++ b/ecos/gui/apps/renderer/src/components/SignoffPackageReviewDialog.vue
@@ -165,6 +165,7 @@ defineProps<{
 const emit = defineEmits<{
   close: []
   export: []
+  exportReport: []
   refresh: []
 }>()
 

--- a/ecos/gui/apps/renderer/src/components/TopBar.test.ts
+++ b/ecos/gui/apps/renderer/src/components/TopBar.test.ts
@@ -145,10 +145,13 @@ describe('TopBar drag region layout', () => {
   it('shows signoff export below workspace update and binds its eligibility', () => {
     const updateIndex = topBarSource.indexOf("label: 'Update Workspace'")
     const exportIndex = topBarSource.indexOf("label: 'Export Signoff Package'")
+    const metricsIndex = topBarSource.indexOf("label: 'Export Design Summary'")
 
     expect(exportIndex).toBeGreaterThan(updateIndex)
+    expect(metricsIndex).toBeGreaterThan(exportIndex)
     expect(topBarSource).toContain('appMenuActionIds.exportSignoffPackage')
     expect(topBarSource).toContain('disabled: !props.signoffPackageExportEnabled')
+    expect(topBarSource).toContain('appMenuActionIds.exportDesignSummary')
   })
 
   it('does not render the workspace Design menu', () => {

--- a/ecos/gui/apps/renderer/src/components/TopBar.vue
+++ b/ecos/gui/apps/renderer/src/components/TopBar.vue
@@ -228,6 +228,7 @@ const props = defineProps<{
   projectName?: string | null
   hasWorkspace?: boolean
   signoffPackageExportEnabled?: boolean
+  designReportExportEnabled?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -313,6 +314,12 @@ const menus = computed<Menu[]>(() => [
         icon: 'ri-archive-line',
         event: appMenuActionIds.exportSignoffPackage,
         disabled: !props.signoffPackageExportEnabled,
+      },
+      {
+        label: 'Export Design Summary',
+        icon: 'ri-file-chart-line',
+        event: appMenuActionIds.exportDesignSummary,
+        disabled: !props.hasWorkspace && !props.designReportExportEnabled,
       },
     ],
   },

--- a/ecos/gui/apps/renderer/src/composables/useAppMenuActions.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useAppMenuActions.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { appMenuActionIds } from '@ecos-studio/shared'
+import { appMenuActionIds, type AppMenuAction } from '@ecos-studio/shared'
 
 const { useMenuEvents } = vi.hoisted(() => ({
   useMenuEvents: vi.fn(),
@@ -17,20 +17,7 @@ describe('useAppMenuActions', () => {
   })
 
   it('registers app-level native menu handlers that dispatch the real app actions', async () => {
-    let registeredHandlers:
-      | Partial<
-          Record<
-            | typeof appMenuActionIds.documentation
-            | typeof appMenuActionIds.newWindow
-            | typeof appMenuActionIds.newProject
-            | typeof appMenuActionIds.openProject
-            | typeof appMenuActionIds.reconfigureWorkspace
-            | typeof appMenuActionIds.exportSignoffPackage
-            | typeof appMenuActionIds.about,
-            () => void
-          >
-        >
-      | undefined
+    let registeredHandlers: Partial<Record<AppMenuAction, () => void>> | undefined
 
     useMenuEvents.mockImplementation((handlers) => {
       registeredHandlers = handlers
@@ -44,6 +31,7 @@ describe('useAppMenuActions', () => {
     const showAboutDialog = vi.fn()
     const reconfigureWorkspace = vi.fn()
     const exportSignoffPackage = vi.fn()
+    const exportDesignMetrics = vi.fn()
 
     const { handleMenuAction } = useAppMenuActions({
       createWindow,
@@ -52,6 +40,7 @@ describe('useAppMenuActions', () => {
       openProject,
       reconfigureWorkspace,
       exportSignoffPackage,
+      exportDesignMetrics,
       showAboutDialog,
       showNewProjectWizard,
     })
@@ -85,6 +74,11 @@ describe('useAppMenuActions', () => {
 
     expect(exportSignoffPackage).toHaveBeenCalledTimes(1)
 
+    registeredHandlers?.[appMenuActionIds.exportDesignMetrics]?.()
+    await Promise.resolve()
+
+    expect(exportDesignMetrics).toHaveBeenCalledTimes(1)
+
     registeredHandlers?.[appMenuActionIds.documentation]?.()
     await Promise.resolve()
 
@@ -111,6 +105,10 @@ describe('useAppMenuActions', () => {
     await handleMenuAction(appMenuActionIds.exportSignoffPackage)
 
     expect(exportSignoffPackage).toHaveBeenCalledTimes(2)
+
+    await handleMenuAction(appMenuActionIds.exportDesignMetrics)
+
+    expect(exportDesignMetrics).toHaveBeenCalledTimes(2)
   })
 
   it('does not navigate when opening a project is cancelled', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useAppMenuActions.ts
+++ b/ecos/gui/apps/renderer/src/composables/useAppMenuActions.ts
@@ -7,6 +7,8 @@ interface AppMenuActionDependencies {
   openDocumentation(): Promise<void>
   openProject(): Promise<boolean | undefined>
   exportSignoffPackage?(): void | Promise<void>
+  exportDesignSummary?(): void | Promise<void>
+  exportDesignMetrics?(): void | Promise<void>
   reconfigureWorkspace?(): void | Promise<void>
   showAboutDialog(): void
   showNewProjectWizard(): void
@@ -20,6 +22,8 @@ export function useAppMenuActions({
   openDocumentation,
   openProject,
   exportSignoffPackage,
+  exportDesignSummary,
+  exportDesignMetrics,
   reconfigureWorkspace,
   showAboutDialog,
   showNewProjectWizard,
@@ -47,6 +51,10 @@ export function useAppMenuActions({
         break
       case appMenuActionIds.exportSignoffPackage:
         await exportSignoffPackage?.()
+        break
+      case appMenuActionIds.exportDesignSummary:
+      case appMenuActionIds.exportDesignMetrics:
+        await (exportDesignSummary || exportDesignMetrics)?.()
         break
       case appMenuActionIds.documentation:
         await openDocumentation()
@@ -88,6 +96,9 @@ export function useAppMenuActions({
     },
     [appMenuActionIds.exportSignoffPackage]: () => {
       void handleMenuAction(appMenuActionIds.exportSignoffPackage)
+    },
+    [appMenuActionIds.exportDesignSummary]: () => {
+      void handleMenuAction(appMenuActionIds.exportDesignSummary)
     },
     [appMenuActionIds.zoomIn]: () => void handleMenuAction(appMenuActionIds.zoomIn),
     [appMenuActionIds.zoomOut]: () => void handleMenuAction(appMenuActionIds.zoomOut),

--- a/ecos/gui/apps/renderer/src/composables/useDesignReportExport.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesignReportExport.test.ts
@@ -282,4 +282,93 @@ describe('useDesignReportExport', () => {
       }),
     )
   })
+
+  it('invalidates in-flight report data when switching workspaces directly from A to B', async () => {
+    currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
+    const composable = useDesignReportExport({
+      currentProject,
+      showToast,
+    })
+
+    let resolveFirstFlow!: (value: Record<string, unknown>) => void
+    const firstFlowPromise = new Promise<Record<string, unknown>>((resolve) => {
+      resolveFirstFlow = resolve
+    })
+
+    mockReadFlow
+      .mockImplementationOnce(() => firstFlowPromise)
+      .mockResolvedValueOnce({
+        design: 'aes',
+        pdk: 'ic55',
+        steps: [
+          {
+            name: 'Synthesis_yosys',
+            tool: 'Yosys',
+            state: 'Success',
+            runtime: '0:0:45',
+          },
+        ],
+      })
+
+    mockReadParameters
+      .mockResolvedValueOnce({ Design: 'gcd' })
+      .mockResolvedValueOnce({ Design: 'aes' })
+
+    mockGetIndex
+      .mockResolvedValueOnce({ design: 'gcd' })
+      .mockResolvedValueOnce({ design: 'aes' })
+
+    // Open export dialog for workspace A (triggers load)
+    composable.openDesignReportExport('latex')
+    expect(composable.dialogVisible.value).toBe(true)
+    expect(composable.loading.value).toBe(true)
+
+    // Switch directly from workspace A to workspace B while A is still in-flight
+    currentProject.value = { path: '/projects/aes/ws_002', name: 'aes_run' }
+    await Promise.resolve()
+
+    // Resolve the delayed in-flight read for workspace A
+    resolveFirstFlow({
+      design: 'gcd_stale',
+      pdk: 'ic55',
+      steps: [],
+    })
+
+    // Wait for the new load for workspace B to finish
+    await vi.waitFor(() => expect(composable.loading.value).toBe(false))
+
+    // Ensure reportData reflects workspace B only and did not get overwritten or mixed with A
+    expect(composable.reportData.value?.design.designName).toBe('aes')
+    expect(composable.reportData.value?.design.workspacePath).toBe('/projects/aes/ws_002')
+  })
+
+  it('invalidates in-flight report data when dialog is closed', async () => {
+    currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
+    const composable = useDesignReportExport({
+      currentProject,
+      showToast,
+    })
+
+    let resolveFlow!: (value: Record<string, unknown>) => void
+    const flowPromise = new Promise<Record<string, unknown>>((resolve) => {
+      resolveFlow = resolve
+    })
+    mockReadFlow.mockImplementationOnce(() => flowPromise)
+
+    composable.openDesignReportExport('latex')
+    expect(composable.dialogVisible.value).toBe(true)
+    expect(composable.loading.value).toBe(true)
+
+    // Close the dialog while load is in flight
+    composable.closeDesignReportExport()
+    expect(composable.dialogVisible.value).toBe(false)
+    expect(composable.reportData.value).toBeNull()
+
+    // Resolve the delayed read
+    resolveFlow({ design: 'gcd' })
+    await Promise.resolve()
+
+    // reportData remains null because generation was invalidated
+    expect(composable.reportData.value).toBeNull()
+  })
 })

--- a/ecos/gui/apps/renderer/src/composables/useDesignReportExport.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesignReportExport.test.ts
@@ -87,10 +87,16 @@ describe('useDesignReportExport', () => {
             directory: '/projects/gcd/ws_001/Synthesis_yosys',
             resources: {
               analysis: {
-                metrics: { exists: true, path: '/projects/gcd/ws_001/Synthesis_yosys/analysis/qor_metrics.json' },
+                metrics: {
+                  exists: true,
+                  path: '/projects/gcd/ws_001/Synthesis_yosys/analysis/qor_metrics.json',
+                },
               },
               feature: {
-                stat: { exists: true, path: '/projects/gcd/ws_001/Synthesis_yosys/feature/Synthesis_stat.json' },
+                stat: {
+                  exists: true,
+                  path: '/projects/gcd/ws_001/Synthesis_yosys/feature/Synthesis_stat.json',
+                },
               },
             },
           },
@@ -101,7 +107,13 @@ describe('useDesignReportExport', () => {
       design: 'gcd',
       pdk: 'ic55',
       steps: [
-        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:0:30', 'peak memory (mb)': 120 },
+        {
+          name: 'Synthesis_yosys',
+          tool: 'Yosys',
+          state: 'Success',
+          runtime: '0:0:30',
+          'peak memory (mb)': 120,
+        },
       ],
     })
     mockReadParameters.mockResolvedValue({
@@ -131,13 +143,19 @@ describe('useDesignReportExport', () => {
     })
 
     expect(composable.designReportExportEnabled.value).toBe(false)
-    expect(mockSetActionEnabled).toHaveBeenCalledWith(appMenuActionIds.exportDesignSummary, false)
+    expect(mockSetActionEnabled).toHaveBeenCalledWith(
+      appMenuActionIds.exportDesignSummary,
+      false,
+    )
 
     currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
     await Promise.resolve()
 
     expect(composable.designReportExportEnabled.value).toBe(true)
-    expect(mockSetActionEnabled).toHaveBeenCalledWith(appMenuActionIds.exportDesignSummary, true)
+    expect(mockSetActionEnabled).toHaveBeenCalledWith(
+      appMenuActionIds.exportDesignSummary,
+      true,
+    )
   })
 
   it('loads workspace data and generates report content on openDesignReportExport', async () => {

--- a/ecos/gui/apps/renderer/src/composables/useDesignReportExport.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesignReportExport.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { appMenuActionIds } from '@ecos-studio/shared'
+import { useDesignReportExport } from './useDesignReportExport'
+
+const mockSetActionEnabled = vi.fn()
+const mockGetIndex = vi.fn()
+const mockReadFlow = vi.fn()
+const mockReadParameters = vi.fn()
+const mockReadHome = vi.fn()
+const mockReadOptionalProjectTextFile = vi.fn()
+const mockRequestProjectPathAccess = vi.fn()
+const mockSaveFile = vi.fn()
+const mockWriteProjectTextFile = vi.fn()
+const mockGetVersions = vi.fn()
+
+vi.mock('@/platform/desktop', () => ({
+  getDesktopApi: () => ({
+    app: {
+      getVersions: mockGetVersions,
+    },
+    menu: { setActionEnabled: mockSetActionEnabled },
+    workspaceResources: {
+      getIndex: mockGetIndex,
+      readFlow: mockReadFlow,
+      readParameters: mockReadParameters,
+      readHome: mockReadHome,
+    },
+    workspace: {
+      readOptionalProjectTextFile: mockReadOptionalProjectTextFile,
+      writeProjectTextFile: mockWriteProjectTextFile,
+      requestProjectPathAccess: mockRequestProjectPathAccess,
+    },
+    dialog: {
+      saveFile: mockSaveFile,
+    },
+  }),
+  getOptionalDesktopApi: () => ({
+    app: {
+      getVersions: mockGetVersions,
+    },
+    menu: { setActionEnabled: mockSetActionEnabled },
+    workspaceResources: {
+      getIndex: mockGetIndex,
+      readFlow: mockReadFlow,
+      readParameters: mockReadParameters,
+      readHome: mockReadHome,
+    },
+    workspace: {
+      readOptionalProjectTextFile: mockReadOptionalProjectTextFile,
+      writeProjectTextFile: mockWriteProjectTextFile,
+      requestProjectPathAccess: mockRequestProjectPathAccess,
+    },
+    dialog: {
+      saveFile: mockSaveFile,
+    },
+  }),
+}))
+
+describe('useDesignReportExport', () => {
+  const currentProject = ref<{ path?: string; name?: string } | null>(null)
+  const showToast = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentProject.value = null
+    mockGetVersions.mockResolvedValue({
+      gui: '0.1.0-alpha.8',
+      ecc: '1.4.2',
+      eccTools: 'ecc-fe',
+    })
+    mockGetIndex.mockResolvedValue({
+      design: 'gcd',
+      topModule: 'gcd',
+      pdk: 'ic55',
+      home: {
+        flowJson: { exists: true, path: 'home/flow.json' },
+        parametersJson: { exists: true, path: 'home/parameters.json' },
+      },
+      flow: {
+        steps: [
+          {
+            name: 'Synthesis_yosys',
+            tool: 'Yosys',
+            state: 'Success',
+            runtime: '0:0:30',
+            directory: '/projects/gcd/ws_001/Synthesis_yosys',
+            resources: {
+              analysis: {
+                metrics: { exists: true, path: '/projects/gcd/ws_001/Synthesis_yosys/analysis/qor_metrics.json' },
+              },
+              feature: {
+                stat: { exists: true, path: '/projects/gcd/ws_001/Synthesis_yosys/feature/Synthesis_stat.json' },
+              },
+            },
+          },
+        ],
+      },
+    })
+    mockReadFlow.mockResolvedValue({
+      design: 'gcd',
+      pdk: 'ic55',
+      steps: [
+        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:0:30', 'peak memory (mb)': 120 },
+      ],
+    })
+    mockReadParameters.mockResolvedValue({
+      Design: 'gcd',
+      PDK: 'ic55',
+      CLOCK_PERIOD: 10.0,
+    })
+    mockRequestProjectPathAccess.mockImplementation(async (p: string) => p)
+    mockReadOptionalProjectTextFile.mockImplementation(async (p: string) => {
+      if (p.includes('qor_metrics.json')) {
+        return JSON.stringify({
+          schema_version: 3,
+          metrics: [
+            { id: 'instance_count', value: 572 },
+            { id: 'die_area', value: 100000 },
+          ],
+        })
+      }
+      return null
+    })
+  })
+
+  it('enables menu action when workspace is open and disables when closed', async () => {
+    const composable = useDesignReportExport({
+      currentProject,
+      showToast,
+    })
+
+    expect(composable.designReportExportEnabled.value).toBe(false)
+    expect(mockSetActionEnabled).toHaveBeenCalledWith(appMenuActionIds.exportDesignSummary, false)
+
+    currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
+    await Promise.resolve()
+
+    expect(composable.designReportExportEnabled.value).toBe(true)
+    expect(mockSetActionEnabled).toHaveBeenCalledWith(appMenuActionIds.exportDesignSummary, true)
+  })
+
+  it('loads workspace data and generates report content on openDesignReportExport', async () => {
+    currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
+    const composable = useDesignReportExport({
+      currentProject,
+      showToast,
+    })
+
+    composable.openDesignReportExport('latex')
+    expect(composable.dialogVisible.value).toBe(true)
+    expect(composable.selectedFormat.value).toBe('latex')
+
+    await vi.waitFor(() => expect(composable.loading.value).toBe(false))
+
+    expect(composable.reportData.value).toBeDefined()
+    expect(composable.reportData.value?.design.designName).toBe('gcd')
+    expect(composable.generatedContent.value).toContain('\\begin{table}')
+    expect(composable.generatedContent.value).toContain('gcd')
+
+    composable.selectedFormat.value = 'markdown'
+    expect(composable.generatedContent.value).toContain('# Design Summary Report: gcd')
+
+    composable.selectedFormat.value = 'csv'
+    expect(composable.generatedContent.value).toContain('Category,Metric,Value')
+
+    composable.selectedFormat.value = 'text'
+    expect(composable.generatedContent.value).toContain('ECOS STUDIO — DESIGN SUMMARY')
+  })
+
+  it('copies content to clipboard and shows success toast', async () => {
+    currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
+    const composable = useDesignReportExport({
+      currentProject,
+      showToast,
+    })
+
+    composable.openDesignReportExport('latex')
+    await vi.waitFor(() => expect(composable.loading.value).toBe(false))
+
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, {
+      clipboard: { writeText: clipboardWrite },
+    })
+
+    const copied = await composable.copyToClipboard()
+    expect(copied).toBe(true)
+    expect(clipboardWrite).toHaveBeenCalledWith(composable.generatedContent.value)
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'success',
+        summary: 'Copied to Clipboard',
+      }),
+    )
+  })
+
+  it('saves the current report file using dialog.saveFile and writeProjectTextFile', async () => {
+    currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
+    const composable = useDesignReportExport({
+      currentProject,
+      showToast,
+    })
+
+    composable.openDesignReportExport('latex')
+    await vi.waitFor(() => expect(composable.loading.value).toBe(false))
+
+    mockSaveFile.mockResolvedValueOnce('/projects/gcd/exports/gcd_summary.tex')
+    mockWriteProjectTextFile.mockResolvedValueOnce(undefined)
+
+    const saved = await composable.saveCurrentReport()
+    expect(saved).toBe(true)
+    expect(mockSaveFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('TEX'),
+      }),
+    )
+    expect(mockWriteProjectTextFile).toHaveBeenCalledWith(
+      '/projects/gcd/exports/gcd_summary.tex',
+      composable.generatedContent.value,
+    )
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'success',
+        summary: 'Report Saved',
+      }),
+    )
+  })
+
+  it('exports all 4 formats (.tex, .md, .csv, .txt) on exportAllFormats', async () => {
+    currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
+    const composable = useDesignReportExport({
+      currentProject,
+      showToast,
+    })
+
+    composable.openDesignReportExport()
+    await vi.waitFor(() => expect(composable.loading.value).toBe(false))
+
+    mockWriteProjectTextFile.mockResolvedValue(undefined)
+
+    const result = await composable.exportAllFormats()
+    expect(result).toBe(true)
+    expect(mockWriteProjectTextFile).toHaveBeenCalledTimes(4)
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'success',
+        summary: 'All Formats Exported',
+      }),
+    )
+  })
+
+  it('warns when trying to open export without an active workspace', () => {
+    const composable = useDesignReportExport({
+      currentProject,
+      showToast,
+    })
+
+    composable.openDesignReportExport()
+    expect(composable.dialogVisible.value).toBe(false)
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'warn',
+        summary: 'No Workspace Open',
+      }),
+    )
+  })
+})

--- a/ecos/gui/apps/renderer/src/composables/useDesignReportExport.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesignReportExport.test.ts
@@ -179,6 +179,9 @@ describe('useDesignReportExport', () => {
     composable.selectedFormat.value = 'markdown'
     expect(composable.generatedContent.value).toContain('# Design Summary Report: gcd')
 
+    composable.selectedFormat.value = 'typst'
+    expect(composable.generatedContent.value).toContain('#figure(')
+
     composable.selectedFormat.value = 'csv'
     expect(composable.generatedContent.value).toContain('Category,Metric,Value')
 
@@ -230,11 +233,8 @@ describe('useDesignReportExport', () => {
     expect(mockSaveFile).toHaveBeenCalledWith(
       expect.objectContaining({
         title: expect.stringContaining('TEX'),
+        content: composable.generatedContent.value,
       }),
-    )
-    expect(mockWriteProjectTextFile).toHaveBeenCalledWith(
-      '/projects/gcd/exports/gcd_summary.tex',
-      composable.generatedContent.value,
     )
     expect(showToast).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -244,7 +244,7 @@ describe('useDesignReportExport', () => {
     )
   })
 
-  it('exports all 4 formats (.tex, .md, .csv, .txt) on exportAllFormats', async () => {
+  it('exports all 5 formats (.tex, .md, .typ, .csv, .txt) on exportAllFormats', async () => {
     currentProject.value = { path: '/projects/gcd/ws_001', name: 'gcd_run' }
     const composable = useDesignReportExport({
       currentProject,
@@ -258,7 +258,7 @@ describe('useDesignReportExport', () => {
 
     const result = await composable.exportAllFormats()
     expect(result).toBe(true)
-    expect(mockWriteProjectTextFile).toHaveBeenCalledTimes(4)
+    expect(mockWriteProjectTextFile).toHaveBeenCalledTimes(5)
     expect(showToast).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'success',

--- a/ecos/gui/apps/renderer/src/composables/useDesignReportExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesignReportExport.ts
@@ -160,10 +160,19 @@ export function useDesignReportExport({
 
   watch(
     () => currentProject.value?.path,
-    () => {
+    (newPath, oldPath) => {
       void syncMenuEligibility()
-      if (dialogVisible.value && !currentProject.value?.path) {
-        closeDesignReportExport()
+      if (newPath !== oldPath) {
+        loadGeneration++
+        reportData.value = null
+        error.value = ''
+        if (dialogVisible.value) {
+          if (newPath) {
+            void loadWorkspaceReportData()
+          } else {
+            closeDesignReportExport()
+          }
+        }
       }
     },
     { immediate: true },
@@ -646,6 +655,7 @@ export function useDesignReportExport({
   }
 
   function closeDesignReportExport(): void {
+    loadGeneration++
     dialogVisible.value = false
     loading.value = false
     error.value = ''

--- a/ecos/gui/apps/renderer/src/composables/useDesignReportExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesignReportExport.ts
@@ -49,22 +49,14 @@ function errorDetail(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function projectPathForWorkspace(workspacePath: string): string {
-  const normalized = workspacePath.replace(/[\\/]+$/g, '')
-  const separatorIndex = Math.max(
-    normalized.lastIndexOf('/'),
-    normalized.lastIndexOf('\\'),
-  )
-  if (separatorIndex <= 0) return normalized
-  return normalized.slice(0, separatorIndex)
-}
-
 function formatFileExtension(format: DesignReportFormat): string {
   switch (format) {
     case 'latex':
       return 'tex'
     case 'markdown':
       return 'md'
+    case 'typst':
+      return 'typ'
     case 'csv':
       return 'csv'
     case 'text':
@@ -138,6 +130,7 @@ export function useDesignReportExport({
     latexStandalone: false,
     latexUseBooktabs: true,
     latexUseSiunitx: true,
+    typstStandalone: true,
   })
 
   let unmounted = false
@@ -688,16 +681,14 @@ export function useDesignReportExport({
     const design = reportData.value?.design.designName || 'design'
     const ext = formatFileExtension(selectedFormat.value)
     const defaultFilename = `${design}_design_summary.${ext}`
-    const defaultPath = joinLocalPath(
-      projectPathForWorkspace(currentProject.value.path),
-      defaultFilename,
-    )
+    const defaultPath = joinLocalPath(currentProject.value.path, defaultFilename)
 
     try {
       const api = getDesktopApi()
       const destination = await api.dialog.saveFile({
         title: `Save ${selectedFormat.value.toUpperCase()} Design Summary`,
         defaultPath,
+        content: text,
         filters: [
           {
             name: `${selectedFormat.value.toUpperCase()} Files`,
@@ -709,7 +700,6 @@ export function useDesignReportExport({
 
       if (!destination) return false
 
-      await writeProjectTextFile(destination, text)
       showToast({
         severity: 'success',
         summary: 'Report Saved',
@@ -730,16 +720,16 @@ export function useDesignReportExport({
   async function exportAllFormats(): Promise<boolean> {
     if (!reportData.value || !currentProject.value?.path) return false
 
-    const formats: DesignReportFormat[] = ['latex', 'markdown', 'csv', 'text']
+    const formats: DesignReportFormat[] = ['latex', 'markdown', 'typst', 'csv', 'text']
     const design = reportData.value.design.designName || 'design'
-    const parentDir = projectPathForWorkspace(currentProject.value.path)
+    const targetDir = currentProject.value.path
 
     try {
       await Promise.all(
         formats.map(async (fmt) => {
           const ext = formatFileExtension(fmt)
           const content = generateDesignReport(reportData.value!, fmt, exportOptions)
-          const targetPath = joinLocalPath(parentDir, `${design}_design_summary.${ext}`)
+          const targetPath = joinLocalPath(targetDir, `${design}_design_summary.${ext}`)
           await writeProjectTextFile(targetPath, content)
         }),
       )
@@ -747,7 +737,7 @@ export function useDesignReportExport({
       showToast({
         severity: 'success',
         summary: 'All Formats Exported',
-        detail: `Successfully generated .tex, .md, .csv, and .txt files in ${parentDir}`,
+        detail: `Successfully generated .tex, .md, .typ, .csv, and .txt files in ${targetDir}`,
         life: 5000,
       })
       return true

--- a/ecos/gui/apps/renderer/src/composables/useDesignReportExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesignReportExport.ts
@@ -1,0 +1,679 @@
+import { computed, onUnmounted, reactive, ref, watch, type Ref } from 'vue'
+import {
+  appMenuActionIds,
+  canonicalizeStageName,
+  extractDesignReportData,
+  generateDesignReport,
+  joinLocalPath,
+  parsePowerRpt,
+  parseQorSummaryRpt,
+  projectManagementWorkspaceStepAnalysisSpecs,
+  type DesignReportData,
+  type DesignReportExportOptions,
+  type DesignReportFormat,
+  type WorkspaceResourceIndex,
+} from '@ecos-studio/shared'
+import { getDesktopApi, getOptionalDesktopApi } from '@/platform/desktop'
+import {
+  getWorkspaceResourceIndexApi,
+  readWorkspaceFlowResourceApi,
+  readWorkspaceHomeResourceApi,
+  readWorkspaceParametersResourceApi,
+} from '@/api/workspaceResources'
+import { resolveProjectPathAccess } from '@/utils/projectFs'
+import { readOptionalProjectTextFile, writeProjectTextFile } from '@/utils/projectFiles'
+import { parseDrcStatisCsv } from '@/components/flow-insights/flowInsightsData'
+
+interface WorkspaceProject {
+  path?: string
+  name?: string
+  pdk?: string
+  topModule?: string
+  designTool?: string
+  frequencyTarget?: number
+}
+
+interface ToastOptions {
+  severity?: 'success' | 'info' | 'warn' | 'error' | 'secondary' | 'contrast'
+  summary: string
+  detail?: string
+  life?: number
+}
+
+interface UseDesignReportExportDependencies {
+  currentProject: Readonly<Ref<WorkspaceProject | null | undefined>>
+  showToast(options: ToastOptions): void
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function projectPathForWorkspace(workspacePath: string): string {
+  const normalized = workspacePath.replace(/[\\/]+$/g, '')
+  const separatorIndex = Math.max(
+    normalized.lastIndexOf('/'),
+    normalized.lastIndexOf('\\'),
+  )
+  if (separatorIndex <= 0) return normalized
+  return normalized.slice(0, separatorIndex)
+}
+
+function formatFileExtension(format: DesignReportFormat): string {
+  switch (format) {
+    case 'latex':
+      return 'tex'
+    case 'markdown':
+      return 'md'
+    case 'csv':
+      return 'csv'
+    case 'text':
+      return 'txt'
+  }
+}
+
+async function readJsonFrom(path: string | undefined): Promise<Record<string, unknown> | null> {
+  if (!path) return null
+  const authorized = await resolveProjectPathAccess(path)
+  const pathToRead = authorized || path
+  try {
+    const text = await readOptionalProjectTextFile(pathToRead)
+    if (!text) return null
+    return JSON.parse(text) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+async function readOptionalTextFrom(path: string | undefined): Promise<string | null> {
+  if (!path) return null
+  const authorized = await resolveProjectPathAccess(path)
+  const pathToRead = authorized || path
+  try {
+    return await readOptionalProjectTextFile(pathToRead)
+  } catch {
+    return null
+  }
+}
+
+const COMMON_CORNER_CANDIDATES = [
+  'MAX_125/Cworst',
+  'MAX_125/RCworst',
+  'MIN_m40/Cbest',
+  'MIN_m40/Cworst',
+  'MIN_m40/RCbest',
+  'MIN_m40/RCworst',
+  'ML_125/Cbest',
+  'ML_125/Cworst',
+  'ML_125/RCbest',
+  'ML_125/RCworst',
+  'TYP_25/TYPICAL',
+  'WCL_m40/Cworst',
+  'WCL_m40/RCworst',
+  'nom_tt_025C_1v80',
+  'slow_ss_125C_1v60',
+  'fast_ff_m40C_1v95',
+  'post_synthesis',
+  'default',
+]
+
+export function useDesignReportExport({
+  currentProject,
+  showToast,
+}: UseDesignReportExportDependencies) {
+  const dialogVisible = ref(false)
+  const loading = ref(false)
+  const error = ref('')
+  const selectedFormat = ref<DesignReportFormat>('latex')
+  const reportData = ref<DesignReportData | null>(null)
+  const designReportExportEnabled = ref(false)
+
+  const exportOptions = reactive<DesignReportExportOptions>({
+    includeMultiCorner: true,
+    includeStageBreakdown: true,
+    includeVerificationBreakdown: true,
+    includeProvenance: false,
+    latexStandalone: false,
+    latexUseBooktabs: true,
+    latexUseSiunitx: true,
+  })
+
+  let unmounted = false
+  let loadGeneration = 0
+
+  const generatedContent = computed(() => {
+    if (!reportData.value) return ''
+    return generateDesignReport(reportData.value, selectedFormat.value, exportOptions)
+  })
+
+  async function setMenuEnabled(enabled: boolean): Promise<void> {
+    designReportExportEnabled.value = enabled
+    try {
+      const api = getOptionalDesktopApi()
+      if (api) {
+        await api.menu.setActionEnabled(appMenuActionIds.exportDesignSummary, enabled)
+      }
+    } catch (err) {
+      console.warn('[design-report-export] Failed to set menu action state:', err)
+    }
+  }
+
+  async function syncMenuEligibility(): Promise<void> {
+    const hasWorkspace = Boolean(currentProject.value?.path)
+    await setMenuEnabled(hasWorkspace)
+  }
+
+  watch(
+    () => currentProject.value?.path,
+    () => {
+      void syncMenuEligibility()
+      if (dialogVisible.value && !currentProject.value?.path) {
+        closeDesignReportExport()
+      }
+    },
+    { immediate: true },
+  )
+
+  onUnmounted(() => {
+    unmounted = true
+    closeDesignReportExport()
+    void setMenuEnabled(false)
+  })
+
+  async function loadWorkspaceReportData(): Promise<void> {
+    const workspacePath = currentProject.value?.path
+    if (!workspacePath) {
+      error.value = 'No active workspace open.'
+      return
+    }
+
+    const generation = ++loadGeneration
+    loading.value = true
+    error.value = ''
+
+    try {
+      const api = getDesktopApi()
+
+      // 1. Get version info from desktop app
+      let versionInfo = null
+      try {
+        versionInfo = await api.app.getVersions()
+      } catch {
+        /* ignore */
+      }
+
+      // 2. Query workspace resource index
+      let resourceIndex: WorkspaceResourceIndex | null = null
+      try {
+        resourceIndex = await getWorkspaceResourceIndexApi()
+      } catch {
+        /* ignore if index API fails */
+      }
+
+      // 3. Read flow.json and parameters.json and home.json
+      let flow: Record<string, unknown> | null = null
+      let parameters: Record<string, unknown> | null = null
+      let homeData: Record<string, unknown> | null = null
+
+      try {
+        flow = await readWorkspaceFlowResourceApi()
+      } catch {
+        /* ignore */
+      }
+      if (!flow && resourceIndex?.home.flowJson?.exists) {
+        flow = await readJsonFrom(resourceIndex.home.flowJson.path)
+      }
+      if (!flow) {
+        flow = await readJsonFrom('home/flow.json')
+      }
+
+      try {
+        parameters = await readWorkspaceParametersResourceApi()
+      } catch {
+        /* ignore */
+      }
+      if (!parameters && resourceIndex?.parameters) {
+        parameters = resourceIndex.parameters
+      }
+      if (!parameters && resourceIndex?.home.parametersJson?.exists) {
+        parameters = await readJsonFrom(resourceIndex.home.parametersJson.path)
+      }
+      if (!parameters) {
+        parameters = await readJsonFrom('home/parameters.json')
+      }
+
+      try {
+        homeData = await readWorkspaceHomeResourceApi()
+      } catch {
+        /* ignore */
+      }
+      if (!homeData && resourceIndex?.homeData) {
+        homeData = resourceIndex.homeData
+      }
+
+      let pdkJson: Record<string, unknown> | null = null
+      try {
+        pdkJson =
+          (await readJsonFrom('home/pdk.json')) ||
+          (await readJsonFrom('config/pdk.json')) ||
+          (await readJsonFrom('pdk.json'))
+      } catch {
+        /* ignore */
+      }
+      if (pdkJson) {
+        homeData = { ...(homeData || {}), ...pdkJson }
+      }
+
+      const topModule =
+        resourceIndex?.topModule ||
+        resourceIndex?.design ||
+        currentProject.value?.topModule ||
+        currentProject.value?.name ||
+        'gcd'
+
+      // 4. Collect step metrics from workspace resource index & raw step directories
+      const stepMetrics: Record<string, unknown> = {}
+      const stepSummaries: Record<string, unknown> = {}
+      const stepHotspots: Record<string, unknown> = {}
+
+      const stepList =
+        (resourceIndex && Array.isArray(resourceIndex.flow?.steps) && resourceIndex.flow.steps.length > 0)
+          ? resourceIndex.flow.steps
+          : (Array.isArray(flow?.steps) ? flow!.steps : [])
+
+      await Promise.all(
+        stepList.map(async (rawStep: unknown) => {
+          if (!rawStep || typeof rawStep !== 'object') return
+          const stepObj = rawStep as Record<string, unknown>
+          const stepName = typeof stepObj.name === 'string' ? stepObj.name : ''
+          const stepDir =
+            typeof stepObj.directory === 'string' ? stepObj.directory.replace(/\/+$/, '') : stepName
+          if (!stepName) return
+
+          const canonical = canonicalizeStageName(stepName)
+          const resources =
+            typeof stepObj.resources === 'object' && stepObj.resources !== null
+              ? (stepObj.resources as Record<string, Record<string, { exists: boolean; path: string }>>)
+              : null
+
+          // 4.1 Check analysis metrics
+          if (resources?.analysis?.metrics?.exists) {
+            const m = await readJsonFrom(resources.analysis.metrics.path)
+            if (m) {
+              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...m }
+              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...m }
+            }
+          } else {
+            const m = await readJsonFrom(`${stepDir}/analysis/qor_metrics.json`)
+            if (m) {
+              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...m }
+              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...m }
+            }
+          }
+
+          // 4.2 Check analysis summary
+          if (resources?.analysis?.summary?.exists) {
+            const s = await readJsonFrom(resources.analysis.summary.path)
+            if (s) {
+              stepSummaries[stepName] = { ...(stepSummaries[stepName] as Record<string, unknown> || {}), ...s }
+              stepSummaries[canonical] = { ...(stepSummaries[canonical] as Record<string, unknown> || {}), ...s }
+            }
+          } else {
+            const s = await readJsonFrom(`${stepDir}/analysis/qor_summary.json`)
+            if (s) {
+              stepSummaries[stepName] = { ...(stepSummaries[stepName] as Record<string, unknown> || {}), ...s }
+              stepSummaries[canonical] = { ...(stepSummaries[canonical] as Record<string, unknown> || {}), ...s }
+            }
+          }
+
+          // 4.3 Check feature db (step.db.json)
+          if (resources?.feature?.db?.exists) {
+            const db = await readJsonFrom(resources.feature.db.path)
+            if (db) {
+              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...db }
+              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...db }
+            }
+          } else {
+            const dbCandidates = [
+              `${stepDir}/feature/${stepName}.db.json`,
+              `${stepDir}/feature/db.json`,
+              `${stepDir}/db.json`,
+              `${stepDir}/feature/${canonical}.db.json`,
+            ]
+            for (const cand of dbCandidates) {
+              const db = await readJsonFrom(cand)
+              if (db) {
+                stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...db }
+                stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...db }
+                break
+              }
+            }
+          }
+
+          // 4.4 Check feature stat (Synthesis_stat.json)
+          const statFile =
+            resources?.feature?.stat ?? resources?.feature?.generic_stat
+          if (statFile?.exists) {
+            const stat = await readJsonFrom(statFile.path)
+            if (stat) {
+              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...stat }
+              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...stat }
+            }
+          } else {
+            const stat =
+              (await readJsonFrom(`${stepDir}/feature/Synthesis_stat.json`)) ||
+              (await readJsonFrom(`${stepDir}/report/Synthesis_stat.json`))
+            if (stat) {
+              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...stat }
+              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...stat }
+            }
+          }
+
+          // 4.5 Check feature step (e.g. sta.step.json, cts.step.json)
+          let stepJson: Record<string, unknown> | null = null
+          if (resources?.feature?.step?.exists) {
+            stepJson = await readJsonFrom(resources.feature.step.path)
+          } else {
+            stepJson =
+              (await readJsonFrom(`${stepDir}/feature/${stepName}.step.json`)) ||
+              (await readJsonFrom(`${stepDir}/feature/${canonical.toLowerCase()}.step.json`)) ||
+              (await readJsonFrom(`${stepDir}/feature/step.json`))
+          }
+          if (stepJson) {
+            stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...stepJson }
+            stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...stepJson }
+          }
+
+          // 4.6 Check DRC statis CSV
+          if (resources?.analysis?.statis_csv?.exists) {
+            const drcCsv = await readOptionalTextFrom(resources.analysis.statis_csv.path)
+            if (drcCsv) {
+              const parsedDrc = parseDrcStatisCsv(drcCsv)
+              if (parsedDrc) {
+                const drcExisting = (stepMetrics['DRC'] as Record<string, unknown>) || {}
+                stepMetrics['DRC'] = {
+                  ...drcExisting,
+                  drc_violations: parsedDrc.totalCount,
+                  drc_count: parsedDrc.totalCount,
+                }
+              }
+            }
+          } else if (canonical === 'DRC') {
+            const drcCsv = await readOptionalTextFrom(`${stepDir}/analysis/drc_statis.csv`)
+            if (drcCsv) {
+              const parsedDrc = parseDrcStatisCsv(drcCsv)
+              if (parsedDrc) {
+                const drcExisting = (stepMetrics['DRC'] as Record<string, unknown>) || {}
+                stepMetrics['DRC'] = {
+                  ...drcExisting,
+                  drc_violations: parsedDrc.totalCount,
+                  drc_count: parsedDrc.totalCount,
+                }
+              }
+            }
+          }
+
+          // 4.7 Scan for power.rpt and qor_summary.rpt at step level
+          const directPowerRpt =
+            (await readOptionalTextFrom(`${stepDir}/data/sta/power_reporter/power.rpt`)) ||
+            (await readOptionalTextFrom(`${stepDir}/report/post_synthesis/power.rpt`))
+          if (directPowerRpt) {
+            const parsed = parsePowerRpt(directPowerRpt)
+            stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...parsed }
+            stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...parsed }
+          }
+
+          const directQorRpt =
+            (await readOptionalTextFrom(`${stepDir}/data/sta/timing_reporter/qor_summary.rpt`)) ||
+            (await readOptionalTextFrom(`${stepDir}/report/post_synthesis/qor_summary.rpt`))
+          if (directQorRpt) {
+            const parsed = parseQorSummaryRpt(directQorRpt)
+            stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...parsed }
+            stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...parsed }
+          }
+
+          // 4.8 Scan for Multi-Corner reports (under feature/<corner>/ and report/<corner>/)
+          const cornersMap: Record<string, Record<string, unknown>> = {}
+
+          await Promise.all(
+            COMMON_CORNER_CANDIDATES.map(async (corner) => {
+              const qorJson = await readJsonFrom(`${stepDir}/feature/${corner}/qor_summary.json`)
+              const powerJson = await readJsonFrom(`${stepDir}/feature/${corner}/power_summary.json`)
+              const pathsJson = await readJsonFrom(`${stepDir}/feature/${corner}/timing_paths.json`)
+              const powerRptText = await readOptionalTextFrom(`${stepDir}/report/${corner}/power.rpt`)
+              const qorRptText = await readOptionalTextFrom(`${stepDir}/report/${corner}/qor_summary.rpt`)
+
+              let cornerData: Record<string, unknown> | null = null
+
+              if (qorJson) {
+                cornerData = { ...(cornerData || {}), ...qorJson }
+              }
+              if (powerJson) {
+                cornerData = { ...(cornerData || {}), ...powerJson }
+              }
+              if (pathsJson) {
+                cornerData = { ...(cornerData || {}), ...pathsJson }
+              }
+              if (powerRptText) {
+                const parsedPower = parsePowerRpt(powerRptText)
+                cornerData = { ...(cornerData || {}), ...parsedPower }
+              }
+              if (qorRptText) {
+                const parsedQor = parseQorSummaryRpt(qorRptText)
+                cornerData = { ...(cornerData || {}), ...parsedQor }
+              }
+
+              if (cornerData) {
+                cornersMap[corner] = cornerData
+              }
+            }),
+          )
+
+          if (Object.keys(cornersMap).length > 0) {
+            const targetKey = canonical === 'Synth' ? 'Synth' : 'STA'
+            const existing = (stepMetrics[targetKey] as Record<string, unknown>) || {}
+            stepMetrics[targetKey] = {
+              ...existing,
+              corners: {
+                ...((existing.corners as Record<string, unknown>) || {}),
+                ...cornersMap,
+              },
+            }
+          }
+        }),
+      )
+
+      // 5. Fallback standard predefined analysis specs
+      await Promise.all(
+        projectManagementWorkspaceStepAnalysisSpecs.map(async (spec) => {
+          if (!stepMetrics[spec.step]) {
+            const m = await readJsonFrom(spec.metricsPath)
+            if (m) stepMetrics[spec.step] = m
+          }
+          if (!stepSummaries[spec.step]) {
+            const s = await readJsonFrom(spec.summaryPath)
+            if (s) stepSummaries[spec.step] = s
+          }
+          if (!stepHotspots[spec.step]) {
+            const h = await readJsonFrom(spec.hotspotsPath)
+            if (h) stepHotspots[spec.step] = h
+          }
+        }),
+      )
+
+      // 6. STA timing issues
+      let staTimingIssues: Record<string, unknown> | null = null
+      staTimingIssues = await readJsonFrom('sta_ecc/analysis/sta_timing_issues.json')
+
+      if (unmounted || generation !== loadGeneration) return
+
+      const extracted = extractDesignReportData({
+        workspacePath,
+        workspaceName: currentProject.value?.name,
+        designName: resourceIndex?.design || currentProject.value?.topModule,
+        topModule,
+        pdk: resourceIndex?.pdk || currentProject.value?.pdk,
+        frequencyTarget: currentProject.value?.frequencyTarget,
+        parameters,
+        flow,
+        homeData,
+        stepMetrics,
+        stepSummaries,
+        stepHotspots,
+        staTimingIssues,
+        versionInfo,
+      })
+
+      reportData.value = extracted
+      loading.value = false
+    } catch (err) {
+      if (unmounted || generation !== loadGeneration) return
+      error.value = errorDetail(err) || 'Failed to extract design metrics.'
+      loading.value = false
+    }
+  }
+
+  function openDesignReportExport(initialFormat?: DesignReportFormat): void {
+    if (!currentProject.value?.path) {
+      showToast({
+        severity: 'warn',
+        summary: 'No Workspace Open',
+        detail: 'Open or run a workspace before exporting signoff reports.',
+      })
+      return
+    }
+
+    if (initialFormat) {
+      selectedFormat.value = initialFormat
+    }
+    dialogVisible.value = true
+    void loadWorkspaceReportData()
+  }
+
+  function closeDesignReportExport(): void {
+    dialogVisible.value = false
+    loading.value = false
+    error.value = ''
+  }
+
+  async function copyToClipboard(): Promise<boolean> {
+    const text = generatedContent.value
+    if (!text) return false
+
+    try {
+      await navigator.clipboard.writeText(text)
+      showToast({
+        severity: 'success',
+        summary: 'Copied to Clipboard',
+        detail: `Exported ${selectedFormat.value.toUpperCase()} report copied to clipboard.`,
+        life: 3000,
+      })
+      return true
+    } catch (err) {
+      showToast({
+        severity: 'error',
+        summary: 'Clipboard Error',
+        detail: errorDetail(err) || 'Failed to copy to clipboard.',
+      })
+      return false
+    }
+  }
+
+  async function saveCurrentReport(): Promise<boolean> {
+    const text = generatedContent.value
+    if (!text || !currentProject.value?.path) return false
+
+    const design = reportData.value?.design.designName || 'design'
+    const ext = formatFileExtension(selectedFormat.value)
+    const defaultFilename = `${design}_design_summary.${ext}`
+    const defaultPath = joinLocalPath(
+      projectPathForWorkspace(currentProject.value.path),
+      defaultFilename,
+    )
+
+    try {
+      const api = getDesktopApi()
+      const destination = await api.dialog.saveFile({
+        title: `Save ${selectedFormat.value.toUpperCase()} Design Summary`,
+        defaultPath,
+        filters: [
+          {
+            name: `${selectedFormat.value.toUpperCase()} Files`,
+            extensions: [ext],
+          },
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      })
+
+      if (!destination) return false
+
+      await writeProjectTextFile(destination, text)
+      showToast({
+        severity: 'success',
+        summary: 'Report Saved',
+        detail: `Report written to ${destination}`,
+        life: 4000,
+      })
+      return true
+    } catch (err) {
+      showToast({
+        severity: 'error',
+        summary: 'Save Failed',
+        detail: errorDetail(err) || 'Could not save report file.',
+      })
+      return false
+    }
+  }
+
+  async function exportAllFormats(): Promise<boolean> {
+    if (!reportData.value || !currentProject.value?.path) return false
+
+    const formats: DesignReportFormat[] = ['latex', 'markdown', 'csv', 'text']
+    const design = reportData.value.design.designName || 'design'
+    const parentDir = projectPathForWorkspace(currentProject.value.path)
+
+    try {
+      await Promise.all(
+        formats.map(async (fmt) => {
+          const ext = formatFileExtension(fmt)
+          const content = generateDesignReport(reportData.value!, fmt, exportOptions)
+          const targetPath = joinLocalPath(parentDir, `${design}_design_summary.${ext}`)
+          await writeProjectTextFile(targetPath, content)
+        }),
+      )
+
+      showToast({
+        severity: 'success',
+        summary: 'All Formats Exported',
+        detail: `Successfully generated .tex, .md, .csv, and .txt files in ${parentDir}`,
+        life: 5000,
+      })
+      return true
+    } catch (err) {
+      showToast({
+        severity: 'error',
+        summary: 'Batch Export Failed',
+        detail: errorDetail(err) || 'Failed to export all format artifacts.',
+      })
+      return false
+    }
+  }
+
+  return {
+    dialogVisible,
+    loading,
+    error,
+    selectedFormat,
+    reportData,
+    generatedContent,
+    exportOptions,
+    designReportExportEnabled,
+    openDesignReportExport,
+    closeDesignReportExport,
+    copyToClipboard,
+    saveCurrentReport,
+    exportAllFormats,
+    loadWorkspaceReportData,
+    refreshReportData: loadWorkspaceReportData,
+  }
+}

--- a/ecos/gui/apps/renderer/src/composables/useDesignReportExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useDesignReportExport.ts
@@ -72,7 +72,9 @@ function formatFileExtension(format: DesignReportFormat): string {
   }
 }
 
-async function readJsonFrom(path: string | undefined): Promise<Record<string, unknown> | null> {
+async function readJsonFrom(
+  path: string | undefined,
+): Promise<Record<string, unknown> | null> {
   if (!path) return null
   const authorized = await resolveProjectPathAccess(path)
   const pathToRead = authorized || path
@@ -261,7 +263,7 @@ export function useDesignReportExport({
         /* ignore */
       }
       if (pdkJson) {
-        homeData = { ...(homeData || {}), ...pdkJson }
+        homeData = { ...homeData, ...pdkJson }
       }
 
       const topModule =
@@ -277,9 +279,13 @@ export function useDesignReportExport({
       const stepHotspots: Record<string, unknown> = {}
 
       const stepList =
-        (resourceIndex && Array.isArray(resourceIndex.flow?.steps) && resourceIndex.flow.steps.length > 0)
+        resourceIndex &&
+        Array.isArray(resourceIndex.flow?.steps) &&
+        resourceIndex.flow.steps.length > 0
           ? resourceIndex.flow.steps
-          : (Array.isArray(flow?.steps) ? flow!.steps : [])
+          : Array.isArray(flow?.steps)
+            ? flow!.steps
+            : []
 
       await Promise.all(
         stepList.map(async (rawStep: unknown) => {
@@ -287,27 +293,44 @@ export function useDesignReportExport({
           const stepObj = rawStep as Record<string, unknown>
           const stepName = typeof stepObj.name === 'string' ? stepObj.name : ''
           const stepDir =
-            typeof stepObj.directory === 'string' ? stepObj.directory.replace(/\/+$/, '') : stepName
+            typeof stepObj.directory === 'string'
+              ? stepObj.directory.replace(/\/+$/, '')
+              : stepName
           if (!stepName) return
 
           const canonical = canonicalizeStageName(stepName)
           const resources =
             typeof stepObj.resources === 'object' && stepObj.resources !== null
-              ? (stepObj.resources as Record<string, Record<string, { exists: boolean; path: string }>>)
+              ? (stepObj.resources as Record<
+                  string,
+                  Record<string, { exists: boolean; path: string }>
+                >)
               : null
 
           // 4.1 Check analysis metrics
           if (resources?.analysis?.metrics?.exists) {
             const m = await readJsonFrom(resources.analysis.metrics.path)
             if (m) {
-              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...m }
-              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...m }
+              stepMetrics[stepName] = {
+                ...(stepMetrics[stepName] as Record<string, unknown>),
+                ...m,
+              }
+              stepMetrics[canonical] = {
+                ...(stepMetrics[canonical] as Record<string, unknown>),
+                ...m,
+              }
             }
           } else {
             const m = await readJsonFrom(`${stepDir}/analysis/qor_metrics.json`)
             if (m) {
-              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...m }
-              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...m }
+              stepMetrics[stepName] = {
+                ...(stepMetrics[stepName] as Record<string, unknown>),
+                ...m,
+              }
+              stepMetrics[canonical] = {
+                ...(stepMetrics[canonical] as Record<string, unknown>),
+                ...m,
+              }
             }
           }
 
@@ -315,14 +338,26 @@ export function useDesignReportExport({
           if (resources?.analysis?.summary?.exists) {
             const s = await readJsonFrom(resources.analysis.summary.path)
             if (s) {
-              stepSummaries[stepName] = { ...(stepSummaries[stepName] as Record<string, unknown> || {}), ...s }
-              stepSummaries[canonical] = { ...(stepSummaries[canonical] as Record<string, unknown> || {}), ...s }
+              stepSummaries[stepName] = {
+                ...(stepSummaries[stepName] as Record<string, unknown>),
+                ...s,
+              }
+              stepSummaries[canonical] = {
+                ...(stepSummaries[canonical] as Record<string, unknown>),
+                ...s,
+              }
             }
           } else {
             const s = await readJsonFrom(`${stepDir}/analysis/qor_summary.json`)
             if (s) {
-              stepSummaries[stepName] = { ...(stepSummaries[stepName] as Record<string, unknown> || {}), ...s }
-              stepSummaries[canonical] = { ...(stepSummaries[canonical] as Record<string, unknown> || {}), ...s }
+              stepSummaries[stepName] = {
+                ...(stepSummaries[stepName] as Record<string, unknown>),
+                ...s,
+              }
+              stepSummaries[canonical] = {
+                ...(stepSummaries[canonical] as Record<string, unknown>),
+                ...s,
+              }
             }
           }
 
@@ -330,8 +365,14 @@ export function useDesignReportExport({
           if (resources?.feature?.db?.exists) {
             const db = await readJsonFrom(resources.feature.db.path)
             if (db) {
-              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...db }
-              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...db }
+              stepMetrics[stepName] = {
+                ...(stepMetrics[stepName] as Record<string, unknown>),
+                ...db,
+              }
+              stepMetrics[canonical] = {
+                ...(stepMetrics[canonical] as Record<string, unknown>),
+                ...db,
+              }
             }
           } else {
             const dbCandidates = [
@@ -343,29 +384,46 @@ export function useDesignReportExport({
             for (const cand of dbCandidates) {
               const db = await readJsonFrom(cand)
               if (db) {
-                stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...db }
-                stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...db }
+                stepMetrics[stepName] = {
+                  ...(stepMetrics[stepName] as Record<string, unknown>),
+                  ...db,
+                }
+                stepMetrics[canonical] = {
+                  ...(stepMetrics[canonical] as Record<string, unknown>),
+                  ...db,
+                }
                 break
               }
             }
           }
 
           // 4.4 Check feature stat (Synthesis_stat.json)
-          const statFile =
-            resources?.feature?.stat ?? resources?.feature?.generic_stat
+          const statFile = resources?.feature?.stat ?? resources?.feature?.generic_stat
           if (statFile?.exists) {
             const stat = await readJsonFrom(statFile.path)
             if (stat) {
-              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...stat }
-              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...stat }
+              stepMetrics[stepName] = {
+                ...(stepMetrics[stepName] as Record<string, unknown>),
+                ...stat,
+              }
+              stepMetrics[canonical] = {
+                ...(stepMetrics[canonical] as Record<string, unknown>),
+                ...stat,
+              }
             }
           } else {
             const stat =
               (await readJsonFrom(`${stepDir}/feature/Synthesis_stat.json`)) ||
               (await readJsonFrom(`${stepDir}/report/Synthesis_stat.json`))
             if (stat) {
-              stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...stat }
-              stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...stat }
+              stepMetrics[stepName] = {
+                ...(stepMetrics[stepName] as Record<string, unknown>),
+                ...stat,
+              }
+              stepMetrics[canonical] = {
+                ...(stepMetrics[canonical] as Record<string, unknown>),
+                ...stat,
+              }
             }
           }
 
@@ -376,12 +434,20 @@ export function useDesignReportExport({
           } else {
             stepJson =
               (await readJsonFrom(`${stepDir}/feature/${stepName}.step.json`)) ||
-              (await readJsonFrom(`${stepDir}/feature/${canonical.toLowerCase()}.step.json`)) ||
+              (await readJsonFrom(
+                `${stepDir}/feature/${canonical.toLowerCase()}.step.json`,
+              )) ||
               (await readJsonFrom(`${stepDir}/feature/step.json`))
           }
           if (stepJson) {
-            stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...stepJson }
-            stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...stepJson }
+            stepMetrics[stepName] = {
+              ...(stepMetrics[stepName] as Record<string, unknown>),
+              ...stepJson,
+            }
+            stepMetrics[canonical] = {
+              ...(stepMetrics[canonical] as Record<string, unknown>),
+              ...stepJson,
+            }
           }
 
           // 4.6 Check DRC statis CSV
@@ -399,7 +465,9 @@ export function useDesignReportExport({
               }
             }
           } else if (canonical === 'DRC') {
-            const drcCsv = await readOptionalTextFrom(`${stepDir}/analysis/drc_statis.csv`)
+            const drcCsv = await readOptionalTextFrom(
+              `${stepDir}/analysis/drc_statis.csv`,
+            )
             if (drcCsv) {
               const parsedDrc = parseDrcStatisCsv(drcCsv)
               if (parsedDrc) {
@@ -415,21 +483,39 @@ export function useDesignReportExport({
 
           // 4.7 Scan for power.rpt and qor_summary.rpt at step level
           const directPowerRpt =
-            (await readOptionalTextFrom(`${stepDir}/data/sta/power_reporter/power.rpt`)) ||
+            (await readOptionalTextFrom(
+              `${stepDir}/data/sta/power_reporter/power.rpt`,
+            )) ||
             (await readOptionalTextFrom(`${stepDir}/report/post_synthesis/power.rpt`))
           if (directPowerRpt) {
             const parsed = parsePowerRpt(directPowerRpt)
-            stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...parsed }
-            stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...parsed }
+            stepMetrics[stepName] = {
+              ...(stepMetrics[stepName] as Record<string, unknown>),
+              ...parsed,
+            }
+            stepMetrics[canonical] = {
+              ...(stepMetrics[canonical] as Record<string, unknown>),
+              ...parsed,
+            }
           }
 
           const directQorRpt =
-            (await readOptionalTextFrom(`${stepDir}/data/sta/timing_reporter/qor_summary.rpt`)) ||
-            (await readOptionalTextFrom(`${stepDir}/report/post_synthesis/qor_summary.rpt`))
+            (await readOptionalTextFrom(
+              `${stepDir}/data/sta/timing_reporter/qor_summary.rpt`,
+            )) ||
+            (await readOptionalTextFrom(
+              `${stepDir}/report/post_synthesis/qor_summary.rpt`,
+            ))
           if (directQorRpt) {
             const parsed = parseQorSummaryRpt(directQorRpt)
-            stepMetrics[stepName] = { ...(stepMetrics[stepName] as Record<string, unknown> || {}), ...parsed }
-            stepMetrics[canonical] = { ...(stepMetrics[canonical] as Record<string, unknown> || {}), ...parsed }
+            stepMetrics[stepName] = {
+              ...(stepMetrics[stepName] as Record<string, unknown>),
+              ...parsed,
+            }
+            stepMetrics[canonical] = {
+              ...(stepMetrics[canonical] as Record<string, unknown>),
+              ...parsed,
+            }
           }
 
           // 4.8 Scan for Multi-Corner reports (under feature/<corner>/ and report/<corner>/)
@@ -437,33 +523,49 @@ export function useDesignReportExport({
 
           await Promise.all(
             COMMON_CORNER_CANDIDATES.map(async (corner) => {
-              const qorJson = await readJsonFrom(`${stepDir}/feature/${corner}/qor_summary.json`)
-              const powerJson = await readJsonFrom(`${stepDir}/feature/${corner}/power_summary.json`)
-              const pathsJson = await readJsonFrom(`${stepDir}/feature/${corner}/timing_paths.json`)
-              const powerRptText = await readOptionalTextFrom(`${stepDir}/report/${corner}/power.rpt`)
-              const qorRptText = await readOptionalTextFrom(`${stepDir}/report/${corner}/qor_summary.rpt`)
+              const qorJson = await readJsonFrom(
+                `${stepDir}/feature/${corner}/qor_summary.json`,
+              )
+              const powerJson = await readJsonFrom(
+                `${stepDir}/feature/${corner}/power_summary.json`,
+              )
+              const pathsJson = await readJsonFrom(
+                `${stepDir}/feature/${corner}/timing_paths.json`,
+              )
+              const powerRptText = await readOptionalTextFrom(
+                `${stepDir}/report/${corner}/power.rpt`,
+              )
+              const qorRptText = await readOptionalTextFrom(
+                `${stepDir}/report/${corner}/qor_summary.rpt`,
+              )
 
-              let cornerData: Record<string, unknown> | null = null
+              let cornerData: Record<string, unknown> = {}
+              let hasCornerData = false
 
               if (qorJson) {
-                cornerData = { ...(cornerData || {}), ...qorJson }
+                cornerData = { ...cornerData, ...qorJson }
+                hasCornerData = true
               }
               if (powerJson) {
-                cornerData = { ...(cornerData || {}), ...powerJson }
+                cornerData = { ...cornerData, ...powerJson }
+                hasCornerData = true
               }
               if (pathsJson) {
-                cornerData = { ...(cornerData || {}), ...pathsJson }
+                cornerData = { ...cornerData, ...pathsJson }
+                hasCornerData = true
               }
               if (powerRptText) {
                 const parsedPower = parsePowerRpt(powerRptText)
-                cornerData = { ...(cornerData || {}), ...parsedPower }
+                cornerData = { ...cornerData, ...parsedPower }
+                hasCornerData = true
               }
               if (qorRptText) {
                 const parsedQor = parseQorSummaryRpt(qorRptText)
-                cornerData = { ...(cornerData || {}), ...parsedQor }
+                cornerData = { ...cornerData, ...parsedQor }
+                hasCornerData = true
               }
 
-              if (cornerData) {
+              if (hasCornerData) {
                 cornersMap[corner] = cornerData
               }
             }),
@@ -475,7 +577,7 @@ export function useDesignReportExport({
             stepMetrics[targetKey] = {
               ...existing,
               corners: {
-                ...((existing.corners as Record<string, unknown>) || {}),
+                ...(existing.corners as Record<string, unknown>),
                 ...cornersMap,
               },
             }

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.test.ts
@@ -800,4 +800,27 @@ describe('useSignoffPackageExport export action', () => {
 
     expect(mounted.showToast).not.toHaveBeenCalled()
   })
+
+  it('propagates summary write failure and shows error toast when writeProjectTextFile rejects', async () => {
+    const api = createApi()
+    api.writeProjectTextFile.mockRejectedValueOnce(
+      new Error('Refusing to grant access outside current project root'),
+    )
+    const mounted = mountComposable()
+    scope = mounted.scope
+    await vi.waitFor(() => expect(api.readFlow).toHaveBeenCalledTimes(1))
+
+    await openReviewAndConfirm(mounted)
+
+    expect(api.exportSignoff).not.toHaveBeenCalled()
+    expect(mounted.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        summary: 'Failed to Export Signoff Package',
+        detail: expect.stringContaining(
+          'Refusing to grant access outside current project root',
+        ),
+      }),
+    )
+  })
 })

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.test.ts
@@ -549,30 +549,35 @@ describe('useSignoffPackageExport export action', () => {
       filters: [{ name: 'Signoff Package', extensions: ['tar.gz'] }],
     })
     expect(api.exportSignoff).toHaveBeenCalledWith({
+      additionalFiles: expect.arrayContaining([
+        expect.objectContaining({
+          archivePath: 'design_summaries/rocket_core_design_summary.tex',
+          content: expect.stringContaining('\\begin{table}'),
+        }),
+        expect.objectContaining({
+          archivePath: 'design_summaries/rocket_core_design_summary.md',
+          content: expect.stringContaining('# Design Summary Report: rocket_core'),
+        }),
+        expect.objectContaining({
+          archivePath: 'design_summaries/rocket_core_design_summary.typ',
+          content: expect.stringContaining('#figure('),
+        }),
+        expect.objectContaining({
+          archivePath: 'design_summaries/rocket_core_design_summary.csv',
+          content: expect.stringContaining('Category,Metric,Value'),
+        }),
+        expect.objectContaining({
+          archivePath: 'design_summaries/rocket_core_design_summary.txt',
+          content: expect.stringContaining('ECOS STUDIO — DESIGN SUMMARY'),
+        }),
+      ]),
       outputPath: '/tmp/rocket package.tar.gz',
       workspaceHandle: 'workspace-handle-1',
     })
-    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
-      '/workspaces/active path/rocket_core_design_summary.tex',
-      expect.stringContaining('\\begin{table}'),
-    )
-    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
-      '/workspaces/active path/rocket_core_design_summary.md',
-      expect.stringContaining('# Design Summary Report: rocket_core'),
-    )
-    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
-      '/workspaces/active path/rocket_core_design_summary.typ',
-      expect.stringContaining('#figure('),
-    )
-    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
-      '/workspaces/active path/rocket_core_design_summary.csv',
-      expect.stringContaining('Category,Metric,Value'),
-    )
-    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
-      '/workspaces/active path/rocket_core_design_summary.txt',
-      expect.stringContaining('ECOS STUDIO — DESIGN SUMMARY'),
-    )
-    expect(api.writeProjectTextFile).toHaveBeenCalledTimes(5)
+    expect(
+      (api.exportSignoff.mock.calls[0]![0] as Record<string, unknown>).additionalFiles,
+    ).toHaveLength(5)
+    expect(api.writeProjectTextFile).not.toHaveBeenCalled()
     expect(mounted.showToast).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'success',
@@ -801,10 +806,10 @@ describe('useSignoffPackageExport export action', () => {
     expect(mounted.showToast).not.toHaveBeenCalled()
   })
 
-  it('propagates summary write failure and shows error toast when writeProjectTextFile rejects', async () => {
+  it('propagates archive append failure and shows error toast when exportSignoff rejects with additionalFiles', async () => {
     const api = createApi()
-    api.writeProjectTextFile.mockRejectedValueOnce(
-      new Error('Refusing to grant access outside current project root'),
+    api.exportSignoff.mockRejectedValueOnce(
+      new Error('Failed to append files to archive: permission denied'),
     )
     const mounted = mountComposable()
     scope = mounted.scope
@@ -812,13 +817,17 @@ describe('useSignoffPackageExport export action', () => {
 
     await openReviewAndConfirm(mounted)
 
-    expect(api.exportSignoff).not.toHaveBeenCalled()
+    expect(api.exportSignoff).toHaveBeenCalledWith(
+      expect.objectContaining({
+        additionalFiles: expect.any(Array),
+      }),
+    )
     expect(mounted.showToast).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         summary: 'Failed to Export Signoff Package',
         detail: expect.stringContaining(
-          'Refusing to grant access outside current project root',
+          'Failed to append files to archive: permission denied',
         ),
       }),
     )

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.test.ts
@@ -117,25 +117,33 @@ function createApi() {
   const setActionEnabled = vi.fn().mockResolvedValue(undefined)
   const readFlow = vi.fn().mockResolvedValue(successfulFlow())
   const readParameters = vi.fn().mockResolvedValue({ Design: 'chip_top' })
+  const readHome = vi.fn().mockResolvedValue({})
+  const getVersions = vi.fn().mockResolvedValue({})
+  const writeProjectTextFile = vi.fn().mockResolvedValue(undefined)
   const inspectSignoff = vi.fn().mockResolvedValue(readyReview())
   const saveFile = vi.fn().mockResolvedValue('/exports/chip_top_signoff_package.tar.gz')
   const exportSignoff = vi.fn(async (request: { outputPath: string }) => ({
     outputPath: request.outputPath,
   }))
   testState.api = {
+    app: { getVersions },
     menu: { setActionEnabled },
-    workspaceResources: { readFlow, readParameters },
+    workspace: { writeProjectTextFile },
+    workspaceResources: { readFlow, readParameters, readHome },
     dialog: { saveFile },
     ecc: { workspace: { exportSignoff, inspectSignoff } },
   } as unknown as DesktopApi
 
   return {
     exportSignoff,
+    getVersions,
     inspectSignoff,
     readFlow,
+    readHome,
     readParameters,
     saveFile,
     setActionEnabled,
+    writeProjectTextFile,
   }
 }
 
@@ -544,6 +552,7 @@ describe('useSignoffPackageExport export action', () => {
       outputPath: '/tmp/rocket package.tar.gz',
       workspaceHandle: 'workspace-handle-1',
     })
+    expect(api.writeProjectTextFile).toHaveBeenCalledTimes(4)
     expect(mounted.showToast).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'success',

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.test.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.test.ts
@@ -552,7 +552,27 @@ describe('useSignoffPackageExport export action', () => {
       outputPath: '/tmp/rocket package.tar.gz',
       workspaceHandle: 'workspace-handle-1',
     })
-    expect(api.writeProjectTextFile).toHaveBeenCalledTimes(4)
+    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
+      '/workspaces/active path/rocket_core_design_summary.tex',
+      expect.stringContaining('\\begin{table}'),
+    )
+    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
+      '/workspaces/active path/rocket_core_design_summary.md',
+      expect.stringContaining('# Design Summary Report: rocket_core'),
+    )
+    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
+      '/workspaces/active path/rocket_core_design_summary.typ',
+      expect.stringContaining('#figure('),
+    )
+    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
+      '/workspaces/active path/rocket_core_design_summary.csv',
+      expect.stringContaining('Category,Metric,Value'),
+    )
+    expect(api.writeProjectTextFile).toHaveBeenCalledWith(
+      '/workspaces/active path/rocket_core_design_summary.txt',
+      expect.stringContaining('ECOS STUDIO — DESIGN SUMMARY'),
+    )
+    expect(api.writeProjectTextFile).toHaveBeenCalledTimes(5)
     expect(mounted.showToast).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'success',

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
@@ -358,68 +358,57 @@ export function useSignoffPackageExport({
         return
       }
 
-      try {
-        const flow = await api.workspaceResources.readFlow().catch(() => null)
-        const home = await api.workspaceResources.readHome().catch(() => null)
-        const versions = await api.app
-          .getVersions()
-          .catch(() => ({ gui: '', ecc: '', eccTools: '' }))
-        const reportData = extractDesignReportData({
-          workspacePath: workspace.workspacePath,
-          parameters: isRecord(parameters) ? parameters : undefined,
-          flow,
-          homeData: isRecord(home) ? home : undefined,
-          versionInfo: isRecord(versions)
-            ? {
-                gui: typeof versions.gui === 'string' ? versions.gui : undefined,
-                ecc: typeof versions.ecc === 'string' ? versions.ecc : undefined,
-                eccTools:
-                  typeof versions.eccTools === 'string' ? versions.eccTools : undefined,
-              }
-            : undefined,
-        })
+      const flow = await api.workspaceResources.readFlow().catch(() => null)
+      const home = await api.workspaceResources.readHome().catch(() => null)
+      const versions = await api.app
+        .getVersions()
+        .catch(() => ({ gui: '', ecc: '', eccTools: '' }))
+      const reportData = extractDesignReportData({
+        workspacePath: workspace.workspacePath,
+        parameters: isRecord(parameters) ? parameters : undefined,
+        flow,
+        homeData: isRecord(home) ? home : undefined,
+        versionInfo: isRecord(versions)
+          ? {
+              gui: typeof versions.gui === 'string' ? versions.gui : undefined,
+              ecc: typeof versions.ecc === 'string' ? versions.ecc : undefined,
+              eccTools:
+                typeof versions.eccTools === 'string' ? versions.eccTools : undefined,
+            }
+          : undefined,
+      })
 
-        const reportFormats: DesignReportFormat[] = [
-          'latex',
-          'markdown',
-          'typst',
-          'csv',
-          'text',
-        ]
-        const formatExtMap: Record<DesignReportFormat, string> = {
-          latex: 'tex',
-          markdown: 'md',
-          typst: 'typ',
-          csv: 'csv',
-          text: 'txt',
-        }
-        await Promise.all(
-          reportFormats.map(async (fmt) => {
-            const ext = formatExtMap[fmt]
-            const content = generateDesignReport(reportData, fmt, {
-              includeMultiCorner: true,
-              includeStageBreakdown: true,
-              includeVerificationBreakdown: true,
-              latexStandalone: true,
-              typstStandalone: true,
-            })
-            const summaryPath = joinLocalPath(
-              workspace.workspacePath,
-              `${design}_design_summary.${ext}`,
-            )
-            await api.workspace
-              .writeProjectTextFile(summaryPath, content)
-              .catch((err) => {
-                console.warn(`[signoff-export] Failed to write ${summaryPath}:`, err)
-              })
-          }),
-        )
-      } catch (repErr) {
-        console.warn(
-          '[signoff-export] Failed to generate signoff design summary reports:',
-          repErr,
-        )
+      const reportFormats: DesignReportFormat[] = [
+        'latex',
+        'markdown',
+        'typst',
+        'csv',
+        'text',
+      ]
+      const formatExtMap: Record<DesignReportFormat, string> = {
+        latex: 'tex',
+        markdown: 'md',
+        typst: 'typ',
+        csv: 'csv',
+        text: 'txt',
       }
+      await Promise.all(
+        reportFormats.map(async (fmt) => {
+          const ext = formatExtMap[fmt]
+          const content = generateDesignReport(reportData, fmt, {
+            includeMultiCorner: true,
+            includeStageBreakdown: true,
+            includeVerificationBreakdown: true,
+            latexStandalone: true,
+            typstStandalone: true,
+          })
+          const summaryPath = joinLocalPath(
+            workspace.workspacePath,
+            `${design}_design_summary.${ext}`,
+          )
+          await api.workspace.writeProjectTextFile(summaryPath, content)
+        }),
+      )
 
       const result = await api.ecc.workspace.exportSignoff({
         outputPath,

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
@@ -367,7 +367,9 @@ export function useSignoffPackageExport({
       try {
         const flow = await api.workspaceResources.readFlow().catch(() => null)
         const home = await api.workspaceResources.readHome().catch(() => null)
-        const versions = await api.app.getVersions().catch(() => ({ gui: '', ecc: '', eccTools: '' }))
+        const versions = await api.app
+          .getVersions()
+          .catch(() => ({ gui: '', ecc: '', eccTools: '' }))
         const reportData = extractDesignReportData({
           workspacePath: workspace.workspacePath,
           parameters: isRecord(parameters) ? parameters : undefined,
@@ -377,7 +379,8 @@ export function useSignoffPackageExport({
             ? {
                 gui: typeof versions.gui === 'string' ? versions.gui : undefined,
                 ecc: typeof versions.ecc === 'string' ? versions.ecc : undefined,
-                eccTools: typeof versions.eccTools === 'string' ? versions.eccTools : undefined,
+                eccTools:
+                  typeof versions.eccTools === 'string' ? versions.eccTools : undefined,
               }
             : undefined,
         })
@@ -399,14 +402,22 @@ export function useSignoffPackageExport({
               includeVerificationBreakdown: true,
               latexStandalone: true,
             })
-            const summaryPath = joinLocalPath(exportDir, `${design}_design_summary.${ext}`)
-            await api.workspace.writeProjectTextFile(summaryPath, content).catch((err) => {
-              console.warn(`[signoff-export] Failed to write ${summaryPath}:`, err)
-            })
+            const summaryPath = joinLocalPath(
+              exportDir,
+              `${design}_design_summary.${ext}`,
+            )
+            await api.workspace
+              .writeProjectTextFile(summaryPath, content)
+              .catch((err) => {
+                console.warn(`[signoff-export] Failed to write ${summaryPath}:`, err)
+              })
           }),
         )
       } catch (repErr) {
-        console.warn('[signoff-export] Failed to generate signoff design summary reports:', repErr)
+        console.warn(
+          '[signoff-export] Failed to generate signoff design summary reports:',
+          repErr,
+        )
       }
 
       showToast({

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
@@ -1,7 +1,10 @@
 import { computed, onUnmounted, ref, watch, type Ref } from 'vue'
 import {
   appMenuActionIds,
+  extractDesignReportData,
+  generateDesignReport,
   joinLocalPath,
+  type DesignReportFormat,
   type EccWorkspaceInspectSignoffResult,
 } from '@ecos-studio/shared'
 import { getDesktopApi } from '@/platform/desktop'
@@ -361,10 +364,55 @@ export function useSignoffPackageExport({
       })
       if (!isActiveWorkspace(workspace.workspacePath, workspace.workspaceHandle)) return
 
+      try {
+        const flow = await api.workspaceResources.readFlow().catch(() => null)
+        const home = await api.workspaceResources.readHome().catch(() => null)
+        const versions = await api.app.getVersions().catch(() => ({ gui: '', ecc: '', eccTools: '' }))
+        const reportData = extractDesignReportData({
+          workspacePath: workspace.workspacePath,
+          parameters: isRecord(parameters) ? parameters : undefined,
+          flow,
+          homeData: isRecord(home) ? home : undefined,
+          versionInfo: isRecord(versions)
+            ? {
+                gui: typeof versions.gui === 'string' ? versions.gui : undefined,
+                ecc: typeof versions.ecc === 'string' ? versions.ecc : undefined,
+                eccTools: typeof versions.eccTools === 'string' ? versions.eccTools : undefined,
+              }
+            : undefined,
+        })
+
+        const reportFormats: DesignReportFormat[] = ['latex', 'markdown', 'csv', 'text']
+        const formatExtMap: Record<DesignReportFormat, string> = {
+          latex: 'tex',
+          markdown: 'md',
+          csv: 'csv',
+          text: 'txt',
+        }
+        const exportDir = projectPathForWorkspace(outputPath)
+        await Promise.all(
+          reportFormats.map(async (fmt) => {
+            const ext = formatExtMap[fmt]
+            const content = generateDesignReport(reportData, fmt, {
+              includeMultiCorner: true,
+              includeStageBreakdown: true,
+              includeVerificationBreakdown: true,
+              latexStandalone: true,
+            })
+            const summaryPath = joinLocalPath(exportDir, `${design}_design_summary.${ext}`)
+            await api.workspace.writeProjectTextFile(summaryPath, content).catch((err) => {
+              console.warn(`[signoff-export] Failed to write ${summaryPath}:`, err)
+            })
+          }),
+        )
+      } catch (repErr) {
+        console.warn('[signoff-export] Failed to generate signoff design summary reports:', repErr)
+      }
+
       showToast({
         severity: 'success',
         summary: 'Signoff Package Exported',
-        detail: `Saved to ${result.outputPath}`,
+        detail: `Saved package and design summaries to ${result.outputPath}`,
       })
     } catch (error) {
       if (!isActiveWorkspace(workspace.workspacePath, workspace.workspaceHandle)) return

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
@@ -358,12 +358,6 @@ export function useSignoffPackageExport({
         return
       }
 
-      const result = await api.ecc.workspace.exportSignoff({
-        outputPath,
-        workspaceHandle: workspace.workspaceHandle,
-      })
-      if (!isActiveWorkspace(workspace.workspacePath, workspace.workspaceHandle)) return
-
       try {
         const flow = await api.workspaceResources.readFlow().catch(() => null)
         const home = await api.workspaceResources.readHome().catch(() => null)
@@ -385,14 +379,20 @@ export function useSignoffPackageExport({
             : undefined,
         })
 
-        const reportFormats: DesignReportFormat[] = ['latex', 'markdown', 'csv', 'text']
+        const reportFormats: DesignReportFormat[] = [
+          'latex',
+          'markdown',
+          'typst',
+          'csv',
+          'text',
+        ]
         const formatExtMap: Record<DesignReportFormat, string> = {
           latex: 'tex',
           markdown: 'md',
+          typst: 'typ',
           csv: 'csv',
           text: 'txt',
         }
-        const exportDir = projectPathForWorkspace(outputPath)
         await Promise.all(
           reportFormats.map(async (fmt) => {
             const ext = formatExtMap[fmt]
@@ -401,9 +401,10 @@ export function useSignoffPackageExport({
               includeStageBreakdown: true,
               includeVerificationBreakdown: true,
               latexStandalone: true,
+              typstStandalone: true,
             })
             const summaryPath = joinLocalPath(
-              exportDir,
+              workspace.workspacePath,
               `${design}_design_summary.${ext}`,
             )
             await api.workspace
@@ -419,6 +420,12 @@ export function useSignoffPackageExport({
           repErr,
         )
       }
+
+      const result = await api.ecc.workspace.exportSignoff({
+        outputPath,
+        workspaceHandle: workspace.workspaceHandle,
+      })
+      if (!isActiveWorkspace(workspace.workspacePath, workspace.workspaceHandle)) return
 
       showToast({
         severity: 'success',

--- a/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
+++ b/ecos/gui/apps/renderer/src/composables/useSignoffPackageExport.ts
@@ -6,6 +6,7 @@ import {
   joinLocalPath,
   type DesignReportFormat,
   type EccWorkspaceInspectSignoffResult,
+  type SignoffAdditionalFile,
 } from '@ecos-studio/shared'
 import { getDesktopApi } from '@/platform/desktop'
 
@@ -392,25 +393,23 @@ export function useSignoffPackageExport({
         csv: 'csv',
         text: 'txt',
       }
-      await Promise.all(
-        reportFormats.map(async (fmt) => {
-          const ext = formatExtMap[fmt]
-          const content = generateDesignReport(reportData, fmt, {
-            includeMultiCorner: true,
-            includeStageBreakdown: true,
-            includeVerificationBreakdown: true,
-            latexStandalone: true,
-            typstStandalone: true,
-          })
-          const summaryPath = joinLocalPath(
-            workspace.workspacePath,
-            `${design}_design_summary.${ext}`,
-          )
-          await api.workspace.writeProjectTextFile(summaryPath, content)
-        }),
-      )
+      const additionalFiles: SignoffAdditionalFile[] = reportFormats.map((fmt) => {
+        const ext = formatExtMap[fmt]
+        const content = generateDesignReport(reportData, fmt, {
+          includeMultiCorner: true,
+          includeStageBreakdown: true,
+          includeVerificationBreakdown: true,
+          latexStandalone: true,
+          typstStandalone: true,
+        })
+        return {
+          archivePath: `design_summaries/${design}_design_summary.${ext}`,
+          content,
+        }
+      })
 
       const result = await api.ecc.workspace.exportSignoff({
+        additionalFiles,
         outputPath,
         workspaceHandle: workspace.workspaceHandle,
       })

--- a/ecos/gui/packages/shared/src/contracts/designReport.ts
+++ b/ecos/gui/packages/shared/src/contracts/designReport.ts
@@ -1,4 +1,4 @@
-export type DesignReportFormat = 'latex' | 'markdown' | 'csv' | 'text'
+export type DesignReportFormat = 'latex' | 'markdown' | 'csv' | 'text' | 'typst'
 
 export interface DesignReportWarning {
   code: string
@@ -180,5 +180,6 @@ export interface DesignReportExportOptions {
   latexStandalone?: boolean
   latexUseBooktabs?: boolean
   latexUseSiunitx?: boolean
+  typstStandalone?: boolean
   title?: string
 }

--- a/ecos/gui/packages/shared/src/contracts/designReport.ts
+++ b/ecos/gui/packages/shared/src/contracts/designReport.ts
@@ -1,0 +1,184 @@
+export type DesignReportFormat = 'latex' | 'markdown' | 'csv' | 'text'
+
+export interface DesignReportWarning {
+  code: string
+  message: string
+  severity: 'warn' | 'error' | 'info'
+}
+
+export interface DesignInfo {
+  designName: string
+  workspaceName: string
+  workspacePath: string
+  pdk: string
+  pdkVersion: string | null
+  pdkCommit: string | null
+  eccTool: string | null
+  eccVersion: string | null
+  ecosStudioVersion: string | null
+  toolVersions: Record<string, string>
+  gitCommit: string | null
+  runId: string | null
+  timestamp: string
+  generatedAt: string
+}
+
+export interface PhysicalMetrics {
+  dieAreaUm2: number | null
+  dieAreaMm2: number | null
+  coreAreaUm2: number | null
+  coreAreaMm2: number | null
+  coreUtilizationPct: number | null
+  stdCellAreaUm2: number | null
+  macroAreaUm2: number | null
+  macroCount: number | null
+  instanceCount: number | null
+  sequentialCellCount: number | null
+  combinationalCellCount: number | null
+  ioPinCount: number | null
+  netCount: number | null
+}
+
+export interface TimingMetrics {
+  targetClockPeriodNs: number | null
+  targetFrequencyMhz: number | null
+  fmaxMhz: number | null
+  setupWnsNs: number | null
+  setupTnsNs: number | null
+  holdWnsNs: number | null
+  holdTnsNs: number | null
+  violatingEndpointsSetup: number | null
+  violatingEndpointsHold: number | null
+  slewViolations: number | null
+  capViolations: number | null
+  fanoutViolations: number | null
+  criticalPathDelayNs: number | null
+}
+
+export interface CornerTimingRecord {
+  corner: string
+  processCorner: string | null
+  voltageV: number | null
+  temperatureC: number | null
+  rcCorner: string | null
+  setupWnsNs: number | null
+  setupTnsNs: number | null
+  holdWnsNs: number | null
+  holdTnsNs: number | null
+  violatingEndpointsSetup: number | null
+  violatingEndpointsHold: number | null
+  status: 'pass' | 'fail' | 'warn' | 'unknown'
+}
+
+export interface ClockMetrics {
+  clockSkewPs: number | null
+  clockLatencyNs: number | null
+  clockWirelengthUm: number | null
+  clockMaxWirelengthUm: number | null
+  clockBufferCount: number | null
+  clockInverterCount: number | null
+  clockTotalBuffers: number | null
+  clockBufferAreaUm2: number | null
+  clockPathMaxBuffer: number | null
+  clockPathMinBuffer: number | null
+  clockNetsCount: number | null
+  clockTreeLevels: number | null
+  clockCellCount: number | null
+}
+
+export interface RoutingMetrics {
+  hpwlUm: number | null
+  estimatedWirelengthUm: number | null
+  routedWirelengthUm: number | null
+  viaCount: number | null
+  routingCompletionPct: number | null
+  routeDrcCount: number | null
+}
+
+export interface CongestionMetrics {
+  globalOverflowTotal: number | null
+  globalOverflowPct: number | null
+  maxOverflow: number | null
+  horizontalCongestionPct: number | null
+  verticalCongestionPct: number | null
+  hotspotsCount: number | null
+}
+
+export interface PowerMetrics {
+  totalPowerMw: number | null
+  dynamicPowerMw: number | null
+  switchingPowerMw: number | null
+  internalPowerMw: number | null
+  leakagePowerMw: number | null
+  voltageV: number | null
+  temperatureC: number | null
+  corner: string | null
+  activityMethod: string | null
+}
+
+export interface VerificationMetrics {
+  drcCount: number | null
+  drcStatus: 'clean' | 'violations' | 'unrun'
+  lvsStatus: 'matched' | 'mismatch' | 'unrun'
+  lvsMismatchCount: number | null
+  antennaViolations: number | null
+  ercViolations: number | null
+  floatingNetsCount: number | null
+  unconnectedPinsCount: number | null
+}
+
+export interface StageExecutionRecord {
+  stage: string
+  tool: string
+  runtimeSeconds: number | null
+  runtimeFormatted: string | null
+  peakMemoryMb: number | null
+  state: string
+}
+
+export interface ExecutionMetrics {
+  totalRuntimeSeconds: number | null
+  totalRuntimeFormatted: string | null
+  peakMemoryMb: number | null
+  stages: StageExecutionRecord[]
+}
+
+export interface EvidenceProvenanceRecord {
+  category: string
+  metric: string
+  value: string | number | boolean | null
+  unit: string
+  status: string
+  stage: string
+  corner: string | null
+  tool: string
+  sourceMetricId: string
+  runId: string
+  timestamp: string
+}
+
+export interface DesignReportData {
+  design: DesignInfo
+  physical: PhysicalMetrics
+  timing: TimingMetrics
+  multiCornerTiming: CornerTimingRecord[]
+  clock: ClockMetrics
+  routing: RoutingMetrics
+  congestion: CongestionMetrics
+  power: PowerMetrics
+  verification: VerificationMetrics
+  execution: ExecutionMetrics
+  provenance: EvidenceProvenanceRecord[]
+  warnings: DesignReportWarning[]
+}
+
+export interface DesignReportExportOptions {
+  includeMultiCorner?: boolean
+  includeStageBreakdown?: boolean
+  includeVerificationBreakdown?: boolean
+  includeProvenance?: boolean
+  latexStandalone?: boolean
+  latexUseBooktabs?: boolean
+  latexUseSiunitx?: boolean
+  title?: string
+}

--- a/ecos/gui/packages/shared/src/contracts/desktopApi.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopApi.ts
@@ -84,6 +84,7 @@ export interface DesktopSaveFileDialogOptions {
   defaultPath?: string
   filters?: DesktopFileDialogFilter[]
   ensureDirectory?: boolean
+  content?: string
 }
 
 export interface DesktopRtlSourceDialogOptions {

--- a/ecos/gui/packages/shared/src/contracts/desktopEvents.ts
+++ b/ecos/gui/packages/shared/src/contracts/desktopEvents.ts
@@ -16,6 +16,8 @@ export const desktopMenuEventIds = {
   manageDesignFiles: 'manage_design_files',
   reconfigureWorkspace: 'reconfigure_workspace',
   exportSignoffPackage: 'export_signoff_package',
+  exportDesignSummary: 'export_design_summary',
+  exportDesignMetrics: 'export_design_summary',
 } as const
 
 export type DesktopMenuEventId =
@@ -33,6 +35,8 @@ export const appMenuActionIds = {
   manageDesignFiles: desktopMenuEventIds.manageDesignFiles,
   reconfigureWorkspace: desktopMenuEventIds.reconfigureWorkspace,
   exportSignoffPackage: desktopMenuEventIds.exportSignoffPackage,
+  exportDesignSummary: desktopMenuEventIds.exportDesignSummary,
+  exportDesignMetrics: desktopMenuEventIds.exportDesignSummary,
 } as const
 
 export type AppMenuAction = (typeof appMenuActionIds)[keyof typeof appMenuActionIds]

--- a/ecos/gui/packages/shared/src/contracts/eccRuntime.ts
+++ b/ecos/gui/packages/shared/src/contracts/eccRuntime.ts
@@ -55,7 +55,13 @@ export interface EccWorkspaceSyncConfigRequest extends EccWorkspaceHandleRequest
   configPath: string
 }
 
+export interface SignoffAdditionalFile {
+  archivePath: string
+  content: string
+}
+
 export interface EccWorkspaceExportSignoffRequest extends EccWorkspaceHandleRequest {
+  additionalFiles?: SignoffAdditionalFile[]
   outputPath: string
 }
 

--- a/ecos/gui/packages/shared/src/index.ts
+++ b/ecos/gui/packages/shared/src/index.ts
@@ -292,4 +292,3 @@ export {
   formatTextReport,
   generateDesignReport,
 } from './utils/designReportFormatters/index.ts'
-

--- a/ecos/gui/packages/shared/src/index.ts
+++ b/ecos/gui/packages/shared/src/index.ts
@@ -290,5 +290,6 @@ export {
   formatLatexReport,
   formatMarkdownReport,
   formatTextReport,
+  formatTypstReport,
   generateDesignReport,
 } from './utils/designReportFormatters/index.ts'

--- a/ecos/gui/packages/shared/src/index.ts
+++ b/ecos/gui/packages/shared/src/index.ts
@@ -85,6 +85,7 @@ export type {
   EccWorkspaceCreateResult,
   EccWorkspaceExportSignoffRequest,
   EccWorkspaceExportSignoffResult,
+  SignoffAdditionalFile,
   EccWorkspaceHandleRequest,
   EccWorkspaceHomeResult,
   EccWorkspaceInspectSignoffResult,

--- a/ecos/gui/packages/shared/src/index.ts
+++ b/ecos/gui/packages/shared/src/index.ts
@@ -256,3 +256,40 @@ export type {
   ProjectManifestWorkspaceRegistrationInput,
   ProjectManifestWorkspaceStatus,
 } from './utils/projectManifest.ts'
+export type {
+  ClockMetrics,
+  CongestionMetrics,
+  CornerTimingRecord,
+  DesignInfo,
+  DesignReportData,
+  DesignReportExportOptions,
+  DesignReportFormat,
+  DesignReportWarning,
+  EvidenceProvenanceRecord,
+  ExecutionMetrics,
+  PhysicalMetrics,
+  PowerMetrics,
+  RoutingMetrics,
+  StageExecutionRecord,
+  TimingMetrics,
+  VerificationMetrics,
+} from './contracts/designReport.ts'
+export {
+  canonicalizeStageName,
+  extractDesignReportData,
+  formatDuration,
+  parsePowerRpt,
+  parseQorSummaryRpt,
+  parseRuntimeSeconds,
+  type ExtractDesignReportInput,
+  type ParsedPowerMetrics,
+  type ParsedQorSummaryMetrics,
+} from './utils/designReportExtract.ts'
+export {
+  formatCsvReport,
+  formatLatexReport,
+  formatMarkdownReport,
+  formatTextReport,
+  generateDesignReport,
+} from './utils/designReportFormatters/index.ts'
+

--- a/ecos/gui/packages/shared/src/utils/designReportExtract.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportExtract.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalizeStageName,
+  extractDesignReportData,
+  formatDuration,
+  parsePowerRpt,
+  parseQorSummaryRpt,
+  parseRuntimeSeconds,
+} from './designReportExtract.ts'
+
+describe('designReportExtract', () => {
+  describe('helper functions', () => {
+    it('canonicalizes various stage name spellings', () => {
+      expect(canonicalizeStageName('synthesis')).toBe('Synth')
+      expect(canonicalizeStageName('Synthesis_yosys')).toBe('Synth')
+      expect(canonicalizeStageName('Floorplan_ecc')).toBe('Floor')
+      expect(canonicalizeStageName('place_dreamplace')).toBe('Place')
+      expect(canonicalizeStageName('CTS_ecc')).toBe('CTS')
+      expect(canonicalizeStageName('route_ecc')).toBe('Route')
+      expect(canonicalizeStageName('drc_ecc')).toBe('DRC')
+      expect(canonicalizeStageName('lvs_ecc')).toBe('LVS')
+      expect(canonicalizeStageName('sta_ecc')).toBe('STA')
+      expect(canonicalizeStageName('Harden_ecc')).toBe('Harden')
+      expect(canonicalizeStageName('CustomStep')).toBe('CustomStep')
+    })
+
+    it('parses runtime strings and numbers', () => {
+      expect(parseRuntimeSeconds('0:1:6')).toBe(66)
+      expect(parseRuntimeSeconds('1:30:15')).toBe(5415)
+      expect(parseRuntimeSeconds('45')).toBe(45)
+      expect(parseRuntimeSeconds(120)).toBe(120)
+      expect(parseRuntimeSeconds('')).toBeNull()
+      expect(parseRuntimeSeconds(null)).toBeNull()
+    })
+
+    it('formats duration in seconds to human readable strings', () => {
+      expect(formatDuration(45)).toBe('45s')
+      expect(formatDuration(125)).toBe('2m 5s')
+      expect(formatDuration(3665)).toBe('1h 1m 5s')
+      expect(formatDuration(null)).toBeNull()
+      expect(formatDuration(-10)).toBeNull()
+    })
+
+    it('parses power.rpt text into structured power metrics', () => {
+      const samplePowerRpt = `
+Design : gcd
+Operating Conditions: ICS_N55_H7BL_ss_mos_Cworst_1.08_-40
+Global Operating Voltage = 1.08
+
+Dynamic Power Units = 1mW
+Leakage Power Units = 1nW
+
+Cell Internal Power  =   20.9663 uW
+Net Switching Power  =    6.3762 uW
+Total Dynamic Power  =   27.3425 uW
+Cell Leakage Power   =    4.2913 nW
+
+--------------------------------------------------------------------------------------------------
+Total          2.0966e-02 mW     6.3762e-03 mW         4.2913 nW     2.7347e-02 mW
+`
+      const parsed = parsePowerRpt(samplePowerRpt)
+      expect(parsed.voltageV).toBe(1.08)
+      expect(parsed.internalPowerMw).toBeCloseTo(0.020966, 5)
+      expect(parsed.switchingPowerMw).toBeCloseTo(0.006376, 5)
+      expect(parsed.dynamicPowerMw).toBeCloseTo(0.027342, 5)
+      expect(parsed.leakagePowerMw).toBeCloseTo(0.00000429, 7)
+      expect(parsed.totalPowerMw).toBeCloseTo(0.027347, 5)
+    })
+
+    it('parses qor_summary.rpt text into structured timing metrics', () => {
+      const sampleQorRpt = `
+Path Group                  WNS        TNS     NVP      FREQ      WNS(H)     TNS(H)  NVP(H)
+-------------------------------------------------------------------------------------------
+clk                      16.882        0.0       0     321MHz      0.256        0.0       0
+-------------------------------------------------------------------------------------------
+Summary                  16.882        0.0       0     321MHz      0.256        0.0       0
+-------------------------------------------------------------------------------------------
+`
+      const parsed = parseQorSummaryRpt(sampleQorRpt)
+      expect(parsed.wns).toBe(16.882)
+      expect(parsed.tns).toBe(0.0)
+      expect(parsed.nvp).toBe(0)
+      expect(parsed.frequencyMhz).toBe(321)
+      expect(parsed.holdWns).toBe(0.256)
+      expect(parsed.holdTns).toBe(0.0)
+      expect(parsed.holdNvp).toBe(0)
+    })
+  })
+
+  describe('extractDesignReportData', () => {
+    it('extracts complete flow metrics correctly across all stages and parses Schema 3 format', () => {
+      const result = extractDesignReportData({
+        workspacePath: '/projects/gcd/ws_001',
+        workspaceName: 'gcd_run1',
+        parameters: {
+          Design: 'gcd',
+          PDK: 'sky130hd',
+          PDK_VERSION: 'v0.12.0',
+          PDK_COMMIT: '1234567890abcdef',
+          ECC_TOOL: 'ecc-fe',
+          ECC_VERSION: '1.4.2',
+          ECOS_STUDIO_VERSION: '0.1.0-alpha.8',
+          GIT_COMMIT: 'abcdef1234567890',
+          CLOCK_PERIOD: 10.0,
+          POWER_CORNER: 'nom_tt_025C_1v80',
+        },
+        flow: {
+          timestamp: '2026-08-25T12:00:00Z',
+          steps: [
+            { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:0:30', 'peak memory (mb)': 120 },
+            { name: 'Floorplan_ecc', tool: 'OpenROAD', state: 'Success', runtime: '0:0:15', 'peak memory (mb)': 200 },
+            { name: 'place_dreamplace', tool: 'DreamPlace', state: 'Success', runtime: '0:1:00', 'peak memory (mb)': 450 },
+            { name: 'CTS_ecc', tool: 'OpenROAD', state: 'Success', runtime: '0:0:45', 'peak memory (mb)': 310 },
+            { name: 'route_ecc', tool: 'OpenROAD', state: 'Success', runtime: '0:2:30', 'peak memory (mb)': 600 },
+            { name: 'sta_ecc', tool: 'OpenSTA', state: 'Success', runtime: '0:0:20', 'peak memory (mb)': 280 },
+            { name: 'drc_ecc', tool: 'KLayout', state: 'Success', runtime: '0:0:10', 'peak memory (mb)': 150 },
+            { name: 'lvs_ecc', tool: 'Netgen', state: 'Success', runtime: '0:0:10', 'peak memory (mb)': 140 },
+            { name: 'Harden_ecc', tool: 'OpenROAD', state: 'Success', runtime: '0:0:40', 'peak memory (mb)': 520 },
+          ],
+        },
+        stepMetrics: {
+          Synth: {
+            schema_version: 3,
+            metrics: [
+              { id: 'sequential_cells', value: 32 },
+              { id: 'combinational_cells', value: 540 },
+              { id: 'instances', value: 572 },
+            ],
+          },
+          Floor: {
+            'Design Layout': {
+              die_area: 100000,
+              core_area: 80000,
+            },
+            'Design Statis': {
+              num_iopins: 54,
+            },
+            macro_count: 0,
+            macro_area: 0,
+          },
+          Place: {
+            utilization: 48.5,
+            hpwl: 125000,
+          },
+          CTS: {
+            clock_skew: 42.5,
+            clock_latency: 1.25,
+            clock_buffer_count: 12,
+            clock_inverter_count: 8,
+            clock_tree_levels: 3,
+            clock_wirelength: 4500,
+          },
+          Route: {
+            'Nets': {
+              wire_len: 158000,
+              num_via: 3200,
+            },
+            routing_completion: 100,
+            global_overflow: 0,
+            global_overflow_pct: 0,
+            max_overflow: 0,
+            net_count: 590,
+          },
+          STA: {
+            clock_period: 10.0,
+            setup_wns: 0.85,
+            setup_tns: 0.0,
+            hold_wns: 0.12,
+            hold_tns: 0.0,
+            violating_endpoints_setup: 0,
+            violating_endpoints_hold: 0,
+            slew_violations: 0,
+            cap_violations: 0,
+            fanout_violations: 0,
+            critical_path_delay: 9.15,
+            total_power: 1.45,
+            dynamic_power: 1.32,
+            switching_power: 0.85,
+            internal_power: 0.47,
+            leakage_power: 0.13,
+            voltage: 1.8,
+            temperature: 25,
+            corners: {
+              nom_tt_025C_1v80: {
+                setup_wns: 0.85,
+                setup_tns: 0.0,
+                hold_wns: 0.12,
+                hold_tns: 0.0,
+                voltage: 1.8,
+                temperature: 25,
+              },
+              ss_100C_1v60: {
+                setup_wns: -0.25,
+                setup_tns: -1.2,
+                hold_wns: 0.35,
+                hold_tns: 0.0,
+                voltage: 1.6,
+                temperature: 100,
+              },
+            },
+          },
+          DRC: {
+            drc_violations: 0,
+            antenna_violations: 0,
+            erc_violations: 0,
+          },
+          LVS: {
+            lvs_mismatches: 0,
+          },
+          Harden: {
+            'Design Layout': {
+              die_area: 100000,
+            },
+            'Instances': {
+              total: {
+                area: 38800,
+                num: 572,
+              },
+            },
+          },
+        },
+      })
+
+      // Design
+      expect(result.design.designName).toBe('gcd')
+      expect(result.design.pdk).toBe('sky130hd')
+      expect(result.design.pdkVersion).toBe('v0.12.0')
+      expect(result.design.pdkCommit).toBe('1234567890abcdef')
+      expect(result.design.eccTool).toBe('ecc-fe')
+      expect(result.design.eccVersion).toBe('1.4.2')
+      expect(result.design.ecosStudioVersion).toBe('0.1.0-alpha.8')
+      expect(result.design.gitCommit).toBe('abcdef1234567890')
+
+      // Physical
+      expect(result.physical.dieAreaUm2).toBe(100000)
+      expect(result.physical.dieAreaMm2).toBe(0.1)
+      expect(result.physical.coreAreaUm2).toBe(80000)
+      expect(result.physical.coreUtilizationPct).toBe(48.5)
+      expect(result.physical.stdCellAreaUm2).toBe(38800)
+      expect(result.physical.instanceCount).toBe(572)
+      expect(result.physical.sequentialCellCount).toBe(32)
+      expect(result.physical.combinationalCellCount).toBe(540)
+      expect(result.physical.ioPinCount).toBe(54)
+      expect(result.physical.netCount).toBe(590)
+
+      // Timing
+      expect(result.timing.targetClockPeriodNs).toBe(10.0)
+      expect(result.timing.targetFrequencyMhz).toBe(100.0)
+      expect(result.timing.setupWnsNs).toBe(0.85)
+      expect(result.timing.setupTnsNs).toBe(0.0)
+      expect(result.timing.holdWnsNs).toBe(0.12)
+      expect(result.timing.holdTnsNs).toBe(0.0)
+      expect(result.timing.fmaxMhz).toBe(+(1000 / (10.0 - 0.85)).toFixed(2))
+      expect(result.timing.criticalPathDelayNs).toBe(9.15)
+      expect(result.timing.slewViolations).toBe(0)
+      expect(result.timing.capViolations).toBe(0)
+      expect(result.timing.fanoutViolations).toBe(0)
+      expect(result.timing.violatingEndpointsSetup).toBe(0)
+
+      // Multi-corner
+      expect(result.multiCornerTiming).toHaveLength(2)
+      expect(result.multiCornerTiming[0].corner).toBe('nom_tt_025C_1v80')
+      expect(result.multiCornerTiming[0].status).toBe('pass')
+      expect(result.multiCornerTiming[1].corner).toBe('ss_100C_1v60')
+      expect(result.multiCornerTiming[1].status).toBe('fail')
+
+      // Clock
+      expect(result.clock.clockSkewPs).toBe(42.5)
+      expect(result.clock.clockLatencyNs).toBe(1.25)
+      expect(result.clock.clockBufferCount).toBe(12)
+      expect(result.clock.clockInverterCount).toBe(8)
+      expect(result.clock.clockTotalBuffers).toBe(20)
+
+      // Routing
+      expect(result.routing.hpwlUm).toBe(125000)
+      expect(result.routing.routedWirelengthUm).toBe(158000)
+      expect(result.routing.viaCount).toBe(3200)
+      expect(result.routing.routingCompletionPct).toBe(100)
+
+      // Power
+      expect(result.power.totalPowerMw).toBe(1.45)
+      expect(result.power.dynamicPowerMw).toBe(1.32)
+      expect(result.power.leakagePowerMw).toBe(0.13)
+
+      // Verification
+      expect(result.verification.drcStatus).toBe('clean')
+      expect(result.verification.drcCount).toBe(0)
+      expect(result.verification.lvsStatus).toBe('matched')
+      expect(result.verification.lvsMismatchCount).toBe(0)
+
+      // Execution
+      expect(result.execution.totalRuntimeSeconds).toBe(380)
+      expect(result.execution.totalRuntimeFormatted).toBe('6m 20s')
+      expect(result.execution.peakMemoryMb).toBe(600)
+      expect(result.execution.stages).toHaveLength(9)
+
+      // Provenance
+      expect(result.provenance.length).toBeGreaterThan(10)
+    })
+
+    it('handles partially completed or missing flow gracefully without throwing', () => {
+      const result = extractDesignReportData({
+        workspacePath: '/projects/partial_design',
+        parameters: {
+          Design: 'partial_alu',
+        },
+        flow: null,
+        stepMetrics: {
+          Synth: {
+            instances: 150,
+          },
+        },
+      })
+
+      expect(result.design.designName).toBe('partial_alu')
+      expect(result.physical.instanceCount).toBe(150)
+      expect(result.physical.dieAreaUm2).toBeNull()
+      expect(result.timing.setupWnsNs).toBeNull()
+      expect(result.multiCornerTiming).toEqual([])
+      expect(result.verification.drcStatus).toBe('unrun')
+      expect(result.execution.stages).toEqual([])
+    })
+
+    it('flags warnings on abnormal values like out of range utilization', () => {
+      const result = extractDesignReportData({
+        workspacePath: '/projects/bad_util',
+        stepMetrics: {
+          Place: {
+            utilization: 125.0, // > 100%
+          },
+        },
+      })
+
+      expect(result.warnings.some((w) => w.code === 'PHYS_UTIL_OUT_OF_RANGE')).toBe(true)
+    })
+
+    it('extracts target clock period and frequency from "Frequency max [MHz]" parameter', () => {
+      const result = extractDesignReportData({
+        workspacePath: '/media/projects/gcd/ws_0001',
+        parameters: {
+          PDK: 'ics55',
+          Design: 'gcd',
+          'Frequency max [MHz]': 50,
+          'Max fanout': 32,
+        },
+        stepMetrics: {
+          STA: {
+            setup_wns: 16.622,
+          },
+        },
+      })
+
+      expect(result.timing.targetFrequencyMhz).toBe(50)
+      expect(result.timing.targetClockPeriodNs).toBe(20.0)
+      expect(result.timing.setupWnsNs).toBe(16.622)
+    })
+  })
+})

--- a/ecos/gui/packages/shared/src/utils/designReportExtract.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportExtract.test.ts
@@ -107,15 +107,69 @@ Summary                  16.882        0.0       0     321MHz      0.256        
         flow: {
           timestamp: '2026-08-25T12:00:00Z',
           steps: [
-            { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:0:30', 'peak memory (mb)': 120 },
-            { name: 'Floorplan_ecc', tool: 'OpenROAD', state: 'Success', runtime: '0:0:15', 'peak memory (mb)': 200 },
-            { name: 'place_dreamplace', tool: 'DreamPlace', state: 'Success', runtime: '0:1:00', 'peak memory (mb)': 450 },
-            { name: 'CTS_ecc', tool: 'OpenROAD', state: 'Success', runtime: '0:0:45', 'peak memory (mb)': 310 },
-            { name: 'route_ecc', tool: 'OpenROAD', state: 'Success', runtime: '0:2:30', 'peak memory (mb)': 600 },
-            { name: 'sta_ecc', tool: 'OpenSTA', state: 'Success', runtime: '0:0:20', 'peak memory (mb)': 280 },
-            { name: 'drc_ecc', tool: 'KLayout', state: 'Success', runtime: '0:0:10', 'peak memory (mb)': 150 },
-            { name: 'lvs_ecc', tool: 'Netgen', state: 'Success', runtime: '0:0:10', 'peak memory (mb)': 140 },
-            { name: 'Harden_ecc', tool: 'OpenROAD', state: 'Success', runtime: '0:0:40', 'peak memory (mb)': 520 },
+            {
+              name: 'Synthesis_yosys',
+              tool: 'Yosys',
+              state: 'Success',
+              runtime: '0:0:30',
+              'peak memory (mb)': 120,
+            },
+            {
+              name: 'Floorplan_ecc',
+              tool: 'OpenROAD',
+              state: 'Success',
+              runtime: '0:0:15',
+              'peak memory (mb)': 200,
+            },
+            {
+              name: 'place_dreamplace',
+              tool: 'DreamPlace',
+              state: 'Success',
+              runtime: '0:1:00',
+              'peak memory (mb)': 450,
+            },
+            {
+              name: 'CTS_ecc',
+              tool: 'OpenROAD',
+              state: 'Success',
+              runtime: '0:0:45',
+              'peak memory (mb)': 310,
+            },
+            {
+              name: 'route_ecc',
+              tool: 'OpenROAD',
+              state: 'Success',
+              runtime: '0:2:30',
+              'peak memory (mb)': 600,
+            },
+            {
+              name: 'sta_ecc',
+              tool: 'OpenSTA',
+              state: 'Success',
+              runtime: '0:0:20',
+              'peak memory (mb)': 280,
+            },
+            {
+              name: 'drc_ecc',
+              tool: 'KLayout',
+              state: 'Success',
+              runtime: '0:0:10',
+              'peak memory (mb)': 150,
+            },
+            {
+              name: 'lvs_ecc',
+              tool: 'Netgen',
+              state: 'Success',
+              runtime: '0:0:10',
+              'peak memory (mb)': 140,
+            },
+            {
+              name: 'Harden_ecc',
+              tool: 'OpenROAD',
+              state: 'Success',
+              runtime: '0:0:40',
+              'peak memory (mb)': 520,
+            },
           ],
         },
         stepMetrics: {
@@ -151,7 +205,7 @@ Summary                  16.882        0.0       0     321MHz      0.256        
             clock_wirelength: 4500,
           },
           Route: {
-            'Nets': {
+            Nets: {
               wire_len: 158000,
               num_via: 3200,
             },
@@ -211,7 +265,7 @@ Summary                  16.882        0.0       0     321MHz      0.256        
             'Design Layout': {
               die_area: 100000,
             },
-            'Instances': {
+            Instances: {
               total: {
                 area: 38800,
                 num: 572,

--- a/ecos/gui/packages/shared/src/utils/designReportExtract.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportExtract.ts
@@ -1,0 +1,1852 @@
+import type {
+  ClockMetrics,
+  CongestionMetrics,
+  CornerTimingRecord,
+  DesignInfo,
+  DesignReportData,
+  DesignReportWarning,
+  EvidenceProvenanceRecord,
+  ExecutionMetrics,
+  PhysicalMetrics,
+  PowerMetrics,
+  RoutingMetrics,
+  StageExecutionRecord,
+  TimingMetrics,
+  VerificationMetrics,
+} from '../contracts/designReport.ts'
+
+export interface ExtractDesignReportInput {
+  workspacePath?: string
+  workspaceName?: string
+  designName?: string
+  topModule?: string
+  pdk?: string
+  pdkVersion?: string | null
+  frequencyTarget?: number
+  parameters?: Record<string, unknown> | null
+  flow?: Record<string, unknown> | null
+  homeData?: Record<string, unknown> | null
+  stepMetrics?: Record<string, unknown> | null
+  stepSummaries?: Record<string, unknown> | null
+  stepHotspots?: Record<string, unknown> | null
+  staTimingIssues?: Record<string, unknown> | null
+  staCornerReports?: Record<string, Record<string, unknown>> | null
+  versionInfo?: {
+    gui?: string
+    runtime?: string
+    ecc?: string
+    dreamplace?: string
+    eccTools?: string
+  } | null
+  generatedAt?: string
+}
+
+function isRecord(val: unknown): val is Record<string, unknown> {
+  return typeof val === 'object' && val !== null && !Array.isArray(val)
+}
+
+function parseJsonSafely(value: unknown): Record<string, unknown> | null {
+  if (isRecord(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
+      if (isRecord(parsed)) return parsed
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+export function parseRuntimeSeconds(runtime: string | number | null | undefined): number | null {
+  if (typeof runtime === 'number' && Number.isFinite(runtime)) return runtime
+  if (typeof runtime !== 'string' || !runtime.trim()) return null
+  const parts = runtime.split(':').map((p) => Number(p.trim()))
+  if (parts.some((p) => !Number.isFinite(p))) return null
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
+  if (parts.length === 2) return parts[0] * 60 + parts[1]
+  if (parts.length === 1) return parts[0]
+  return null
+}
+
+export function formatDuration(seconds: number | null): string | null {
+  if (seconds === null || !Number.isFinite(seconds) || seconds < 0) return null
+  const total = Math.round(seconds)
+  const hrs = Math.floor(total / 3600)
+  const mins = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+  if (hrs > 0) {
+    return `${hrs}h ${mins}m ${secs}s`
+  }
+  if (mins > 0) {
+    return `${mins}m ${secs}s`
+  }
+  return `${secs}s`
+}
+
+const STAGE_CANONICAL_NAMES: Record<string, string> = {
+  synthesis: 'Synth',
+  synth: 'Synth',
+  synthesis_yosys: 'Synth',
+  yosys: 'Synth',
+  floorplan: 'Floor',
+  floor: 'Floor',
+  floorplan_ecc: 'Floor',
+  macro_placement: 'Floor',
+  fixfanout: 'Fanout',
+  fixfanout_ecc: 'Fanout',
+  fanout: 'Fanout',
+  placement: 'Place',
+  place: 'Place',
+  place_dreamplace: 'Place',
+  dreamplace: 'Place',
+  global_placement: 'Place',
+  detailed_placement: 'Place',
+  cts: 'CTS',
+  cts_ecc: 'CTS',
+  legalization: 'Legal',
+  legal: 'Legal',
+  legalization_dreamplace: 'Legal',
+  routing: 'Route',
+  route: 'Route',
+  route_ecc: 'Route',
+  global_route: 'Route',
+  detail_route: 'Route',
+  drc: 'DRC',
+  drc_ecc: 'DRC',
+  lvs: 'LVS',
+  lvs_ecc: 'LVS',
+  filler: 'Filler',
+  filler_ecc: 'Filler',
+  rcx: 'RCX',
+  rcx_ecc: 'RCX',
+  sta: 'STA',
+  sta_ecc: 'STA',
+  sta_signoff: 'STA',
+  signoff: 'STA',
+  post_route_sta: 'STA',
+  sta_corner: 'STA',
+  power: 'Power',
+  power_ecc: 'Power',
+  sta_power: 'Power',
+  harden: 'Harden',
+  harden_ecc: 'Harden',
+}
+
+export function canonicalizeStageName(name: string): string {
+  const normalized = name.trim().toLowerCase()
+  return STAGE_CANONICAL_NAMES[normalized] || name.trim()
+}
+
+export interface ParsedPowerMetrics {
+  totalPowerMw: number | null
+  dynamicPowerMw: number | null
+  leakagePowerMw: number | null
+  internalPowerMw: number | null
+  switchingPowerMw: number | null
+  voltageV: number | null
+}
+
+function convertUnitToMw(val: number, unitStr: string): number {
+  if (!Number.isFinite(val)) return 0
+  const u = unitStr.toLowerCase()
+  if (u === 'w') return val * 1000
+  if (u === 'mw') return val
+  if (u === 'uw' || u === 'µw') return val / 1000
+  if (u === 'nw') return val / 1e6
+  if (u === 'pw') return val / 1e9
+  return val
+}
+
+export function parsePowerRpt(text: string | null | undefined): ParsedPowerMetrics {
+  if (!text) {
+    return {
+      totalPowerMw: null,
+      dynamicPowerMw: null,
+      leakagePowerMw: null,
+      internalPowerMw: null,
+      switchingPowerMw: null,
+      voltageV: null,
+    }
+  }
+
+  let totalPowerMw: number | null = null
+  let dynamicPowerMw: number | null = null
+  let leakagePowerMw: number | null = null
+  let internalPowerMw: number | null = null
+  let switchingPowerMw: number | null = null
+  let voltageV: number | null = null
+
+  const voltMatch = text.match(/Global Operating Voltage\s*=\s*([\d.]+)/i)
+  if (voltMatch) voltageV = Number(voltMatch[1])
+
+  const intMatch = text.match(/Cell Internal Power\s*=\s*([\d.e+-]+)\s*([uUnNmMgk]?W)/i)
+  if (intMatch) internalPowerMw = convertUnitToMw(Number(intMatch[1]), intMatch[2])
+
+  const swMatch = text.match(/Net Switching Power\s*=\s*([\d.e+-]+)\s*([uUnNmMgk]?W)/i)
+  if (swMatch) switchingPowerMw = convertUnitToMw(Number(swMatch[1]), swMatch[2])
+
+  const dynMatch = text.match(/Total Dynamic Power\s*=\s*([\d.e+-]+)\s*([uUnNmMgk]?W)/i)
+  if (dynMatch) dynamicPowerMw = convertUnitToMw(Number(dynMatch[1]), dynMatch[2])
+
+  const leakMatch = text.match(/Cell Leakage Power\s*=\s*([\d.e+-]+)\s*([uUnNmMgk]?W)/i)
+  if (leakMatch) leakagePowerMw = convertUnitToMw(Number(leakMatch[1]), leakMatch[2])
+
+  const totalMatch = text.match(
+    /Total\s+[\d.e+-]+\s*[a-zA-Z]+\s+[\d.e+-]+\s*[a-zA-Z]+\s+[\d.e+-]+\s*[a-zA-Z]+\s+([\d.e+-]+)\s*([uUnNmMgk]?W)/i,
+  )
+  if (totalMatch) {
+    totalPowerMw = convertUnitToMw(Number(totalMatch[1]), totalMatch[2])
+  } else if (dynamicPowerMw !== null || leakagePowerMw !== null) {
+    totalPowerMw = +((dynamicPowerMw ?? 0) + (leakagePowerMw ?? 0)).toFixed(4)
+  }
+
+  return {
+    totalPowerMw,
+    dynamicPowerMw,
+    leakagePowerMw,
+    internalPowerMw,
+    switchingPowerMw,
+    voltageV,
+  }
+}
+
+export interface ParsedQorSummaryMetrics {
+  wns: number | null
+  tns: number | null
+  nvp: number | null
+  frequencyMhz: number | null
+  holdWns: number | null
+  holdTns: number | null
+  holdNvp: number | null
+}
+
+export function parseQorSummaryRpt(text: string | null | undefined): ParsedQorSummaryMetrics {
+  if (!text) {
+    return {
+      wns: null,
+      tns: null,
+      nvp: null,
+      frequencyMhz: null,
+      holdWns: null,
+      holdTns: null,
+      holdNvp: null,
+    }
+  }
+
+  const lines = text.split(/\r?\n/)
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('Summary') || trimmed.startsWith('clk')) {
+      const parts = trimmed.split(/\s+/)
+      if (parts.length >= 8) {
+        const wns = Number(parts[1])
+        const tns = Number(parts[2])
+        const nvp = Number(parts[3])
+        const freqStr = parts[4].replace(/mhz/i, '')
+        const freq = Number(freqStr)
+        const holdWns = Number(parts[5])
+        const holdTns = Number(parts[6])
+        const holdNvp = Number(parts[7])
+        return {
+          wns: Number.isFinite(wns) ? wns : null,
+          tns: Number.isFinite(tns) ? tns : null,
+          nvp: Number.isFinite(nvp) ? nvp : null,
+          frequencyMhz: Number.isFinite(freq) ? freq : null,
+          holdWns: Number.isFinite(holdWns) ? holdWns : null,
+          holdTns: Number.isFinite(holdTns) ? holdTns : null,
+          holdNvp: Number.isFinite(holdNvp) ? holdNvp : null,
+        }
+      }
+    }
+  }
+  return {
+    wns: null,
+    tns: null,
+    nvp: null,
+    frequencyMhz: null,
+    holdWns: null,
+    holdTns: null,
+    holdNvp: null,
+  }
+}
+
+
+interface RawMetricFinding {
+  value: unknown
+  sourceKey: string
+  stage: string
+}
+
+function getNestedValue(obj: Record<string, unknown>, pathStr: string): unknown {
+  const parts = pathStr.split('.')
+  let current: unknown = obj
+  for (const part of parts) {
+    if (!isRecord(current)) return undefined
+    if (part in current && current[part] !== undefined) {
+      current = current[part]
+      continue
+    }
+    const normPart = part.toLowerCase().replace(/[\s_-]/g, '')
+    let matched = false
+    for (const k of Object.keys(current)) {
+      const normK = k.toLowerCase().replace(/[\s_-]/g, '')
+      if (normK === normPart) {
+        current = current[k]
+        matched = true
+        break
+      }
+    }
+    if (!matched) return undefined
+  }
+  return current
+}
+
+function findMetricInRecord(
+  metricsRecord: Record<string, unknown> | null,
+  aliases: string[],
+  stageName: string,
+): RawMetricFinding | null {
+  if (!metricsRecord) return null
+
+  // 1. Schema 3 Array format: metrics: Array<{ id: string, value: unknown, ... }>
+  if (Array.isArray(metricsRecord.metrics)) {
+    for (const item of metricsRecord.metrics) {
+      if (!isRecord(item)) continue
+      const id = typeof item.id === 'string' ? item.id.toLowerCase().replace(/[\s_-]/g, '') : ''
+      const displayName = typeof item.display_name === 'string' ? item.display_name.toLowerCase().replace(/[\s_-]/g, '') : ''
+      for (const alias of aliases) {
+        const normAlias = alias.toLowerCase().replace(/[\s_-]/g, '')
+        if ((id === normAlias || displayName === normAlias) && item.value !== undefined && item.value !== null) {
+          return {
+            value: item.value,
+            sourceKey: typeof item.id === 'string' ? item.id : alias,
+            stage: stageName,
+          }
+        }
+      }
+    }
+  }
+
+  // 2. Direct property matches on root
+  for (const alias of aliases) {
+    if (alias in metricsRecord && metricsRecord[alias] !== undefined && metricsRecord[alias] !== null) {
+      return {
+        value: metricsRecord[alias],
+        sourceKey: alias,
+        stage: stageName,
+      }
+    }
+  }
+
+  // 3. Hierarchical / dot notation paths (e.g., 'Design Layout.die_area', 'Instances.total.area')
+  for (const alias of aliases) {
+    if (alias.includes('.')) {
+      const nestedVal = getNestedValue(metricsRecord, alias)
+      if (nestedVal !== undefined && nestedVal !== null) {
+        return {
+          value: nestedVal,
+          sourceKey: alias,
+          stage: stageName,
+        }
+      }
+    }
+  }
+
+  // 4. Nested object property search
+  for (const key of Object.keys(metricsRecord)) {
+    const val = metricsRecord[key]
+    if (isRecord(val)) {
+      for (const alias of aliases) {
+        if (alias in val && val[alias] !== undefined && val[alias] !== null) {
+          return {
+            value: val[alias],
+            sourceKey: `${key}.${alias}`,
+            stage: stageName,
+          }
+        }
+      }
+    }
+  }
+
+  // 5. Case-insensitive / normalized root property search
+  for (const alias of aliases) {
+    const normAlias = alias.toLowerCase().replace(/[\s_-]/g, '')
+    for (const key of Object.keys(metricsRecord)) {
+      const normKey = key.toLowerCase().replace(/[\s_-]/g, '')
+      if (normKey === normAlias && metricsRecord[key] !== undefined && metricsRecord[key] !== null) {
+        return {
+          value: metricsRecord[key],
+          sourceKey: key,
+          stage: stageName,
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+function parseNumber(val: unknown): number | null {
+  if (typeof val === 'number' && Number.isFinite(val)) return val
+  if (isRecord(val) && 'value' in val) {
+    return parseNumber(val.value)
+  }
+  if (typeof val === 'string' && val.trim() !== '') {
+    const cleaned = val.replace(/,/g, '').trim()
+    const parsed = Number(cleaned)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+export function extractDesignReportData(input: ExtractDesignReportInput): DesignReportData {
+  const warnings: DesignReportWarning[] = []
+  const provenance: EvidenceProvenanceRecord[] = []
+
+  const params = parseJsonSafely(input.parameters) || {}
+  const flow = parseJsonSafely(input.flow) || {}
+  const home = parseJsonSafely(input.homeData) || {}
+  const stepMetrics = input.stepMetrics || {}
+  const stepSummaries = input.stepSummaries || {}
+  const stepHotspots = input.stepHotspots || {}
+  const staTimingIssues = parseJsonSafely(input.staTimingIssues)
+
+  // 1. Extract Design & Tool Metadata
+  const designName =
+    input.designName ||
+    input.topModule ||
+    (typeof params.Design === 'string' && params.Design) ||
+    (typeof params.DESIGN === 'string' && params.DESIGN) ||
+    (typeof params.DESIGN_NAME === 'string' && params.DESIGN_NAME) ||
+    (typeof params.top_module === 'string' && params.top_module) ||
+    (typeof params.TOP_MODULE === 'string' && params.TOP_MODULE) ||
+    (typeof flow.design === 'string' && flow.design) ||
+    (typeof home.design === 'string' && home.design) ||
+    input.workspaceName ||
+    'Unknown_Design'
+
+  const pdk =
+    input.pdk ||
+    (typeof params.PDK === 'string' && params.PDK) ||
+    (typeof params.pdk === 'string' && params.pdk) ||
+    (typeof flow.pdk === 'string' && flow.pdk) ||
+    (typeof home.pdk === 'string' && home.pdk) ||
+    'sky130hd'
+
+  const pdkVersion =
+    (typeof params.PDK_VERSION === 'string' && params.PDK_VERSION) ||
+    (typeof params.pdk_version === 'string' && params.pdk_version) ||
+    (typeof home.pdk_version === 'string' && home.pdk_version) ||
+    null
+
+  const pdkCommit =
+    (typeof params.PDK_COMMIT === 'string' && params.PDK_COMMIT) ||
+    (typeof params.pdk_commit === 'string' && params.pdk_commit) ||
+    (typeof params.PDK_GIT_COMMIT === 'string' && params.PDK_GIT_COMMIT) ||
+    (typeof params.pdk_git_commit === 'string' && params.pdk_git_commit) ||
+    (typeof params.PDK_COMMIT_ID === 'string' && params.PDK_COMMIT_ID) ||
+    (typeof params.pdk_commit_id === 'string' && params.pdk_commit_id) ||
+    (typeof params.pdkCommit === 'string' && params.pdkCommit) ||
+    (typeof home.pdk_commit === 'string' && home.pdk_commit) ||
+    (typeof home.pdk_commit_id === 'string' && home.pdk_commit_id) ||
+    (typeof home.pdkCommit === 'string' && home.pdkCommit) ||
+    (typeof home.pdk_git_commit === 'string' && home.pdk_git_commit) ||
+    (typeof home.commit === 'string' && home.commit) ||
+    (typeof home.commit_id === 'string' && home.commit_id) ||
+    (typeof home.git_commit === 'string' && home.git_commit) ||
+    null
+
+  let eccTool: string | null =
+    input.versionInfo?.eccTools ||
+    (typeof params.ECC_TOOL === 'string' && params.ECC_TOOL) ||
+    (typeof params.ecc_tool === 'string' && params.ecc_tool) ||
+    (typeof flow.tool === 'string' && flow.tool) ||
+    (Array.isArray(flow.steps) && typeof (flow.steps[0] as Record<string, unknown>)?.tool === 'string' && (flow.steps[0] as Record<string, unknown>).tool as string) ||
+    'ecc'
+
+  if (eccTool === 'unknown') {
+    eccTool = 'ecc'
+  }
+
+  const rawEccVer =
+    input.versionInfo?.ecc ||
+    (typeof params.ECC_VERSION === 'string' && params.ECC_VERSION) ||
+    (typeof params.ecc_version === 'string' && params.ecc_version) ||
+    (typeof home.ecc_version === 'string' && home.ecc_version) ||
+    null
+
+  const eccVersion = rawEccVer === 'unknown' ? null : rawEccVer
+
+  const ecosStudioVersion =
+    input.versionInfo?.gui ||
+    (typeof params.ECOS_STUDIO_VERSION === 'string' && params.ECOS_STUDIO_VERSION) ||
+    (typeof params.ecos_studio_version === 'string' && params.ecos_studio_version) ||
+    '0.1.0-alpha.8'
+
+  const gitCommit =
+    (typeof params.GIT_COMMIT === 'string' && params.GIT_COMMIT) ||
+    (typeof params.git_commit === 'string' && params.git_commit) ||
+    null
+
+  const runId =
+    (typeof params.RUN_ID === 'string' && params.RUN_ID) ||
+    (typeof params.run_id === 'string' && params.run_id) ||
+    (typeof flow.run_id === 'string' && flow.run_id) ||
+    null
+
+  const timestamp =
+    (typeof flow.timestamp === 'string' && flow.timestamp) ||
+    (typeof params.timestamp === 'string' && params.timestamp) ||
+    new Date().toISOString()
+
+  const generatedAt = input.generatedAt || new Date().toISOString()
+
+  // Collect step metric stores across canonical names
+  const normalizedStepMetrics: Record<string, Record<string, unknown>> = {}
+
+  for (const [key, value] of Object.entries(stepMetrics)) {
+    const canonical = canonicalizeStageName(key)
+    const parsed = parseJsonSafely(value)
+    if (parsed) {
+      normalizedStepMetrics[key] = { ...(normalizedStepMetrics[key] || {}), ...parsed }
+      normalizedStepMetrics[canonical] = {
+        ...(normalizedStepMetrics[canonical] || {}),
+        ...parsed,
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(stepSummaries)) {
+    const canonical = canonicalizeStageName(key)
+    const parsed = parseJsonSafely(value)
+    if (parsed) {
+      normalizedStepMetrics[key] = { ...(normalizedStepMetrics[key] || {}), ...parsed }
+      normalizedStepMetrics[canonical] = {
+        ...(normalizedStepMetrics[canonical] || {}),
+        ...parsed,
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(stepHotspots)) {
+    const canonical = canonicalizeStageName(key)
+    const parsed = parseJsonSafely(value)
+    if (parsed) {
+      normalizedStepMetrics[key] = { ...(normalizedStepMetrics[key] || {}), ...parsed }
+      normalizedStepMetrics[canonical] = {
+        ...(normalizedStepMetrics[canonical] || {}),
+        ...parsed,
+      }
+    }
+  }
+
+  if (staTimingIssues) {
+    normalizedStepMetrics['STA'] = {
+      ...(normalizedStepMetrics['STA'] || {}),
+      ...staTimingIssues,
+    }
+  }
+
+  if (params && Object.keys(params).length > 0) {
+    normalizedStepMetrics['Parameters'] = {
+      ...(normalizedStepMetrics['Parameters'] || {}),
+      ...params,
+    }
+  }
+
+  if (home && Object.keys(home).length > 0) {
+    normalizedStepMetrics['Home'] = {
+      ...(normalizedStepMetrics['Home'] || {}),
+      ...home,
+    }
+    normalizedStepMetrics['Parameters'] = {
+      ...(normalizedStepMetrics['Parameters'] || {}),
+      ...home,
+    }
+  }
+
+  // Multi-stage lookup helper with fallback priority
+  function queryMetric(
+    category: string,
+    metricDisplayName: string,
+    stagePriority: string[],
+    aliases: string[],
+    unit = '',
+  ): { value: number | null; stage: string; sourceKey: string } {
+    for (const stage of stagePriority) {
+      const stepData = normalizedStepMetrics[stage]
+      if (!stepData) continue
+
+      const finding = findMetricInRecord(stepData, aliases, stage)
+      if (finding) {
+        const num = parseNumber(finding.value)
+        if (num !== null) {
+          provenance.push({
+            category,
+            metric: metricDisplayName,
+            value: num,
+            unit,
+            status: 'VERIFIED',
+            stage: finding.stage,
+            corner: null,
+            tool: stage,
+            sourceMetricId: finding.sourceKey,
+            runId: runId || 'run_latest',
+            timestamp,
+          })
+          return { value: num, stage: finding.stage, sourceKey: finding.sourceKey }
+        }
+      }
+    }
+
+    // Check parameters as fallback for design-wide settings
+    for (const alias of aliases) {
+      if (alias in params && params[alias] !== undefined && params[alias] !== null) {
+        const num = parseNumber(params[alias])
+        if (num !== null) {
+          provenance.push({
+            category,
+            metric: metricDisplayName,
+            value: num,
+            unit,
+            status: 'CONFIGURED',
+            stage: 'Parameters',
+            corner: null,
+            tool: 'Configuration',
+            sourceMetricId: alias,
+            runId: runId || 'run_latest',
+            timestamp,
+          })
+          return { value: num, stage: 'Parameters', sourceKey: alias }
+        }
+      }
+      if (alias in home && home[alias] !== undefined && home[alias] !== null) {
+        const num = parseNumber(home[alias])
+        if (num !== null) {
+          return { value: num, stage: 'Home', sourceKey: alias }
+        }
+      }
+    }
+
+    return { value: null, stage: '', sourceKey: '' }
+  }
+
+  // 2. Physical Metrics
+  const dieAreaRes = queryMetric(
+    'Physical',
+    'Die Area',
+    ['Harden', 'Route', 'Legal', 'Place', 'Floor'],
+    [
+      'Design Layout.die_area',
+      'die_area_um2',
+      'die_area',
+      'dieArea',
+      'die_area_um',
+      'die_area_mm2',
+    ],
+    'um2',
+  )
+  let dieAreaUm2 = dieAreaRes.value
+  if (dieAreaUm2 !== null && dieAreaUm2 < 100) {
+    dieAreaUm2 = dieAreaUm2 * 1e6
+  }
+  const dieAreaMm2 = dieAreaUm2 !== null ? +(dieAreaUm2 / 1e6).toFixed(4) : null
+
+  const coreAreaRes = queryMetric(
+    'Physical',
+    'Core Area',
+    ['Harden', 'Route', 'Legal', 'Place', 'Floor'],
+    ['Design Layout.core_area', 'core_area_um2', 'core_area', 'coreArea', 'core_area_um'],
+    'um2',
+  )
+  let coreAreaUm2 = coreAreaRes.value
+  if (coreAreaUm2 !== null && coreAreaUm2 < 100) {
+    coreAreaUm2 = coreAreaUm2 * 1e6
+  }
+  const coreAreaMm2 = coreAreaUm2 !== null ? +(coreAreaUm2 / 1e6).toFixed(4) : null
+
+  const utilRes = queryMetric(
+    'Physical',
+    'Core Utilization',
+    ['Harden', 'Route', 'Legal', 'Place', 'Floor'],
+    [
+      'Design Layout.core_usage',
+      'Design Layout.die_usage',
+      'core_utilization',
+      'utilization',
+      'core_utilization_pct',
+      'utilization_pct',
+      'coreUtilization',
+    ],
+    '%',
+  )
+  let coreUtilizationPct = utilRes.value
+  if (coreUtilizationPct !== null && coreUtilizationPct > 0 && coreUtilizationPct <= 1.0) {
+    coreUtilizationPct = +(coreUtilizationPct * 100).toFixed(2)
+  }
+
+  if (coreUtilizationPct !== null && (coreUtilizationPct < 0 || coreUtilizationPct > 100)) {
+    warnings.push({
+      code: 'PHYS_UTIL_OUT_OF_RANGE',
+      message: `Core utilization ${coreUtilizationPct}% is outside standard range (0-100%).`,
+      severity: 'warn',
+    })
+  }
+
+  const stdCellAreaRes = queryMetric(
+    'Physical',
+    'Standard Cell Area',
+    ['Harden', 'Route', 'Legal', 'Place', 'Floor', 'Synth'],
+    [
+      'Instances.total.area',
+      'Instances.logic.area',
+      'design.area',
+      'stdcell_area',
+      'std_cell_area',
+      'cell_area',
+      'stdCellArea',
+      'area',
+    ],
+    'um2',
+  )
+  const stdCellAreaUm2 = stdCellAreaRes.value
+
+  const macroAreaRes = queryMetric(
+    'Physical',
+    'Macro Area',
+    ['Harden', 'Route', 'Place', 'Floor'],
+    ['Instances.macros.area', 'macro_area', 'macro_area_um2', 'macroArea'],
+    'um2',
+  )
+  const macroAreaUm2 = macroAreaRes.value
+
+  const macroCountRes = queryMetric(
+    'Physical',
+    'Macro Count',
+    ['Harden', 'Route', 'Place', 'Floor'],
+    ['Instances.macros.num', 'macro_count', 'num_macros', 'macroCount'],
+    'count',
+  )
+  const macroCount = macroCountRes.value
+
+  const instCountRes = queryMetric(
+    'Physical',
+    'Total Instances',
+    ['Harden', 'Route', 'Legal', 'Place', 'CTS', 'Fanout', 'Floor', 'Synth'],
+    [
+      'Design Statis.num_instances',
+      'Instances.total.num',
+      'design.num_cells',
+      'instance_count',
+      'instances',
+      'instanceCount',
+      'num_cells',
+      'total_instances',
+    ],
+    'count',
+  )
+  const instanceCount = instCountRes.value
+
+  const seqCellRes = queryMetric(
+    'Physical',
+    'Sequential Cell Count',
+    ['Harden', 'Route', 'CTS', 'Place', 'Synth'],
+    ['Instances.clock.num', 'sequential_cells', 'seq_cells', 'sequential_cell_count', 'flip_flops', 'registers'],
+    'count',
+  )
+  const sequentialCellCount = seqCellRes.value
+
+  const combCellRes = queryMetric(
+    'Physical',
+    'Combinational Cell Count',
+    ['Harden', 'Route', 'Place', 'Synth'],
+    ['Instances.logic.num', 'combinational_cells', 'comb_cells', 'combinational_cell_count', 'logic_cells'],
+    'count',
+  )
+  const combinationalCellCount = combCellRes.value
+
+  const ioPinRes = queryMetric(
+    'Physical',
+    'IO Pin Count',
+    ['Harden', 'Route', 'Floor', 'Synth'],
+    [
+      'Design Statis.num_iopins',
+      'Instances.total.pin_num',
+      'design.num_ports',
+      'io_pin_count',
+      'io_pins',
+      'ioPins',
+      'num_ports',
+      'pins',
+    ],
+    'count',
+  )
+  const ioPinCount = ioPinRes.value
+
+  const netCountRes = queryMetric(
+    'Physical',
+    'Total Nets',
+    ['Harden', 'Route', 'Legal', 'Place', 'CTS', 'Fanout', 'Floor', 'Synth'],
+    ['Design Statis.num_nets', 'design.num_wires', 'net_count', 'nets', 'netCount', 'num_wires'],
+    'count',
+  )
+  const netCount = netCountRes.value
+
+  const physical: PhysicalMetrics = {
+    dieAreaUm2,
+    dieAreaMm2,
+    coreAreaUm2,
+    coreAreaMm2,
+    coreUtilizationPct,
+    stdCellAreaUm2,
+    macroAreaUm2,
+    macroCount,
+    instanceCount,
+    sequentialCellCount,
+    combinationalCellCount,
+    ioPinCount,
+    netCount,
+  }
+
+  // 3. Timing & Clock Quality
+  let targetClockPeriodNs: number | null = null
+  let targetFrequencyMhz: number | null = null
+
+  const clockPeriodRes = queryMetric(
+    'Timing',
+    'Target Clock Period',
+    ['STA', 'CTS', 'Route', 'Place', 'Synth', 'Parameters', 'Home'],
+    [
+      'clock_period',
+      'CLOCK_PERIOD',
+      'target_clock_period',
+      'target_clock_period_ns',
+      'clockPeriod',
+      'target_period',
+      'PERIOD',
+      'period',
+      'SDC_CLOCK_PERIOD',
+      'sdc_clock_period',
+      'summary.clock_period',
+      'summary.setup.clock_period',
+      'summary.target_clock_period',
+    ],
+    'ns',
+  )
+  if (clockPeriodRes.value !== null && clockPeriodRes.value > 0) {
+    targetClockPeriodNs = clockPeriodRes.value
+    targetFrequencyMhz = +(1000 / targetClockPeriodNs).toFixed(2)
+  } else {
+    // Check frequency target aliases
+    const freqRes = queryMetric(
+      'Timing',
+      'Target Frequency',
+      ['STA', 'Parameters', 'Home', 'Synth'],
+      [
+        'Frequency max [MHz]',
+        'Frequency max',
+        'Frequency [MHz]',
+        'Frequency',
+        'frequency_max_mhz',
+        'frequency_max',
+        'CLOCK_FREQ_MHZ',
+        'target_frequency_mhz',
+        'clock_frequency_mhz',
+        'target_frequency',
+        'frequencyTarget',
+        'FREQUENCY',
+        'frequency',
+      ],
+      'MHz',
+    )
+    if (freqRes.value !== null && freqRes.value > 0) {
+      targetFrequencyMhz = freqRes.value
+      targetClockPeriodNs = +(1000 / targetFrequencyMhz).toFixed(3)
+    } else if (input.frequencyTarget && input.frequencyTarget > 0) {
+      targetFrequencyMhz = input.frequencyTarget
+      targetClockPeriodNs = +(1000 / targetFrequencyMhz).toFixed(3)
+    }
+  }
+
+  let setupWnsNs: number | null = null
+  const setupWnsRes = queryMetric(
+    'Timing',
+    'Setup WNS',
+    ['STA', 'Route', 'CTS', 'Place', 'Synth'],
+    [
+      'sta_setup_wns',
+      'setup_wns',
+      'setup.wns',
+      'summary.setup.wns',
+      'summary.wns',
+      'worst_negative_slack_setup',
+      'worst_negative_slack',
+      'worstSetup.wns',
+      'wns',
+    ],
+    'ns',
+  )
+  setupWnsNs = setupWnsRes.value
+
+  let setupTnsNs: number | null = null
+  const setupTnsRes = queryMetric(
+    'Timing',
+    'Setup TNS',
+    ['STA', 'Route', 'CTS', 'Place', 'Synth'],
+    [
+      'sta_setup_tns',
+      'setup_tns',
+      'setup.tns',
+      'summary.setup.tns',
+      'summary.tns',
+      'total_negative_slack_setup',
+      'total_negative_slack',
+      'tns',
+    ],
+    'ns',
+  )
+  setupTnsNs = setupTnsRes.value
+
+  let holdWnsNs: number | null = null
+  const holdWnsRes = queryMetric(
+    'Timing',
+    'Hold WNS',
+    ['STA', 'Route', 'CTS', 'Place'],
+    [
+      'sta_hold_wns',
+      'hold_wns',
+      'hold.wns',
+      'summary.hold.wns',
+      'hold_worst_negative_slack',
+      'worstHold.wns',
+    ],
+    'ns',
+  )
+  holdWnsNs = holdWnsRes.value
+
+  let holdTnsNs: number | null = null
+  const holdTnsRes = queryMetric(
+    'Timing',
+    'Hold TNS',
+    ['STA', 'Route', 'CTS', 'Place'],
+    [
+      'sta_hold_tns',
+      'hold_tns',
+      'hold.tns',
+      'summary.hold.tns',
+      'hold_total_negative_slack',
+    ],
+    'ns',
+  )
+  holdTnsNs = holdTnsRes.value
+
+  let violatingEndpointsSetup: number | null = null
+  const endpSetupRes = queryMetric(
+    'Timing',
+    'Setup Violating Endpoints',
+    ['STA', 'Route'],
+    [
+      'violating_endpoints_setup',
+      'setup.nvp',
+      'summary.setup.nvp',
+      'setup_violating_endpoints',
+      'setup_nvp',
+      'setupViolationCount',
+      'nvp',
+    ],
+    'endpoints',
+  )
+  violatingEndpointsSetup = endpSetupRes.value
+
+  let violatingEndpointsHold: number | null = null
+  const endpHoldRes = queryMetric(
+    'Timing',
+    'Hold Violating Endpoints',
+    ['STA', 'Route'],
+    [
+      'violating_endpoints_hold',
+      'hold.nvp',
+      'summary.hold.nvp',
+      'hold_violating_endpoints',
+      'hold_nvp',
+      'holdViolationCount',
+    ],
+    'endpoints',
+  )
+  violatingEndpointsHold = endpHoldRes.value
+
+function parseCornerAttributes(name: string): {
+  process: string | null
+  temperatureC: number | null
+  voltageV: number | null
+  rcCorner: string | null
+} {
+  let process: string | null = null
+  let temperatureC: number | null = null
+  let voltageV: number | null = null
+  let rcCorner: string | null = null
+
+  const parts = name.split(/[/_]/)
+  for (const p of parts) {
+    const trimmed = p.trim()
+    if (/^(MAX|MIN|ML|TYP|WCL|ss|ff|tt|fs|sf)$/i.test(trimmed)) {
+      process = trimmed.toUpperCase()
+    }
+    const tempMatch = trimmed.match(/^(?:m(\d+)|(-?\d+)C?)$/i)
+    if (tempMatch) {
+      if (tempMatch[1]) {
+        temperatureC = -Number(tempMatch[1])
+      } else if (tempMatch[2]) {
+        temperatureC = Number(tempMatch[2])
+      }
+    }
+    const voltMatch = trimmed.match(/(\d+)v(\d+)/i)
+    if (voltMatch) {
+      voltageV = Number(`${voltMatch[1]}.${voltMatch[2]}`)
+    }
+    if (/^(Cworst|RCworst|Cbest|RCbest|TYPICAL|typical|best|worst)$/i.test(trimmed)) {
+      rcCorner = trimmed
+    }
+  }
+
+  return { process, temperatureC, voltageV, rcCorner }
+}
+
+  // 4. Multi-Corner Timing Extraction
+  const multiCornerTiming: CornerTimingRecord[] = []
+  const allCornersSources: Array<Record<string, unknown> | undefined> = [
+    normalizedStepMetrics['STA']?.corners as Record<string, unknown> | undefined,
+    normalizedStepMetrics['sta_ecc']?.corners as Record<string, unknown> | undefined,
+    normalizedStepMetrics['Synth']?.corners as Record<string, unknown> | undefined,
+    input.staCornerReports ?? undefined,
+  ]
+
+  const mergedCorners: Record<string, Record<string, unknown>> = {}
+  for (const cSrc of allCornersSources) {
+    if (isRecord(cSrc)) {
+      for (const [cName, cData] of Object.entries(cSrc)) {
+        if (isRecord(cData)) {
+          mergedCorners[cName] = { ...(mergedCorners[cName] || {}), ...cData }
+        }
+      }
+    }
+  }
+
+  for (const [cornerName, cVal] of Object.entries(mergedCorners)) {
+    if (!isRecord(cVal)) continue
+    const inferred = parseCornerAttributes(cornerName)
+
+    const setupObj = isRecord(cVal.setup) ? cVal.setup : null
+    const holdObj = isRecord(cVal.hold) ? cVal.hold : null
+    const summaryObj = isRecord(cVal.summary) ? cVal.summary : null
+    const summarySetup = isRecord(summaryObj?.setup) ? summaryObj.setup : null
+    const summaryHold = isRecord(summaryObj?.hold) ? summaryObj.hold : null
+
+    const cSetupWns = parseNumber(cVal.setup_wns ?? cVal.wns ?? setupObj?.wns ?? summarySetup?.wns)
+    const cSetupTns = parseNumber(cVal.setup_tns ?? cVal.tns ?? setupObj?.tns ?? summarySetup?.tns)
+    const cHoldWns = parseNumber(cVal.hold_wns ?? holdObj?.wns ?? summaryHold?.wns)
+    const cHoldTns = parseNumber(cVal.hold_tns ?? holdObj?.tns ?? summaryHold?.tns)
+    const cVoltage = parseNumber(cVal.voltage ?? cVal.voltage_v ?? inferred.voltageV)
+    const cTemp = parseNumber(cVal.temperature ?? cVal.temperature_c ?? inferred.temperatureC)
+    const cProcess = (typeof cVal.process === 'string' && cVal.process) || inferred.process
+    const cRc = (typeof cVal.rc === 'string' && cVal.rc) || inferred.rcCorner
+    const cEndpSetup = parseNumber(cVal.violating_endpoints_setup ?? setupObj?.nvp ?? summarySetup?.nvp)
+    const cEndpHold = parseNumber(cVal.violating_endpoints_hold ?? holdObj?.nvp ?? summaryHold?.nvp)
+
+    const pass = (cSetupWns === null || cSetupWns >= 0) && (cHoldWns === null || cHoldWns >= 0)
+    const status = pass ? 'pass' : 'fail'
+
+    multiCornerTiming.push({
+      corner: cornerName,
+      processCorner: cProcess,
+      voltageV: cVoltage,
+      temperatureC: cTemp,
+      rcCorner: cRc,
+      setupWnsNs: cSetupWns,
+      setupTnsNs: cSetupTns,
+      holdWnsNs: cHoldWns,
+      holdTnsNs: cHoldTns,
+      violatingEndpointsSetup: cEndpSetup,
+      violatingEndpointsHold: cEndpHold,
+      status,
+    })
+  }
+
+  // If top-level timing metrics were missing, roll them up from multi-corner timing
+  if (multiCornerTiming.length > 0) {
+    const validSetupWns = multiCornerTiming.map((c) => c.setupWnsNs).filter((v): v is number => v !== null)
+    const validSetupTns = multiCornerTiming.map((c) => c.setupTnsNs).filter((v): v is number => v !== null)
+    const validHoldWns = multiCornerTiming.map((c) => c.holdWnsNs).filter((v): v is number => v !== null)
+    const validHoldTns = multiCornerTiming.map((c) => c.holdTnsNs).filter((v): v is number => v !== null)
+
+    if (setupWnsNs === null && validSetupWns.length > 0) {
+      setupWnsNs = Math.min(...validSetupWns)
+    }
+    if (setupTnsNs === null && validSetupTns.length > 0) {
+      setupTnsNs = Math.min(...validSetupTns)
+    }
+    if (holdWnsNs === null && validHoldWns.length > 0) {
+      holdWnsNs = Math.min(...validHoldWns)
+    }
+    if (holdTnsNs === null && validHoldTns.length > 0) {
+      holdTnsNs = Math.min(...validHoldTns)
+    }
+    if (violatingEndpointsSetup === null) {
+      violatingEndpointsSetup = multiCornerTiming.reduce(
+        (sum, c) => sum + (c.violatingEndpointsSetup ?? 0),
+        0,
+      )
+    }
+    if (violatingEndpointsHold === null) {
+      violatingEndpointsHold = multiCornerTiming.reduce(
+        (sum, c) => sum + (c.violatingEndpointsHold ?? 0),
+        0,
+      )
+    }
+  }
+
+  // Calculate Achieved Fmax
+  let fmaxMhz: number | null = null
+  const fmaxRes = queryMetric(
+    'Timing',
+    'Achieved Fmax',
+    ['STA', 'Route', 'CTS'],
+    [
+      'sta_frequency_mhz',
+      'frequency_mhz',
+      'fmax',
+      'achieved_frequency',
+      'summary.setup.frequency_mhz',
+      'setup.frequency_mhz',
+      'summary.frequency_mhz',
+    ],
+    'MHz',
+  )
+  if (fmaxRes.value !== null) {
+    fmaxMhz = fmaxRes.value
+  } else if (targetClockPeriodNs !== null && setupWnsNs !== null) {
+    const minPeriod = targetClockPeriodNs - setupWnsNs
+    if (minPeriod > 0) {
+      fmaxMhz = +(1000 / minPeriod).toFixed(2)
+    }
+  } else if (targetClockPeriodNs !== null) {
+    fmaxMhz = +(1000 / targetClockPeriodNs).toFixed(2)
+  }
+
+  const slewViolRes = queryMetric(
+    'Timing',
+    'Max Slew Violations',
+    ['STA', 'Route', 'CTS', 'Synth'],
+    ['slew_violations', 'max_slew_violations', 'slew_viols', 'trans_violations', 'transition_violations', 'max_transition_violations', 'max_slew', 'slew_violation_count', 'summary.slew.violations', 'slew.violations', 'check_slew'],
+    'violations',
+  )
+  let slewViolations = slewViolRes.value
+  if (slewViolations === null && setupWnsNs !== null && setupWnsNs >= 0) {
+    slewViolations = 0
+  }
+
+  const capViolRes = queryMetric(
+    'Timing',
+    'Max Cap Violations',
+    ['STA', 'Route', 'CTS', 'Synth'],
+    ['cap_violations', 'max_cap_violations', 'cap_viols', 'max_cap', 'capacitance_violations', 'max_capacitance_violations', 'cap_violation_count', 'summary.cap.violations', 'cap.violations', 'check_cap'],
+    'violations',
+  )
+  let capViolations = capViolRes.value
+  if (capViolations === null && setupWnsNs !== null && setupWnsNs >= 0) {
+    capViolations = 0
+  }
+
+  const fanoutViolRes = queryMetric(
+    'Timing',
+    'Max Fanout Violations',
+    ['STA', 'Route', 'Fanout', 'CTS', 'Synth'],
+    ['fanout_violations', 'max_fanout_violations', 'fanout_viols', 'fanout_max_violations', 'max_fanout', 'fanout_violation_count', 'summary.fanout.violations', 'fanout.violations', 'check_fanout'],
+    'violations',
+  )
+  let fanoutViolations = fanoutViolRes.value
+  if (fanoutViolations === null && setupWnsNs !== null && setupWnsNs >= 0) {
+    fanoutViolations = 0
+  }
+
+  const critPathRes = queryMetric(
+    'Timing',
+    'Critical Path Delay',
+    ['STA', 'Route', 'CTS', 'Synth'],
+    ['critical_path_delay', 'critical_path_delay_ns', 'crit_path_delay', 'data_path_delay', 'arrival_time', 'data_arrival_time', 'path_delay', 'worst_path_delay'],
+    'ns',
+  )
+  let criticalPathDelayNs = critPathRes.value
+  if (criticalPathDelayNs === null && targetClockPeriodNs !== null && setupWnsNs !== null) {
+    const derived = targetClockPeriodNs - setupWnsNs
+    if (derived > 0) {
+      criticalPathDelayNs = +derived.toFixed(3)
+    }
+  } else if (criticalPathDelayNs === null && fmaxMhz !== null && fmaxMhz > 0) {
+    criticalPathDelayNs = +(1000 / fmaxMhz).toFixed(3)
+  }
+
+  const timing: TimingMetrics = {
+    targetClockPeriodNs,
+    targetFrequencyMhz,
+    fmaxMhz,
+    setupWnsNs,
+    setupTnsNs,
+    holdWnsNs,
+    holdTnsNs,
+    violatingEndpointsSetup,
+    violatingEndpointsHold,
+    slewViolations,
+    capViolations,
+    fanoutViolations,
+    criticalPathDelayNs,
+  }
+
+  // 5. Clock Quality
+  const skewRes = queryMetric(
+    'Clock',
+    'Clock Skew',
+    ['CTS', 'STA', 'Route'],
+    [
+      'cts_worst_optimized_skew_ns',
+      'worst_optimized_skew_ns',
+      'cts_worst_skew_ns',
+      'worst_skew_ns',
+      'clock_skew',
+      'skew_ps',
+      'skew',
+      'max_clock_skew',
+      'cts_clock_skew',
+      'worst_skew',
+    ],
+    'ps',
+  )
+  let clockSkewPs: number | null = null
+  if (skewRes.value !== null) {
+    if (
+      skewRes.sourceKey.endsWith('_ns') ||
+      (skewRes.value > 0 && skewRes.value < 10.0)
+    ) {
+      clockSkewPs = +(skewRes.value * 1000).toFixed(1)
+    } else {
+      clockSkewPs = +skewRes.value.toFixed(1)
+    }
+  }
+
+  const latencyRes = queryMetric(
+    'Clock',
+    'Clock Insertion Latency',
+    ['CTS', 'STA', 'Route'],
+    [
+      'cts_worst_max_insertion_latency_ns',
+      'worst_max_insertion_latency_ns',
+      'cts_insertion_latency_ns',
+      'worst_insertion_latency_ns',
+      'clock_latency',
+      'latency_ns',
+      'insertion_latency',
+      'clock_insertion_delay',
+      'cts_latency',
+      'insertion_delay',
+    ],
+    'ns',
+  )
+  const clockLatencyNs = latencyRes.value
+
+  const clockWirelengthRes = queryMetric(
+    'Clock',
+    'Clock Wirelength',
+    ['CTS', 'Route'],
+    [
+      'total_clock_wirelength',
+      'CTS.total_clock_wirelength',
+      'clock_wirelength',
+      'clock_wire_length',
+      'clock_wirelength_um',
+    ],
+    'um',
+  )
+  const clockWirelengthUm = clockWirelengthRes.value
+
+  const clockMaxWirelengthRes = queryMetric(
+    'Clock',
+    'Max Clock Wirelength',
+    ['CTS', 'Route'],
+    [
+      'cts_clock_wirelength_max',
+      'max_clock_wirelength',
+      'CTS.max_clock_wirelength',
+    ],
+    'um',
+  )
+  const clockMaxWirelengthUm = clockMaxWirelengthRes.value
+
+  const clockBufferCountRes = queryMetric(
+    'Clock',
+    'Clock Buffer Count',
+    ['CTS', 'Route', 'Place', 'Floor'],
+    [
+      'cts_buffer_count',
+      'CTS.buffer_num',
+      'buffer_num',
+      'clock_buffer_count',
+      'clock_buffers',
+      'num_clock_buffers',
+    ],
+    'count',
+  )
+  const clockBufferCount = clockBufferCountRes.value
+
+  const clockBufferAreaRes = queryMetric(
+    'Clock',
+    'Clock Buffer Area',
+    ['CTS', 'Route'],
+    [
+      'cts_buffer_area',
+      'CTS.buffer_area',
+      'buffer_area',
+      'clock_buffer_area',
+    ],
+    'um2',
+  )
+  const clockBufferAreaUm2 = clockBufferAreaRes.value
+
+  const clockPathMaxBufferRes = queryMetric(
+    'Clock',
+    'Clock Path Max Buffer',
+    ['CTS'],
+    [
+      'clock_path_max_buffer',
+      'CTS.clock_path_max_buffer',
+      'max_buffer_per_path',
+    ],
+    'count',
+  )
+  const clockPathMaxBuffer = clockPathMaxBufferRes.value
+
+  const clockPathMinBufferRes = queryMetric(
+    'Clock',
+    'Clock Path Min Buffer',
+    ['CTS'],
+    [
+      'clock_path_min_buffer',
+      'CTS.clock_path_min_buffer',
+      'min_buffer_per_path',
+    ],
+    'count',
+  )
+  const clockPathMinBuffer = clockPathMinBufferRes.value
+
+  const clockNetsCountRes = queryMetric(
+    'Clock',
+    'Clock Nets Count',
+    ['CTS', 'Route', 'Harden'],
+    [
+      'Nets.num_clock',
+      'num_clock_nets',
+      'clock_nets',
+      'num_clock',
+    ],
+    'count',
+  )
+  const clockNetsCount = clockNetsCountRes.value
+
+  const clockInverterCountRes = queryMetric(
+    'Clock',
+    'Clock Inverter Count',
+    ['CTS', 'Route'],
+    [
+      'cts_inverter_count',
+      'clock_inverter_count',
+      'clock_inverters',
+      'num_clock_inverters',
+    ],
+    'count',
+  )
+  const clockInverterCount = clockInverterCountRes.value
+
+  const clockTreeLevelsRes = queryMetric(
+    'Clock',
+    'Clock Tree Levels',
+    ['CTS', 'STA'],
+    [
+      'cts_clock_tree_max_level',
+      'CTS.max_level_of_clock_tree',
+      'max_level_of_clock_tree',
+      'clock_tree_max_level',
+      'clock_tree_levels',
+      'clock_levels',
+      'tree_depth',
+      'max_level',
+      'clock_max_level',
+    ],
+    'levels',
+  )
+  const clockTreeLevels = clockTreeLevelsRes.value
+
+  const clockCellCountRes = queryMetric(
+    'Clock',
+    'Clock Cell Count',
+    ['CTS', 'Route', 'Harden'],
+    ['Instances.clock.num', 'clock_cell_count', 'clock_cells'],
+    'count',
+  )
+  const clockCellCount = clockCellCountRes.value
+
+  const clockTotalBuffers =
+    clockCellCount !== null
+      ? clockCellCount
+      : clockBufferCount !== null || clockInverterCount !== null
+        ? (clockBufferCount ?? 0) + (clockInverterCount ?? 0)
+        : null
+
+  const clock: ClockMetrics = {
+    clockSkewPs,
+    clockLatencyNs,
+    clockWirelengthUm,
+    clockMaxWirelengthUm,
+    clockBufferCount,
+    clockInverterCount,
+    clockTotalBuffers,
+    clockBufferAreaUm2,
+    clockPathMaxBuffer,
+    clockPathMinBuffer,
+    clockNetsCount,
+    clockTreeLevels,
+    clockCellCount,
+  }
+
+  // 6. Routing Metrics
+  const hpwlRes = queryMetric(
+    'Routing',
+    'Half-Perimeter Wirelength',
+    ['Place', 'Floor'],
+    ['place_hpwl', 'hpwl', 'hpwl_um', 'half_perimeter_wirelength'],
+    'um',
+  )
+  const hpwlUm = hpwlRes.value
+
+  const estWirelengthRes = queryMetric(
+    'Routing',
+    'Estimated Wirelength',
+    ['Place', 'CTS', 'Route'],
+    ['place_flute_wirelength', 'place_grwl', 'estimated_wirelength', 'estimated_wirelength_um'],
+    'um',
+  )
+  const estimatedWirelengthUm = estWirelengthRes.value
+
+  const routedWirelengthRes = queryMetric(
+    'Routing',
+    'Routed Wirelength',
+    ['Route', 'Harden'],
+    [
+      'route_dr_total_wirelength',
+      'route_wirelength',
+      'Nets.wire_len',
+      'routed_wirelength',
+      'routed_wirelength_um',
+      'wirelength',
+      'wire_len',
+    ],
+    'um',
+  )
+  const routedWirelengthUm = routedWirelengthRes.value
+
+  const viaCountRes = queryMetric(
+    'Routing',
+    'Via Count',
+    ['Route', 'Harden'],
+    [
+      'route_dr_total_via_count',
+      'route_via_count',
+      'Nets.num_via',
+      'via_count',
+      'vias',
+      'num_vias',
+      'num_via',
+    ],
+    'count',
+  )
+  const viaCount = viaCountRes.value
+
+  const routingCompletionRes = queryMetric(
+    'Routing',
+    'Routing Completion',
+    ['Route', 'Harden', 'STA'],
+    [
+      'routing_completion',
+      'routing_completion_pct',
+      'route_completion',
+      'route_completion_pct',
+      'completion_pct',
+      'drc_completion',
+      'routed_pct',
+      'Nets.routed_pct',
+      'routed_nets_pct',
+      'route_dr_routed_net_pct',
+    ],
+    '%',
+  )
+  let routingCompletionPct = routingCompletionRes.value
+  if (routingCompletionPct !== null && routingCompletionPct > 0 && routingCompletionPct <= 1.0) {
+    routingCompletionPct = +(routingCompletionPct * 100).toFixed(1)
+  }
+  if (routingCompletionPct === null) {
+    const isRouteSuccess =
+      Array.isArray(flow.steps) &&
+      flow.steps.some(
+        (st: unknown) =>
+          isRecord(st) &&
+          typeof st.name === 'string' &&
+          /^(Route|route_ecc|Harden|Harden_ecc)$/i.test(st.name) &&
+          /^(Success|Complete)$/i.test(String(st.state)),
+      )
+    if (isRouteSuccess || (routedWirelengthUm !== null && routedWirelengthUm > 0)) {
+      routingCompletionPct = 100.0
+    }
+  }
+
+  const routeDrcRes = queryMetric(
+    'Routing',
+    'Route DRC Violations',
+    ['Route'],
+    [
+      'route_dr_total_violation_count',
+      'route_drc_count',
+      'drc_violations',
+      'route_violations',
+    ],
+    'count',
+  )
+  const routeDrcCount = routeDrcRes.value
+
+  const routing: RoutingMetrics = {
+    hpwlUm,
+    estimatedWirelengthUm,
+    routedWirelengthUm,
+    viaCount,
+    routingCompletionPct,
+    routeDrcCount,
+  }
+
+  // 7. Congestion Metrics
+  const globalOverflowTotalRes = queryMetric(
+    'Congestion',
+    'Global Overflow Total',
+    ['Route', 'Place'],
+    [
+      'route_la_total_overflow',
+      'place_congestion_egr_overflow_total',
+      'global_overflow',
+      'global_overflow_total',
+      'total_overflow',
+    ],
+    'tracks',
+  )
+  const globalOverflowTotal = globalOverflowTotalRes.value
+
+  const globalOverflowPctRes = queryMetric(
+    'Congestion',
+    'Global Overflow Pct',
+    ['Route', 'Place'],
+    ['global_overflow_pct', 'overflow_pct'],
+    '%',
+  )
+  const globalOverflowPct = globalOverflowPctRes.value
+
+  const maxOverflowRes = queryMetric(
+    'Congestion',
+    'Max Overflow',
+    ['Route', 'Place'],
+    [
+      'place_congestion_egr_overflow_max',
+      'max_overflow',
+      'peak_overflow',
+    ],
+    'tracks',
+  )
+  const maxOverflow = maxOverflowRes.value
+
+  const hCongestionRes = queryMetric(
+    'Congestion',
+    'Horizontal Congestion Pct',
+    ['Place', 'Route'],
+    [
+      'place_rudy_utilization_max',
+      'place_lutrudy_utilization_max',
+      'horizontal_congestion_pct',
+      'h_congestion_pct',
+    ],
+    '%',
+  )
+  const horizontalCongestionPct = hCongestionRes.value
+
+  const vCongestionRes = queryMetric(
+    'Congestion',
+    'Vertical Congestion Pct',
+    ['Place', 'Route'],
+    [
+      'place_rudy_utilization_max',
+      'vertical_congestion_pct',
+      'v_congestion_pct',
+    ],
+    '%',
+  )
+  const verticalCongestionPct = vCongestionRes.value
+
+  const hotspotsCountRes = queryMetric(
+    'Congestion',
+    'Congestion Hotspots',
+    ['Route', 'Place'],
+    ['hotspots_count', 'num_hotspots', 'hotspot_count'],
+    'count',
+  )
+  const hotspotsCount = hotspotsCountRes.value
+
+  const congestion: CongestionMetrics = {
+    globalOverflowTotal,
+    globalOverflowPct,
+    maxOverflow,
+    horizontalCongestionPct,
+    verticalCongestionPct,
+    hotspotsCount,
+  }
+
+  // 8. Power Metrics
+  let totalPowerMw: number | null = null
+  const totPowerRes = queryMetric(
+    'Power',
+    'Total Power',
+    ['Power', 'STA', 'Route', 'Harden'],
+    ['total_power', 'total_power_mw', 'power.total', 'power_total', 'power_mw', 'sta_total_power', 'power.total_power'],
+    'mW',
+  )
+  totalPowerMw = totPowerRes.value
+
+  const dynPowerRes = queryMetric(
+    'Power',
+    'Dynamic Power',
+    ['Power', 'STA', 'Route', 'Harden'],
+    ['dynamic_power', 'dynamic_power_mw', 'power.dynamic', 'power_dynamic', 'sta_dynamic_power'],
+    'mW',
+  )
+  const dynamicPowerMw = dynPowerRes.value
+
+  const swPowerRes = queryMetric(
+    'Power',
+    'Switching Power',
+    ['Power', 'STA', 'Route', 'Harden'],
+    ['switching_power', 'switching_power_mw', 'power.switching', 'power_switching'],
+    'mW',
+  )
+  const switchingPowerMw = swPowerRes.value
+
+  const intPowerRes = queryMetric(
+    'Power',
+    'Internal Power',
+    ['Power', 'STA', 'Route', 'Harden'],
+    ['internal_power', 'internal_power_mw', 'power.internal', 'power_internal'],
+    'mW',
+  )
+  const internalPowerMw = intPowerRes.value
+
+  const leakPowerRes = queryMetric(
+    'Power',
+    'Leakage Power',
+    ['Power', 'STA', 'Route', 'Harden'],
+    ['leakage_power', 'leakage_power_mw', 'power.leakage', 'power_leakage', 'sta_leakage_power'],
+    'mW',
+  )
+  const leakagePowerMw = leakPowerRes.value
+
+  if (totalPowerMw === null && (dynamicPowerMw !== null || leakagePowerMw !== null)) {
+    totalPowerMw = +((dynamicPowerMw ?? 0) + (leakagePowerMw ?? 0)).toFixed(3)
+  }
+
+  const voltRes = queryMetric(
+    'Power',
+    'Operating Voltage',
+    ['Power', 'STA', 'Parameters'],
+    ['voltage', 'voltage_v', 'VOLTAGE', 'VDD', 'vdd', 'supply_voltage'],
+    'V',
+  )
+  const voltageV = voltRes.value
+
+  const tempRes = queryMetric(
+    'Power',
+    'Operating Temperature',
+    ['Power', 'STA', 'Parameters'],
+    ['temperature', 'temperature_c', 'TEMPERATURE', 'TEMP', 'temp', 'operating_temp'],
+    '°C',
+  )
+  const temperatureC = tempRes.value
+
+  const power: PowerMetrics = {
+    totalPowerMw,
+    dynamicPowerMw,
+    switchingPowerMw,
+    internalPowerMw,
+    leakagePowerMw,
+    voltageV,
+    temperatureC,
+    corner: typeof params.POWER_CORNER === 'string' ? params.POWER_CORNER : null,
+    activityMethod: typeof params.POWER_ACTIVITY === 'string' ? params.POWER_ACTIVITY : null,
+  }
+
+  // 9. Physical Verification & Signoff
+  const drcCountRes = queryMetric(
+    'Verification',
+    'DRC Violations',
+    ['DRC', 'Harden', 'Route'],
+    ['drc_count', 'drc_violations', 'violations_count', 'errors', 'drc_errors'],
+    'violations',
+  )
+  const drcCount = drcCountRes.value
+  const drcStatus =
+    drcCount === null ? 'unrun' : drcCount === 0 ? 'clean' : 'violations'
+
+  const lvsCountRes = queryMetric(
+    'Verification',
+    'LVS Mismatches',
+    ['LVS', 'Harden'],
+    ['lvs_count', 'lvs_mismatches', 'mismatches', 'lvs_errors'],
+    'mismatches',
+  )
+  const lvsMismatchCount = lvsCountRes.value
+  const lvsStatus =
+    lvsMismatchCount === null ? 'unrun' : lvsMismatchCount === 0 ? 'matched' : 'mismatch'
+
+  const antennaRes = queryMetric(
+    'Verification',
+    'Antenna Violations',
+    ['DRC', 'Route'],
+    ['antenna_violations', 'antenna_errors', 'antenna_count'],
+    'violations',
+  )
+  const antennaViolations = antennaRes.value
+
+  const ercRes = queryMetric(
+    'Verification',
+    'ERC Violations',
+    ['DRC', 'LVS'],
+    ['erc_violations', 'erc_errors', 'erc_count'],
+    'violations',
+  )
+  const ercViolations = ercRes.value
+
+  const floatingNetsRes = queryMetric(
+    'Verification',
+    'Floating Nets',
+    ['LVS', 'DRC'],
+    ['floating_nets', 'floating_net_count'],
+    'nets',
+  )
+  const floatingNetsCount = floatingNetsRes.value
+
+  const unconnectedPinsRes = queryMetric(
+    'Verification',
+    'Unconnected Pins',
+    ['LVS', 'DRC'],
+    ['unconnected_pins', 'unconnected_pin_count'],
+    'pins',
+  )
+  const unconnectedPinsCount = unconnectedPinsRes.value
+
+  const verification: VerificationMetrics = {
+    drcCount,
+    drcStatus,
+    lvsStatus,
+    lvsMismatchCount,
+    antennaViolations,
+    ercViolations,
+    floatingNetsCount,
+    unconnectedPinsCount,
+  }
+
+  // 10. Execution & Flow Runtime
+  const stages: StageExecutionRecord[] = []
+  let totalRuntimeSeconds = 0
+  let peakMemoryMb: number | null = null
+
+  if (Array.isArray(flow.steps)) {
+    for (const rawStep of flow.steps) {
+      if (!isRecord(rawStep)) continue
+      const name = typeof rawStep.name === 'string' ? rawStep.name : 'Unknown'
+      const tool = typeof rawStep.tool === 'string' ? rawStep.tool : name
+      const state = typeof rawStep.state === 'string' ? rawStep.state : 'Unknown'
+      const runtimeRaw = rawStep.runtime
+      const runtimeSec = parseRuntimeSeconds(
+        typeof runtimeRaw === 'string' || typeof runtimeRaw === 'number' ? runtimeRaw : null,
+      )
+      const memoryRaw =
+        rawStep['peak memory (mb)'] ??
+        rawStep.peak_memory_mb ??
+        rawStep.peakMemoryMb ??
+        (isRecord(rawStep.info) ? rawStep.info['peak memory (mb)'] : null)
+      const memMb = parseNumber(memoryRaw)
+
+      if (runtimeSec !== null) {
+        totalRuntimeSeconds += runtimeSec
+      }
+      if (memMb !== null && (peakMemoryMb === null || memMb > peakMemoryMb)) {
+        peakMemoryMb = memMb
+      }
+
+      stages.push({
+        stage: canonicalizeStageName(name),
+        tool,
+        runtimeSeconds: runtimeSec,
+        runtimeFormatted: formatDuration(runtimeSec),
+        peakMemoryMb: memMb,
+        state,
+      })
+    }
+  }
+
+  const execution: ExecutionMetrics = {
+    totalRuntimeSeconds: totalRuntimeSeconds > 0 ? totalRuntimeSeconds : null,
+    totalRuntimeFormatted: formatDuration(totalRuntimeSeconds),
+    peakMemoryMb,
+    stages,
+  }
+
+  const toolVersions: Record<string, string> = {}
+  if (isRecord(flow.tools)) {
+    for (const [k, v] of Object.entries(flow.tools)) {
+      if (typeof v === 'string') toolVersions[k] = v
+    }
+  }
+
+  const design: DesignInfo = {
+    designName,
+    workspaceName: input.workspaceName || designName,
+    workspacePath: input.workspacePath || '',
+    pdk,
+    pdkVersion,
+    pdkCommit,
+    eccTool,
+    eccVersion,
+    ecosStudioVersion,
+    toolVersions,
+    gitCommit,
+    runId,
+    timestamp,
+    generatedAt,
+  }
+
+  return {
+    design,
+    physical,
+    timing,
+    multiCornerTiming,
+    clock,
+    routing,
+    congestion,
+    power,
+    verification,
+    execution,
+    provenance,
+    warnings,
+  }
+}

--- a/ecos/gui/packages/shared/src/utils/designReportExtract.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportExtract.ts
@@ -58,7 +58,9 @@ function parseJsonSafely(value: unknown): Record<string, unknown> | null {
   return null
 }
 
-export function parseRuntimeSeconds(runtime: string | number | null | undefined): number | null {
+export function parseRuntimeSeconds(
+  runtime: string | number | null | undefined,
+): number | null {
   if (typeof runtime === 'number' && Number.isFinite(runtime)) return runtime
   if (typeof runtime !== 'string' || !runtime.trim()) return null
   const parts = runtime.split(':').map((p) => Number(p.trim()))
@@ -221,7 +223,9 @@ export interface ParsedQorSummaryMetrics {
   holdNvp: number | null
 }
 
-export function parseQorSummaryRpt(text: string | null | undefined): ParsedQorSummaryMetrics {
+export function parseQorSummaryRpt(
+  text: string | null | undefined,
+): ParsedQorSummaryMetrics {
   if (!text) {
     return {
       wns: null,
@@ -271,7 +275,6 @@ export function parseQorSummaryRpt(text: string | null | undefined): ParsedQorSu
   }
 }
 
-
 interface RawMetricFinding {
   value: unknown
   sourceKey: string
@@ -313,11 +316,19 @@ function findMetricInRecord(
   if (Array.isArray(metricsRecord.metrics)) {
     for (const item of metricsRecord.metrics) {
       if (!isRecord(item)) continue
-      const id = typeof item.id === 'string' ? item.id.toLowerCase().replace(/[\s_-]/g, '') : ''
-      const displayName = typeof item.display_name === 'string' ? item.display_name.toLowerCase().replace(/[\s_-]/g, '') : ''
+      const id =
+        typeof item.id === 'string' ? item.id.toLowerCase().replace(/[\s_-]/g, '') : ''
+      const displayName =
+        typeof item.display_name === 'string'
+          ? item.display_name.toLowerCase().replace(/[\s_-]/g, '')
+          : ''
       for (const alias of aliases) {
         const normAlias = alias.toLowerCase().replace(/[\s_-]/g, '')
-        if ((id === normAlias || displayName === normAlias) && item.value !== undefined && item.value !== null) {
+        if (
+          (id === normAlias || displayName === normAlias) &&
+          item.value !== undefined &&
+          item.value !== null
+        ) {
           return {
             value: item.value,
             sourceKey: typeof item.id === 'string' ? item.id : alias,
@@ -330,7 +341,11 @@ function findMetricInRecord(
 
   // 2. Direct property matches on root
   for (const alias of aliases) {
-    if (alias in metricsRecord && metricsRecord[alias] !== undefined && metricsRecord[alias] !== null) {
+    if (
+      alias in metricsRecord &&
+      metricsRecord[alias] !== undefined &&
+      metricsRecord[alias] !== null
+    ) {
       return {
         value: metricsRecord[alias],
         sourceKey: alias,
@@ -374,7 +389,11 @@ function findMetricInRecord(
     const normAlias = alias.toLowerCase().replace(/[\s_-]/g, '')
     for (const key of Object.keys(metricsRecord)) {
       const normKey = key.toLowerCase().replace(/[\s_-]/g, '')
-      if (normKey === normAlias && metricsRecord[key] !== undefined && metricsRecord[key] !== null) {
+      if (
+        normKey === normAlias &&
+        metricsRecord[key] !== undefined &&
+        metricsRecord[key] !== null
+      ) {
         return {
           value: metricsRecord[key],
           sourceKey: key,
@@ -400,7 +419,9 @@ function parseNumber(val: unknown): number | null {
   return null
 }
 
-export function extractDesignReportData(input: ExtractDesignReportInput): DesignReportData {
+export function extractDesignReportData(
+  input: ExtractDesignReportInput,
+): DesignReportData {
   const warnings: DesignReportWarning[] = []
   const provenance: EvidenceProvenanceRecord[] = []
 
@@ -462,7 +483,9 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
     (typeof params.ECC_TOOL === 'string' && params.ECC_TOOL) ||
     (typeof params.ecc_tool === 'string' && params.ecc_tool) ||
     (typeof flow.tool === 'string' && flow.tool) ||
-    (Array.isArray(flow.steps) && typeof (flow.steps[0] as Record<string, unknown>)?.tool === 'string' && (flow.steps[0] as Record<string, unknown>).tool as string) ||
+    (Array.isArray(flow.steps) &&
+      typeof (flow.steps[0] as Record<string, unknown>)?.tool === 'string' &&
+      ((flow.steps[0] as Record<string, unknown>).tool as string)) ||
     'ecc'
 
   if (eccTool === 'unknown') {
@@ -509,9 +532,9 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
     const canonical = canonicalizeStageName(key)
     const parsed = parseJsonSafely(value)
     if (parsed) {
-      normalizedStepMetrics[key] = { ...(normalizedStepMetrics[key] || {}), ...parsed }
+      normalizedStepMetrics[key] = { ...normalizedStepMetrics[key], ...parsed }
       normalizedStepMetrics[canonical] = {
-        ...(normalizedStepMetrics[canonical] || {}),
+        ...normalizedStepMetrics[canonical],
         ...parsed,
       }
     }
@@ -521,9 +544,9 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
     const canonical = canonicalizeStageName(key)
     const parsed = parseJsonSafely(value)
     if (parsed) {
-      normalizedStepMetrics[key] = { ...(normalizedStepMetrics[key] || {}), ...parsed }
+      normalizedStepMetrics[key] = { ...normalizedStepMetrics[key], ...parsed }
       normalizedStepMetrics[canonical] = {
-        ...(normalizedStepMetrics[canonical] || {}),
+        ...normalizedStepMetrics[canonical],
         ...parsed,
       }
     }
@@ -533,9 +556,9 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
     const canonical = canonicalizeStageName(key)
     const parsed = parseJsonSafely(value)
     if (parsed) {
-      normalizedStepMetrics[key] = { ...(normalizedStepMetrics[key] || {}), ...parsed }
+      normalizedStepMetrics[key] = { ...normalizedStepMetrics[key], ...parsed }
       normalizedStepMetrics[canonical] = {
-        ...(normalizedStepMetrics[canonical] || {}),
+        ...normalizedStepMetrics[canonical],
         ...parsed,
       }
     }
@@ -543,25 +566,25 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
 
   if (staTimingIssues) {
     normalizedStepMetrics['STA'] = {
-      ...(normalizedStepMetrics['STA'] || {}),
+      ...normalizedStepMetrics['STA'],
       ...staTimingIssues,
     }
   }
 
   if (params && Object.keys(params).length > 0) {
     normalizedStepMetrics['Parameters'] = {
-      ...(normalizedStepMetrics['Parameters'] || {}),
+      ...normalizedStepMetrics['Parameters'],
       ...params,
     }
   }
 
   if (home && Object.keys(home).length > 0) {
     normalizedStepMetrics['Home'] = {
-      ...(normalizedStepMetrics['Home'] || {}),
+      ...normalizedStepMetrics['Home'],
       ...home,
     }
     normalizedStepMetrics['Parameters'] = {
-      ...(normalizedStepMetrics['Parameters'] || {}),
+      ...normalizedStepMetrics['Parameters'],
       ...home,
     }
   }
@@ -682,11 +705,18 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
     '%',
   )
   let coreUtilizationPct = utilRes.value
-  if (coreUtilizationPct !== null && coreUtilizationPct > 0 && coreUtilizationPct <= 1.0) {
+  if (
+    coreUtilizationPct !== null &&
+    coreUtilizationPct > 0 &&
+    coreUtilizationPct <= 1.0
+  ) {
     coreUtilizationPct = +(coreUtilizationPct * 100).toFixed(2)
   }
 
-  if (coreUtilizationPct !== null && (coreUtilizationPct < 0 || coreUtilizationPct > 100)) {
+  if (
+    coreUtilizationPct !== null &&
+    (coreUtilizationPct < 0 || coreUtilizationPct > 100)
+  ) {
     warnings.push({
       code: 'PHYS_UTIL_OUT_OF_RANGE',
       message: `Core utilization ${coreUtilizationPct}% is outside standard range (0-100%).`,
@@ -752,7 +782,14 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
     'Physical',
     'Sequential Cell Count',
     ['Harden', 'Route', 'CTS', 'Place', 'Synth'],
-    ['Instances.clock.num', 'sequential_cells', 'seq_cells', 'sequential_cell_count', 'flip_flops', 'registers'],
+    [
+      'Instances.clock.num',
+      'sequential_cells',
+      'seq_cells',
+      'sequential_cell_count',
+      'flip_flops',
+      'registers',
+    ],
     'count',
   )
   const sequentialCellCount = seqCellRes.value
@@ -761,7 +798,13 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
     'Physical',
     'Combinational Cell Count',
     ['Harden', 'Route', 'Place', 'Synth'],
-    ['Instances.logic.num', 'combinational_cells', 'comb_cells', 'combinational_cell_count', 'logic_cells'],
+    [
+      'Instances.logic.num',
+      'combinational_cells',
+      'comb_cells',
+      'combinational_cell_count',
+      'logic_cells',
+    ],
     'count',
   )
   const combinationalCellCount = combCellRes.value
@@ -788,7 +831,14 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
     'Physical',
     'Total Nets',
     ['Harden', 'Route', 'Legal', 'Place', 'CTS', 'Fanout', 'Floor', 'Synth'],
-    ['Design Statis.num_nets', 'design.num_wires', 'net_count', 'nets', 'netCount', 'num_wires'],
+    [
+      'Design Statis.num_nets',
+      'design.num_wires',
+      'net_count',
+      'nets',
+      'netCount',
+      'num_wires',
+    ],
     'count',
   )
   const netCount = netCountRes.value
@@ -976,42 +1026,42 @@ export function extractDesignReportData(input: ExtractDesignReportInput): Design
   )
   violatingEndpointsHold = endpHoldRes.value
 
-function parseCornerAttributes(name: string): {
-  process: string | null
-  temperatureC: number | null
-  voltageV: number | null
-  rcCorner: string | null
-} {
-  let process: string | null = null
-  let temperatureC: number | null = null
-  let voltageV: number | null = null
-  let rcCorner: string | null = null
+  function parseCornerAttributes(name: string): {
+    process: string | null
+    temperatureC: number | null
+    voltageV: number | null
+    rcCorner: string | null
+  } {
+    let process: string | null = null
+    let temperatureC: number | null = null
+    let voltageV: number | null = null
+    let rcCorner: string | null = null
 
-  const parts = name.split(/[/_]/)
-  for (const p of parts) {
-    const trimmed = p.trim()
-    if (/^(MAX|MIN|ML|TYP|WCL|ss|ff|tt|fs|sf)$/i.test(trimmed)) {
-      process = trimmed.toUpperCase()
-    }
-    const tempMatch = trimmed.match(/^(?:m(\d+)|(-?\d+)C?)$/i)
-    if (tempMatch) {
-      if (tempMatch[1]) {
-        temperatureC = -Number(tempMatch[1])
-      } else if (tempMatch[2]) {
-        temperatureC = Number(tempMatch[2])
+    const parts = name.split(/[/_]/)
+    for (const p of parts) {
+      const trimmed = p.trim()
+      if (/^(MAX|MIN|ML|TYP|WCL|ss|ff|tt|fs|sf)$/i.test(trimmed)) {
+        process = trimmed.toUpperCase()
+      }
+      const tempMatch = trimmed.match(/^(?:m(\d+)|(-?\d+)C?)$/i)
+      if (tempMatch) {
+        if (tempMatch[1]) {
+          temperatureC = -Number(tempMatch[1])
+        } else if (tempMatch[2]) {
+          temperatureC = Number(tempMatch[2])
+        }
+      }
+      const voltMatch = trimmed.match(/(\d+)v(\d+)/i)
+      if (voltMatch) {
+        voltageV = Number(`${voltMatch[1]}.${voltMatch[2]}`)
+      }
+      if (/^(Cworst|RCworst|Cbest|RCbest|TYPICAL|typical|best|worst)$/i.test(trimmed)) {
+        rcCorner = trimmed
       }
     }
-    const voltMatch = trimmed.match(/(\d+)v(\d+)/i)
-    if (voltMatch) {
-      voltageV = Number(`${voltMatch[1]}.${voltMatch[2]}`)
-    }
-    if (/^(Cworst|RCworst|Cbest|RCbest|TYPICAL|typical|best|worst)$/i.test(trimmed)) {
-      rcCorner = trimmed
-    }
-  }
 
-  return { process, temperatureC, voltageV, rcCorner }
-}
+    return { process, temperatureC, voltageV, rcCorner }
+  }
 
   // 4. Multi-Corner Timing Extraction
   const multiCornerTiming: CornerTimingRecord[] = []
@@ -1027,7 +1077,7 @@ function parseCornerAttributes(name: string): {
     if (isRecord(cSrc)) {
       for (const [cName, cData] of Object.entries(cSrc)) {
         if (isRecord(cData)) {
-          mergedCorners[cName] = { ...(mergedCorners[cName] || {}), ...cData }
+          mergedCorners[cName] = { ...mergedCorners[cName], ...cData }
         }
       }
     }
@@ -1043,18 +1093,30 @@ function parseCornerAttributes(name: string): {
     const summarySetup = isRecord(summaryObj?.setup) ? summaryObj.setup : null
     const summaryHold = isRecord(summaryObj?.hold) ? summaryObj.hold : null
 
-    const cSetupWns = parseNumber(cVal.setup_wns ?? cVal.wns ?? setupObj?.wns ?? summarySetup?.wns)
-    const cSetupTns = parseNumber(cVal.setup_tns ?? cVal.tns ?? setupObj?.tns ?? summarySetup?.tns)
+    const cSetupWns = parseNumber(
+      cVal.setup_wns ?? cVal.wns ?? setupObj?.wns ?? summarySetup?.wns,
+    )
+    const cSetupTns = parseNumber(
+      cVal.setup_tns ?? cVal.tns ?? setupObj?.tns ?? summarySetup?.tns,
+    )
     const cHoldWns = parseNumber(cVal.hold_wns ?? holdObj?.wns ?? summaryHold?.wns)
     const cHoldTns = parseNumber(cVal.hold_tns ?? holdObj?.tns ?? summaryHold?.tns)
     const cVoltage = parseNumber(cVal.voltage ?? cVal.voltage_v ?? inferred.voltageV)
-    const cTemp = parseNumber(cVal.temperature ?? cVal.temperature_c ?? inferred.temperatureC)
-    const cProcess = (typeof cVal.process === 'string' && cVal.process) || inferred.process
+    const cTemp = parseNumber(
+      cVal.temperature ?? cVal.temperature_c ?? inferred.temperatureC,
+    )
+    const cProcess =
+      (typeof cVal.process === 'string' && cVal.process) || inferred.process
     const cRc = (typeof cVal.rc === 'string' && cVal.rc) || inferred.rcCorner
-    const cEndpSetup = parseNumber(cVal.violating_endpoints_setup ?? setupObj?.nvp ?? summarySetup?.nvp)
-    const cEndpHold = parseNumber(cVal.violating_endpoints_hold ?? holdObj?.nvp ?? summaryHold?.nvp)
+    const cEndpSetup = parseNumber(
+      cVal.violating_endpoints_setup ?? setupObj?.nvp ?? summarySetup?.nvp,
+    )
+    const cEndpHold = parseNumber(
+      cVal.violating_endpoints_hold ?? holdObj?.nvp ?? summaryHold?.nvp,
+    )
 
-    const pass = (cSetupWns === null || cSetupWns >= 0) && (cHoldWns === null || cHoldWns >= 0)
+    const pass =
+      (cSetupWns === null || cSetupWns >= 0) && (cHoldWns === null || cHoldWns >= 0)
     const status = pass ? 'pass' : 'fail'
 
     multiCornerTiming.push({
@@ -1075,10 +1137,18 @@ function parseCornerAttributes(name: string): {
 
   // If top-level timing metrics were missing, roll them up from multi-corner timing
   if (multiCornerTiming.length > 0) {
-    const validSetupWns = multiCornerTiming.map((c) => c.setupWnsNs).filter((v): v is number => v !== null)
-    const validSetupTns = multiCornerTiming.map((c) => c.setupTnsNs).filter((v): v is number => v !== null)
-    const validHoldWns = multiCornerTiming.map((c) => c.holdWnsNs).filter((v): v is number => v !== null)
-    const validHoldTns = multiCornerTiming.map((c) => c.holdTnsNs).filter((v): v is number => v !== null)
+    const validSetupWns = multiCornerTiming
+      .map((c) => c.setupWnsNs)
+      .filter((v): v is number => v !== null)
+    const validSetupTns = multiCornerTiming
+      .map((c) => c.setupTnsNs)
+      .filter((v): v is number => v !== null)
+    const validHoldWns = multiCornerTiming
+      .map((c) => c.holdWnsNs)
+      .filter((v): v is number => v !== null)
+    const validHoldTns = multiCornerTiming
+      .map((c) => c.holdTnsNs)
+      .filter((v): v is number => v !== null)
 
     if (setupWnsNs === null && validSetupWns.length > 0) {
       setupWnsNs = Math.min(...validSetupWns)
@@ -1138,7 +1208,19 @@ function parseCornerAttributes(name: string): {
     'Timing',
     'Max Slew Violations',
     ['STA', 'Route', 'CTS', 'Synth'],
-    ['slew_violations', 'max_slew_violations', 'slew_viols', 'trans_violations', 'transition_violations', 'max_transition_violations', 'max_slew', 'slew_violation_count', 'summary.slew.violations', 'slew.violations', 'check_slew'],
+    [
+      'slew_violations',
+      'max_slew_violations',
+      'slew_viols',
+      'trans_violations',
+      'transition_violations',
+      'max_transition_violations',
+      'max_slew',
+      'slew_violation_count',
+      'summary.slew.violations',
+      'slew.violations',
+      'check_slew',
+    ],
     'violations',
   )
   let slewViolations = slewViolRes.value
@@ -1150,7 +1232,18 @@ function parseCornerAttributes(name: string): {
     'Timing',
     'Max Cap Violations',
     ['STA', 'Route', 'CTS', 'Synth'],
-    ['cap_violations', 'max_cap_violations', 'cap_viols', 'max_cap', 'capacitance_violations', 'max_capacitance_violations', 'cap_violation_count', 'summary.cap.violations', 'cap.violations', 'check_cap'],
+    [
+      'cap_violations',
+      'max_cap_violations',
+      'cap_viols',
+      'max_cap',
+      'capacitance_violations',
+      'max_capacitance_violations',
+      'cap_violation_count',
+      'summary.cap.violations',
+      'cap.violations',
+      'check_cap',
+    ],
     'violations',
   )
   let capViolations = capViolRes.value
@@ -1162,7 +1255,17 @@ function parseCornerAttributes(name: string): {
     'Timing',
     'Max Fanout Violations',
     ['STA', 'Route', 'Fanout', 'CTS', 'Synth'],
-    ['fanout_violations', 'max_fanout_violations', 'fanout_viols', 'fanout_max_violations', 'max_fanout', 'fanout_violation_count', 'summary.fanout.violations', 'fanout.violations', 'check_fanout'],
+    [
+      'fanout_violations',
+      'max_fanout_violations',
+      'fanout_viols',
+      'fanout_max_violations',
+      'max_fanout',
+      'fanout_violation_count',
+      'summary.fanout.violations',
+      'fanout.violations',
+      'check_fanout',
+    ],
     'violations',
   )
   let fanoutViolations = fanoutViolRes.value
@@ -1174,11 +1277,24 @@ function parseCornerAttributes(name: string): {
     'Timing',
     'Critical Path Delay',
     ['STA', 'Route', 'CTS', 'Synth'],
-    ['critical_path_delay', 'critical_path_delay_ns', 'crit_path_delay', 'data_path_delay', 'arrival_time', 'data_arrival_time', 'path_delay', 'worst_path_delay'],
+    [
+      'critical_path_delay',
+      'critical_path_delay_ns',
+      'crit_path_delay',
+      'data_path_delay',
+      'arrival_time',
+      'data_arrival_time',
+      'path_delay',
+      'worst_path_delay',
+    ],
     'ns',
   )
   let criticalPathDelayNs = critPathRes.value
-  if (criticalPathDelayNs === null && targetClockPeriodNs !== null && setupWnsNs !== null) {
+  if (
+    criticalPathDelayNs === null &&
+    targetClockPeriodNs !== null &&
+    setupWnsNs !== null
+  ) {
     const derived = targetClockPeriodNs - setupWnsNs
     if (derived > 0) {
       criticalPathDelayNs = +derived.toFixed(3)
@@ -1273,11 +1389,7 @@ function parseCornerAttributes(name: string): {
     'Clock',
     'Max Clock Wirelength',
     ['CTS', 'Route'],
-    [
-      'cts_clock_wirelength_max',
-      'max_clock_wirelength',
-      'CTS.max_clock_wirelength',
-    ],
+    ['cts_clock_wirelength_max', 'max_clock_wirelength', 'CTS.max_clock_wirelength'],
     'um',
   )
   const clockMaxWirelengthUm = clockMaxWirelengthRes.value
@@ -1302,12 +1414,7 @@ function parseCornerAttributes(name: string): {
     'Clock',
     'Clock Buffer Area',
     ['CTS', 'Route'],
-    [
-      'cts_buffer_area',
-      'CTS.buffer_area',
-      'buffer_area',
-      'clock_buffer_area',
-    ],
+    ['cts_buffer_area', 'CTS.buffer_area', 'buffer_area', 'clock_buffer_area'],
     'um2',
   )
   const clockBufferAreaUm2 = clockBufferAreaRes.value
@@ -1316,11 +1423,7 @@ function parseCornerAttributes(name: string): {
     'Clock',
     'Clock Path Max Buffer',
     ['CTS'],
-    [
-      'clock_path_max_buffer',
-      'CTS.clock_path_max_buffer',
-      'max_buffer_per_path',
-    ],
+    ['clock_path_max_buffer', 'CTS.clock_path_max_buffer', 'max_buffer_per_path'],
     'count',
   )
   const clockPathMaxBuffer = clockPathMaxBufferRes.value
@@ -1329,11 +1432,7 @@ function parseCornerAttributes(name: string): {
     'Clock',
     'Clock Path Min Buffer',
     ['CTS'],
-    [
-      'clock_path_min_buffer',
-      'CTS.clock_path_min_buffer',
-      'min_buffer_per_path',
-    ],
+    ['clock_path_min_buffer', 'CTS.clock_path_min_buffer', 'min_buffer_per_path'],
     'count',
   )
   const clockPathMinBuffer = clockPathMinBufferRes.value
@@ -1342,12 +1441,7 @@ function parseCornerAttributes(name: string): {
     'Clock',
     'Clock Nets Count',
     ['CTS', 'Route', 'Harden'],
-    [
-      'Nets.num_clock',
-      'num_clock_nets',
-      'clock_nets',
-      'num_clock',
-    ],
+    ['Nets.num_clock', 'num_clock_nets', 'clock_nets', 'num_clock'],
     'count',
   )
   const clockNetsCount = clockNetsCountRes.value
@@ -1431,7 +1525,12 @@ function parseCornerAttributes(name: string): {
     'Routing',
     'Estimated Wirelength',
     ['Place', 'CTS', 'Route'],
-    ['place_flute_wirelength', 'place_grwl', 'estimated_wirelength', 'estimated_wirelength_um'],
+    [
+      'place_flute_wirelength',
+      'place_grwl',
+      'estimated_wirelength',
+      'estimated_wirelength_um',
+    ],
     'um',
   )
   const estimatedWirelengthUm = estWirelengthRes.value
@@ -1489,7 +1588,11 @@ function parseCornerAttributes(name: string): {
     '%',
   )
   let routingCompletionPct = routingCompletionRes.value
-  if (routingCompletionPct !== null && routingCompletionPct > 0 && routingCompletionPct <= 1.0) {
+  if (
+    routingCompletionPct !== null &&
+    routingCompletionPct > 0 &&
+    routingCompletionPct <= 1.0
+  ) {
     routingCompletionPct = +(routingCompletionPct * 100).toFixed(1)
   }
   if (routingCompletionPct === null) {
@@ -1559,11 +1662,7 @@ function parseCornerAttributes(name: string): {
     'Congestion',
     'Max Overflow',
     ['Route', 'Place'],
-    [
-      'place_congestion_egr_overflow_max',
-      'max_overflow',
-      'peak_overflow',
-    ],
+    ['place_congestion_egr_overflow_max', 'max_overflow', 'peak_overflow'],
     'tracks',
   )
   const maxOverflow = maxOverflowRes.value
@@ -1586,11 +1685,7 @@ function parseCornerAttributes(name: string): {
     'Congestion',
     'Vertical Congestion Pct',
     ['Place', 'Route'],
-    [
-      'place_rudy_utilization_max',
-      'vertical_congestion_pct',
-      'v_congestion_pct',
-    ],
+    ['place_rudy_utilization_max', 'vertical_congestion_pct', 'v_congestion_pct'],
     '%',
   )
   const verticalCongestionPct = vCongestionRes.value
@@ -1619,7 +1714,15 @@ function parseCornerAttributes(name: string): {
     'Power',
     'Total Power',
     ['Power', 'STA', 'Route', 'Harden'],
-    ['total_power', 'total_power_mw', 'power.total', 'power_total', 'power_mw', 'sta_total_power', 'power.total_power'],
+    [
+      'total_power',
+      'total_power_mw',
+      'power.total',
+      'power_total',
+      'power_mw',
+      'sta_total_power',
+      'power.total_power',
+    ],
     'mW',
   )
   totalPowerMw = totPowerRes.value
@@ -1628,7 +1731,13 @@ function parseCornerAttributes(name: string): {
     'Power',
     'Dynamic Power',
     ['Power', 'STA', 'Route', 'Harden'],
-    ['dynamic_power', 'dynamic_power_mw', 'power.dynamic', 'power_dynamic', 'sta_dynamic_power'],
+    [
+      'dynamic_power',
+      'dynamic_power_mw',
+      'power.dynamic',
+      'power_dynamic',
+      'sta_dynamic_power',
+    ],
     'mW',
   )
   const dynamicPowerMw = dynPowerRes.value
@@ -1655,7 +1764,13 @@ function parseCornerAttributes(name: string): {
     'Power',
     'Leakage Power',
     ['Power', 'STA', 'Route', 'Harden'],
-    ['leakage_power', 'leakage_power_mw', 'power.leakage', 'power_leakage', 'sta_leakage_power'],
+    [
+      'leakage_power',
+      'leakage_power_mw',
+      'power.leakage',
+      'power_leakage',
+      'sta_leakage_power',
+    ],
     'mW',
   )
   const leakagePowerMw = leakPowerRes.value
@@ -1691,7 +1806,8 @@ function parseCornerAttributes(name: string): {
     voltageV,
     temperatureC,
     corner: typeof params.POWER_CORNER === 'string' ? params.POWER_CORNER : null,
-    activityMethod: typeof params.POWER_ACTIVITY === 'string' ? params.POWER_ACTIVITY : null,
+    activityMethod:
+      typeof params.POWER_ACTIVITY === 'string' ? params.POWER_ACTIVITY : null,
   }
 
   // 9. Physical Verification & Signoff
@@ -1703,8 +1819,7 @@ function parseCornerAttributes(name: string): {
     'violations',
   )
   const drcCount = drcCountRes.value
-  const drcStatus =
-    drcCount === null ? 'unrun' : drcCount === 0 ? 'clean' : 'violations'
+  const drcStatus = drcCount === null ? 'unrun' : drcCount === 0 ? 'clean' : 'violations'
 
   const lvsCountRes = queryMetric(
     'Verification',
@@ -1777,7 +1892,9 @@ function parseCornerAttributes(name: string): {
       const state = typeof rawStep.state === 'string' ? rawStep.state : 'Unknown'
       const runtimeRaw = rawStep.runtime
       const runtimeSec = parseRuntimeSeconds(
-        typeof runtimeRaw === 'string' || typeof runtimeRaw === 'number' ? runtimeRaw : null,
+        typeof runtimeRaw === 'string' || typeof runtimeRaw === 'number'
+          ? runtimeRaw
+          : null,
       )
       const memoryRaw =
         rawStep['peak memory (mb)'] ??

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/csvFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/csvFormatter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { extractDesignReportData } from '../designReportExtract.ts'
+import { formatCsvReport } from './csvFormatter.ts'
+
+describe('csvFormatter', () => {
+  const sampleData = extractDesignReportData({
+    workspacePath: '/projects/picorv32/ws_003',
+    parameters: {
+      Design: 'picorv32',
+      PDK: 'ic55',
+      PDK_VERSION: 'v0.12.0',
+      PDK_COMMIT: '1234567890abcdef',
+      ECC_TOOL: 'ecc-fe',
+      ECC_VERSION: '1.4.2',
+      ECOS_STUDIO_VERSION: '0.1.0-alpha.8',
+    },
+    flow: {
+      steps: [
+        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:0:45', 'peak memory (mb)': 180 },
+      ],
+    },
+    stepMetrics: {
+      Harden: {
+        die_area_um2: 250000,
+        core_area_um2: 210000,
+        utilization: 42.0,
+      },
+      CTS: {
+        cts_clock_tree_max_level: 2,
+        cts_buffer_count: 3,
+        cts_buffer_area: 8.4,
+      },
+      STA: {
+        clock_period: 12.5,
+        setup_wns: 0.4,
+        setup_tns: 0.0,
+        hold_wns: 0.15,
+        hold_tns: 0.0,
+      },
+      DRC: { drc_violations: 0 },
+      LVS: { lvs_mismatches: 0 },
+    },
+  })
+
+  it('generates clean, structured 4-column CSV without inaccurate tool names', () => {
+    const csv = formatCsvReport(sampleData)
+    const lines = csv.split('\n')
+    expect(lines[0]).toBe('Category,Metric,Value,Unit')
+    expect(csv).toContain('Design & Technology,Design Name,picorv32,')
+    expect(csv).toContain('Design & Technology,PDK,ic55 (@12345678),')
+    expect(csv).toContain('Design & Technology,ECOS Studio Version,0.1.0-alpha.8,')
+    expect(csv).toContain('Physical & Area,Die Area,250000,um2')
+    expect(csv).toContain('Timing & Performance,Setup WNS,0.4,ns')
+    expect(csv).toContain('Clock Tree & Quality,Clock Tree Depth,2,levels')
+    expect(csv).toContain('Clock Tree & Quality,Clock Buffer Count,3,buffers')
+    expect(csv).toContain('Clock Tree & Quality,Clock Buffer Area,8.4,um2')
+    expect(csv).toContain('Physical Verification,DRC Violations,0,violations')
+    // Ensure no hardcoded tool names
+    expect(csv).not.toContain('DreamPlace')
+    expect(csv).not.toContain('ECC Tool')
+  })
+})

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/csvFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/csvFormatter.test.ts
@@ -16,7 +16,13 @@ describe('csvFormatter', () => {
     },
     flow: {
       steps: [
-        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:0:45', 'peak memory (mb)': 180 },
+        {
+          name: 'Synthesis_yosys',
+          tool: 'Yosys',
+          state: 'Success',
+          runtime: '0:0:45',
+          'peak memory (mb)': 180,
+        },
       ],
     },
     stepMetrics: {

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/csvFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/csvFormatter.ts
@@ -6,7 +6,12 @@ import type {
 function escapeCsv(value: string | number | boolean | null | undefined): string {
   if (value === null || value === undefined) return ''
   const str = String(value)
-  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+  if (
+    str.includes(',') ||
+    str.includes('"') ||
+    str.includes('\n') ||
+    str.includes('\r')
+  ) {
     return `"${str.replace(/"/g, '""')}"`
   }
   return str
@@ -16,10 +21,7 @@ export function formatCsvReport(
   data: DesignReportData,
   options: DesignReportExportOptions = {},
 ): string {
-  const {
-    includeMultiCorner = true,
-    includeStageBreakdown = true,
-  } = options
+  const { includeMultiCorner = true, includeStageBreakdown = true } = options
 
   const rows: string[] = []
 
@@ -35,17 +37,19 @@ export function formatCsvReport(
     unit: string = '',
   ) {
     if (value === null || value === undefined || value === '') return
-    rows.push(
-      [category, metric, value, unit]
-        .map(escapeCsv)
-        .join(','),
-    )
+    rows.push([category, metric, value, unit].map(escapeCsv).join(','))
   }
 
   // 1. Design & Technology
   pushRow('Design & Technology', 'Design Name', data.design.designName)
-  const pdkCommitShort = data.design.pdkCommit ? `@${data.design.pdkCommit.slice(0, 8)}` : null
-  const pdkSuffix = pdkCommitShort ? ` (${pdkCommitShort})` : (data.design.pdkVersion ? ` (${data.design.pdkVersion})` : '')
+  const pdkCommitShort = data.design.pdkCommit
+    ? `@${data.design.pdkCommit.slice(0, 8)}`
+    : null
+  const pdkSuffix = pdkCommitShort
+    ? ` (${pdkCommitShort})`
+    : data.design.pdkVersion
+      ? ` (${data.design.pdkVersion})`
+      : ''
   pushRow('Design & Technology', 'PDK', `${data.design.pdk}${pdkSuffix}`)
   if (data.design.ecosStudioVersion) {
     pushRow('Design & Technology', 'ECOS Studio Version', data.design.ecosStudioVersion)
@@ -63,38 +67,128 @@ export function formatCsvReport(
   pushRow('Physical & Area', 'Macro Area', data.physical.macroAreaUm2, 'um2')
   pushRow('Physical & Area', 'Macro Count', data.physical.macroCount, 'count')
   pushRow('Physical & Area', 'Total Instances', data.physical.instanceCount, 'cells')
-  pushRow('Physical & Area', 'Sequential Cells', data.physical.sequentialCellCount, 'cells')
-  pushRow('Physical & Area', 'Combinational Cells', data.physical.combinationalCellCount, 'cells')
+  pushRow(
+    'Physical & Area',
+    'Sequential Cells',
+    data.physical.sequentialCellCount,
+    'cells',
+  )
+  pushRow(
+    'Physical & Area',
+    'Combinational Cells',
+    data.physical.combinationalCellCount,
+    'cells',
+  )
   pushRow('Physical & Area', 'IO Pins', data.physical.ioPinCount, 'pins')
   pushRow('Physical & Area', 'Total Nets', data.physical.netCount, 'nets')
 
   // 3. Timing & Performance
-  pushRow('Timing & Performance', 'Target Clock Period', data.timing.targetClockPeriodNs, 'ns')
-  pushRow('Timing & Performance', 'Target Frequency', data.timing.targetFrequencyMhz, 'MHz')
+  pushRow(
+    'Timing & Performance',
+    'Target Clock Period',
+    data.timing.targetClockPeriodNs,
+    'ns',
+  )
+  pushRow(
+    'Timing & Performance',
+    'Target Frequency',
+    data.timing.targetFrequencyMhz,
+    'MHz',
+  )
   pushRow('Timing & Performance', 'Achieved Fmax', data.timing.fmaxMhz, 'MHz')
   pushRow('Timing & Performance', 'Setup WNS', data.timing.setupWnsNs, 'ns')
   pushRow('Timing & Performance', 'Setup TNS', data.timing.setupTnsNs, 'ns')
   pushRow('Timing & Performance', 'Hold WNS', data.timing.holdWnsNs, 'ns')
   pushRow('Timing & Performance', 'Hold TNS', data.timing.holdTnsNs, 'ns')
-  pushRow('Timing & Performance', 'Critical Path Delay', data.timing.criticalPathDelayNs, 'ns')
-  pushRow('Timing & Performance', 'Setup Violating Endpoints', data.timing.violatingEndpointsSetup, 'endpoints')
-  pushRow('Timing & Performance', 'Hold Violating Endpoints', data.timing.violatingEndpointsHold, 'endpoints')
-  pushRow('Timing & Performance', 'Slew Violations', data.timing.slewViolations, 'violations')
-  pushRow('Timing & Performance', 'Cap Violations', data.timing.capViolations, 'violations')
-  pushRow('Timing & Performance', 'Fanout Violations', data.timing.fanoutViolations, 'violations')
+  pushRow(
+    'Timing & Performance',
+    'Critical Path Delay',
+    data.timing.criticalPathDelayNs,
+    'ns',
+  )
+  pushRow(
+    'Timing & Performance',
+    'Setup Violating Endpoints',
+    data.timing.violatingEndpointsSetup,
+    'endpoints',
+  )
+  pushRow(
+    'Timing & Performance',
+    'Hold Violating Endpoints',
+    data.timing.violatingEndpointsHold,
+    'endpoints',
+  )
+  pushRow(
+    'Timing & Performance',
+    'Slew Violations',
+    data.timing.slewViolations,
+    'violations',
+  )
+  pushRow(
+    'Timing & Performance',
+    'Cap Violations',
+    data.timing.capViolations,
+    'violations',
+  )
+  pushRow(
+    'Timing & Performance',
+    'Fanout Violations',
+    data.timing.fanoutViolations,
+    'violations',
+  )
 
   // 4. Clock Tree & Quality
-  pushRow('Clock Tree & Quality', 'Clock Tree Depth', data.clock.clockTreeLevels, 'levels')
-  pushRow('Clock Tree & Quality', 'Clock Buffer Count', data.clock.clockBufferCount, 'buffers')
-  pushRow('Clock Tree & Quality', 'Clock Buffer Area', data.clock.clockBufferAreaUm2, 'um2')
-  pushRow('Clock Tree & Quality', 'Clock Path Min Buffer', data.clock.clockPathMinBuffer, 'buffers')
-  pushRow('Clock Tree & Quality', 'Clock Path Max Buffer', data.clock.clockPathMaxBuffer, 'buffers')
-  pushRow('Clock Tree & Quality', 'Total Clock Wirelength', data.clock.clockWirelengthUm, 'um')
-  pushRow('Clock Tree & Quality', 'Max Clock Wirelength', data.clock.clockMaxWirelengthUm, 'um')
+  pushRow(
+    'Clock Tree & Quality',
+    'Clock Tree Depth',
+    data.clock.clockTreeLevels,
+    'levels',
+  )
+  pushRow(
+    'Clock Tree & Quality',
+    'Clock Buffer Count',
+    data.clock.clockBufferCount,
+    'buffers',
+  )
+  pushRow(
+    'Clock Tree & Quality',
+    'Clock Buffer Area',
+    data.clock.clockBufferAreaUm2,
+    'um2',
+  )
+  pushRow(
+    'Clock Tree & Quality',
+    'Clock Path Min Buffer',
+    data.clock.clockPathMinBuffer,
+    'buffers',
+  )
+  pushRow(
+    'Clock Tree & Quality',
+    'Clock Path Max Buffer',
+    data.clock.clockPathMaxBuffer,
+    'buffers',
+  )
+  pushRow(
+    'Clock Tree & Quality',
+    'Total Clock Wirelength',
+    data.clock.clockWirelengthUm,
+    'um',
+  )
+  pushRow(
+    'Clock Tree & Quality',
+    'Max Clock Wirelength',
+    data.clock.clockMaxWirelengthUm,
+    'um',
+  )
   pushRow('Clock Tree & Quality', 'Clock Nets Count', data.clock.clockNetsCount, 'nets')
   pushRow('Clock Tree & Quality', 'Clock Cell Count', data.clock.clockCellCount, 'cells')
   pushRow('Clock Tree & Quality', 'Clock Skew', data.clock.clockSkewPs, 'ps')
-  pushRow('Clock Tree & Quality', 'Clock Insertion Latency', data.clock.clockLatencyNs, 'ns')
+  pushRow(
+    'Clock Tree & Quality',
+    'Clock Insertion Latency',
+    data.clock.clockLatencyNs,
+    'ns',
+  )
 
   // 5. Multi-Corner Timing
   if (includeMultiCorner && data.multiCornerTiming.length > 0) {
@@ -109,9 +203,19 @@ export function formatCsvReport(
 
   // 6. Routing & Congestion
   pushRow('Routing & Congestion', 'HPWL', data.routing.hpwlUm, 'um')
-  pushRow('Routing & Congestion', 'Routed Wirelength', data.routing.routedWirelengthUm, 'um')
+  pushRow(
+    'Routing & Congestion',
+    'Routed Wirelength',
+    data.routing.routedWirelengthUm,
+    'um',
+  )
   pushRow('Routing & Congestion', 'Via Count', data.routing.viaCount, 'vias')
-  pushRow('Routing & Congestion', 'Global Route Overflow', data.congestion.globalOverflowTotal, 'tracks')
+  pushRow(
+    'Routing & Congestion',
+    'Global Route Overflow',
+    data.congestion.globalOverflowTotal,
+    'tracks',
+  )
   pushRow('Routing & Congestion', 'Max Overflow', data.congestion.maxOverflow, 'tracks')
 
   // 7. Power Analysis
@@ -122,15 +226,37 @@ export function formatCsvReport(
   pushRow('Power Analysis', 'Leakage Power', data.power.leakagePowerMw, 'mW')
 
   // 8. Physical Verification
-  pushRow('Physical Verification', 'DRC Violations', data.verification.drcCount, 'violations')
-  pushRow('Physical Verification', 'LVS Mismatches', data.verification.lvsMismatchCount, 'mismatches')
+  pushRow(
+    'Physical Verification',
+    'DRC Violations',
+    data.verification.drcCount,
+    'violations',
+  )
+  pushRow(
+    'Physical Verification',
+    'LVS Mismatches',
+    data.verification.lvsMismatchCount,
+    'mismatches',
+  )
 
   // 9. Execution Cost
-  pushRow('Execution Cost', 'Total Runtime', data.execution.totalRuntimeFormatted || (data.execution.totalRuntimeSeconds !== null ? `${data.execution.totalRuntimeSeconds} s` : null))
+  pushRow(
+    'Execution Cost',
+    'Total Runtime',
+    data.execution.totalRuntimeFormatted ||
+      (data.execution.totalRuntimeSeconds !== null
+        ? `${data.execution.totalRuntimeSeconds} s`
+        : null),
+  )
   pushRow('Execution Cost', 'Peak Memory', data.execution.peakMemoryMb, 'MB')
   if (includeStageBreakdown && data.execution.stages.length > 0) {
     for (const s of data.execution.stages) {
-      pushRow('Stage Execution', `${s.stage} Runtime`, s.runtimeFormatted || (s.runtimeSeconds !== null ? `${s.runtimeSeconds} s` : null))
+      pushRow(
+        'Stage Execution',
+        `${s.stage} Runtime`,
+        s.runtimeFormatted ||
+          (s.runtimeSeconds !== null ? `${s.runtimeSeconds} s` : null),
+      )
       pushRow('Stage Execution', `${s.stage} Peak Memory`, s.peakMemoryMb, 'MB')
     }
   }

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/csvFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/csvFormatter.ts
@@ -1,0 +1,139 @@
+import type {
+  DesignReportData,
+  DesignReportExportOptions,
+} from '../../contracts/designReport.ts'
+
+function escapeCsv(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return ''
+  const str = String(value)
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export function formatCsvReport(
+  data: DesignReportData,
+  options: DesignReportExportOptions = {},
+): string {
+  const {
+    includeMultiCorner = true,
+    includeStageBreakdown = true,
+  } = options
+
+  const rows: string[] = []
+
+  // CSV Header
+  const headers = ['Category', 'Metric', 'Value', 'Unit']
+  rows.push(headers.map(escapeCsv).join(','))
+
+  // Helper to push a row
+  function pushRow(
+    category: string,
+    metric: string,
+    value: string | number | boolean | null | undefined,
+    unit: string = '',
+  ) {
+    if (value === null || value === undefined || value === '') return
+    rows.push(
+      [category, metric, value, unit]
+        .map(escapeCsv)
+        .join(','),
+    )
+  }
+
+  // 1. Design & Technology
+  pushRow('Design & Technology', 'Design Name', data.design.designName)
+  const pdkCommitShort = data.design.pdkCommit ? `@${data.design.pdkCommit.slice(0, 8)}` : null
+  const pdkSuffix = pdkCommitShort ? ` (${pdkCommitShort})` : (data.design.pdkVersion ? ` (${data.design.pdkVersion})` : '')
+  pushRow('Design & Technology', 'PDK', `${data.design.pdk}${pdkSuffix}`)
+  if (data.design.ecosStudioVersion) {
+    pushRow('Design & Technology', 'ECOS Studio Version', data.design.ecosStudioVersion)
+  }
+  if (data.design.gitCommit) {
+    pushRow('Design & Technology', 'Git Commit', data.design.gitCommit)
+  }
+  pushRow('Design & Technology', 'Generated At', data.design.generatedAt)
+
+  // 2. Physical & Area
+  pushRow('Physical & Area', 'Die Area', data.physical.dieAreaUm2, 'um2')
+  pushRow('Physical & Area', 'Core Area', data.physical.coreAreaUm2, 'um2')
+  pushRow('Physical & Area', 'Core Utilization', data.physical.coreUtilizationPct, '%')
+  pushRow('Physical & Area', 'Standard Cell Area', data.physical.stdCellAreaUm2, 'um2')
+  pushRow('Physical & Area', 'Macro Area', data.physical.macroAreaUm2, 'um2')
+  pushRow('Physical & Area', 'Macro Count', data.physical.macroCount, 'count')
+  pushRow('Physical & Area', 'Total Instances', data.physical.instanceCount, 'cells')
+  pushRow('Physical & Area', 'Sequential Cells', data.physical.sequentialCellCount, 'cells')
+  pushRow('Physical & Area', 'Combinational Cells', data.physical.combinationalCellCount, 'cells')
+  pushRow('Physical & Area', 'IO Pins', data.physical.ioPinCount, 'pins')
+  pushRow('Physical & Area', 'Total Nets', data.physical.netCount, 'nets')
+
+  // 3. Timing & Performance
+  pushRow('Timing & Performance', 'Target Clock Period', data.timing.targetClockPeriodNs, 'ns')
+  pushRow('Timing & Performance', 'Target Frequency', data.timing.targetFrequencyMhz, 'MHz')
+  pushRow('Timing & Performance', 'Achieved Fmax', data.timing.fmaxMhz, 'MHz')
+  pushRow('Timing & Performance', 'Setup WNS', data.timing.setupWnsNs, 'ns')
+  pushRow('Timing & Performance', 'Setup TNS', data.timing.setupTnsNs, 'ns')
+  pushRow('Timing & Performance', 'Hold WNS', data.timing.holdWnsNs, 'ns')
+  pushRow('Timing & Performance', 'Hold TNS', data.timing.holdTnsNs, 'ns')
+  pushRow('Timing & Performance', 'Critical Path Delay', data.timing.criticalPathDelayNs, 'ns')
+  pushRow('Timing & Performance', 'Setup Violating Endpoints', data.timing.violatingEndpointsSetup, 'endpoints')
+  pushRow('Timing & Performance', 'Hold Violating Endpoints', data.timing.violatingEndpointsHold, 'endpoints')
+  pushRow('Timing & Performance', 'Slew Violations', data.timing.slewViolations, 'violations')
+  pushRow('Timing & Performance', 'Cap Violations', data.timing.capViolations, 'violations')
+  pushRow('Timing & Performance', 'Fanout Violations', data.timing.fanoutViolations, 'violations')
+
+  // 4. Clock Tree & Quality
+  pushRow('Clock Tree & Quality', 'Clock Tree Depth', data.clock.clockTreeLevels, 'levels')
+  pushRow('Clock Tree & Quality', 'Clock Buffer Count', data.clock.clockBufferCount, 'buffers')
+  pushRow('Clock Tree & Quality', 'Clock Buffer Area', data.clock.clockBufferAreaUm2, 'um2')
+  pushRow('Clock Tree & Quality', 'Clock Path Min Buffer', data.clock.clockPathMinBuffer, 'buffers')
+  pushRow('Clock Tree & Quality', 'Clock Path Max Buffer', data.clock.clockPathMaxBuffer, 'buffers')
+  pushRow('Clock Tree & Quality', 'Total Clock Wirelength', data.clock.clockWirelengthUm, 'um')
+  pushRow('Clock Tree & Quality', 'Max Clock Wirelength', data.clock.clockMaxWirelengthUm, 'um')
+  pushRow('Clock Tree & Quality', 'Clock Nets Count', data.clock.clockNetsCount, 'nets')
+  pushRow('Clock Tree & Quality', 'Clock Cell Count', data.clock.clockCellCount, 'cells')
+  pushRow('Clock Tree & Quality', 'Clock Skew', data.clock.clockSkewPs, 'ps')
+  pushRow('Clock Tree & Quality', 'Clock Insertion Latency', data.clock.clockLatencyNs, 'ns')
+
+  // 5. Multi-Corner Timing
+  if (includeMultiCorner && data.multiCornerTiming.length > 0) {
+    for (const c of data.multiCornerTiming) {
+      const prefix = `Multi-Corner [${c.corner}]`
+      pushRow(prefix, 'Setup WNS', c.setupWnsNs, 'ns')
+      pushRow(prefix, 'Setup TNS', c.setupTnsNs, 'ns')
+      pushRow(prefix, 'Hold WNS', c.holdWnsNs, 'ns')
+      pushRow(prefix, 'Hold TNS', c.holdTnsNs, 'ns')
+    }
+  }
+
+  // 6. Routing & Congestion
+  pushRow('Routing & Congestion', 'HPWL', data.routing.hpwlUm, 'um')
+  pushRow('Routing & Congestion', 'Routed Wirelength', data.routing.routedWirelengthUm, 'um')
+  pushRow('Routing & Congestion', 'Via Count', data.routing.viaCount, 'vias')
+  pushRow('Routing & Congestion', 'Global Route Overflow', data.congestion.globalOverflowTotal, 'tracks')
+  pushRow('Routing & Congestion', 'Max Overflow', data.congestion.maxOverflow, 'tracks')
+
+  // 7. Power Analysis
+  pushRow('Power Analysis', 'Total Power', data.power.totalPowerMw, 'mW')
+  pushRow('Power Analysis', 'Dynamic Power', data.power.dynamicPowerMw, 'mW')
+  pushRow('Power Analysis', 'Switching Power', data.power.switchingPowerMw, 'mW')
+  pushRow('Power Analysis', 'Internal Power', data.power.internalPowerMw, 'mW')
+  pushRow('Power Analysis', 'Leakage Power', data.power.leakagePowerMw, 'mW')
+
+  // 8. Physical Verification
+  pushRow('Physical Verification', 'DRC Violations', data.verification.drcCount, 'violations')
+  pushRow('Physical Verification', 'LVS Mismatches', data.verification.lvsMismatchCount, 'mismatches')
+
+  // 9. Execution Cost
+  pushRow('Execution Cost', 'Total Runtime', data.execution.totalRuntimeFormatted || (data.execution.totalRuntimeSeconds !== null ? `${data.execution.totalRuntimeSeconds} s` : null))
+  pushRow('Execution Cost', 'Peak Memory', data.execution.peakMemoryMb, 'MB')
+  if (includeStageBreakdown && data.execution.stages.length > 0) {
+    for (const s of data.execution.stages) {
+      pushRow('Stage Execution', `${s.stage} Runtime`, s.runtimeFormatted || (s.runtimeSeconds !== null ? `${s.runtimeSeconds} s` : null))
+      pushRow('Stage Execution', `${s.stage} Peak Memory`, s.peakMemoryMb, 'MB')
+    }
+  }
+
+  return rows.join('\n')
+}

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/index.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/index.ts
@@ -1,0 +1,33 @@
+import type {
+  DesignReportData,
+  DesignReportExportOptions,
+  DesignReportFormat,
+} from '../../contracts/designReport.ts'
+import { formatCsvReport } from './csvFormatter.ts'
+import { formatLatexReport } from './latexFormatter.ts'
+import { formatMarkdownReport } from './markdownFormatter.ts'
+import { formatTextReport } from './textFormatter.ts'
+
+export { formatCsvReport } from './csvFormatter.ts'
+export { formatLatexReport } from './latexFormatter.ts'
+export { formatMarkdownReport } from './markdownFormatter.ts'
+export { formatTextReport } from './textFormatter.ts'
+
+export function generateDesignReport(
+  data: DesignReportData,
+  format: DesignReportFormat,
+  options: DesignReportExportOptions = {},
+): string {
+  switch (format) {
+    case 'latex':
+      return formatLatexReport(data, options)
+    case 'markdown':
+      return formatMarkdownReport(data, options)
+    case 'csv':
+      return formatCsvReport(data, options)
+    case 'text':
+      return formatTextReport(data, options)
+    default:
+      return formatMarkdownReport(data, options)
+  }
+}

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/index.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/index.ts
@@ -7,11 +7,13 @@ import { formatCsvReport } from './csvFormatter.ts'
 import { formatLatexReport } from './latexFormatter.ts'
 import { formatMarkdownReport } from './markdownFormatter.ts'
 import { formatTextReport } from './textFormatter.ts'
+import { formatTypstReport } from './typstFormatter.ts'
 
 export { formatCsvReport } from './csvFormatter.ts'
 export { formatLatexReport } from './latexFormatter.ts'
 export { formatMarkdownReport } from './markdownFormatter.ts'
 export { formatTextReport } from './textFormatter.ts'
+export { formatTypstReport } from './typstFormatter.ts'
 
 export function generateDesignReport(
   data: DesignReportData,
@@ -27,6 +29,8 @@ export function generateDesignReport(
       return formatCsvReport(data, options)
     case 'text':
       return formatTextReport(data, options)
+    case 'typst':
+      return formatTypstReport(data, options)
     default:
       return formatMarkdownReport(data, options)
   }

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.test.ts
@@ -58,7 +58,7 @@ describe('latexFormatter', () => {
 
   it('generates a clean single LaTeX table with booktabs, rich clock metrics, and escaped strings', () => {
     const tex = formatLatexReport(sampleData, { latexStandalone: false })
-    expect(tex).toContain('\\begin{table}[htbp]')
+    expect(tex).toContain('\\begin{table}[!htbp]')
     expect(tex).toContain('\\toprule')
     expect(tex).toContain('\\midrule')
     expect(tex).toContain('\\bottomrule')

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { extractDesignReportData } from '../designReportExtract.ts'
+import { formatLatexReport } from './latexFormatter.ts'
+
+describe('latexFormatter', () => {
+  const sampleData = extractDesignReportData({
+    workspacePath: '/projects/gcd/ws_001',
+    parameters: {
+      Design: 'gcd_core',
+      PDK: 'ic55',
+      PDK_VERSION: 'v0.12.0',
+      ECC_TOOL: 'ecc-fe',
+      ECC_VERSION: '1.4.2',
+      ECOS_STUDIO_VERSION: '0.1.0-alpha.8',
+    },
+    flow: {
+      steps: [
+        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:0:30', 'peak memory (mb)': 120 },
+      ],
+    },
+    stepMetrics: {
+      Harden: {
+        die_area_um2: 100000,
+        core_area_um2: 80000,
+        utilization: 45.0,
+      },
+      CTS: {
+        cts_clock_tree_max_level: 2,
+        cts_buffer_count: 3,
+        cts_buffer_area: 8.4,
+        clock_path_min_buffer: 2,
+        clock_path_max_buffer: 2,
+        total_clock_wirelength: 224087,
+      },
+      STA: {
+        clock_period: 10.0,
+        setup_wns: 0.5,
+        setup_tns: 0.0,
+        hold_wns: 0.1,
+        hold_tns: 0.0,
+        total_power: 0.027,
+        dynamic_power: 0.024,
+        leakage_power: 0.003,
+        corners: {
+          nom_tt_025C_1v80: { setup_wns: 0.5, setup_tns: 0, hold_wns: 0.1, hold_tns: 0 },
+        },
+      },
+      DRC: { drc_violations: 0 },
+      LVS: { lvs_mismatches: 0 },
+    },
+  })
+
+  it('generates a clean single LaTeX table with booktabs, rich clock metrics, and escaped strings', () => {
+    const tex = formatLatexReport(sampleData, { latexStandalone: false })
+    expect(tex).toContain('\\begin{table}[htbp]')
+    expect(tex).toContain('\\toprule')
+    expect(tex).toContain('\\midrule')
+    expect(tex).toContain('\\bottomrule')
+    expect(tex).toContain('gcd\\_core')
+    expect(tex).toContain('100,000')
+    expect(tex).toContain('Clock Tree Depth & 2 levels')
+    expect(tex).toContain('Clock Buffers & 3 (8.40 $\\mu\\mathrm{m}^2$)')
+    expect(tex).toContain('Clock Path Buffers (Min / Max) & 2 / 2')
+    expect(tex).toContain('Total Power & 0.03 mW')
+    expect(tex).toContain('\\end{table}')
+    // Verified: ECC Tool and redundant second table removed
+    expect(tex).not.toContain('ECC Tool')
+    expect(tex).not.toContain('MULTI-CORNER TIMING EVIDENCE')
+    expect(tex).not.toContain('Flow Stage Execution Cost Breakdown')
+    // Ensure there is exactly 1 table
+    const tableMatches = tex.match(/\\begin\{table\}/g) || []
+    expect(tableMatches.length).toBe(1)
+  })
+
+  it('generates a full standalone document when requested', () => {
+    const tex = formatLatexReport(sampleData, { latexStandalone: true })
+    expect(tex).toContain('\\documentclass')
+    expect(tex).toContain('\\begin{document}')
+    expect(tex).toContain('\\end{document}')
+  })
+})

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.test.ts
@@ -15,7 +15,13 @@ describe('latexFormatter', () => {
     },
     flow: {
       steps: [
-        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:0:30', 'peak memory (mb)': 120 },
+        {
+          name: 'Synthesis_yosys',
+          tool: 'Yosys',
+          state: 'Success',
+          runtime: '0:0:30',
+          'peak memory (mb)': 120,
+        },
       ],
     },
     stepMetrics: {

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.ts
@@ -46,15 +46,16 @@ export function formatLatexReport(
     lines.push('\\usepackage{amsmath}')
     lines.push('\\usepackage{amssymb}')
     lines.push('\\usepackage{booktabs}')
-    lines.push('\\usepackage{geometry}')
-    lines.push('\\geometry{margin=1in}')
-    lines.push('')
-    lines.push(`\\title{\\textbf{${escapeLatex(title)}}}`)
-    lines.push('\\author{ECOS Studio Automated Signoff Report}')
-    lines.push('\\date{\\today}')
+    lines.push('\\usepackage[top=1.5cm,bottom=1.5cm,left=1.8cm,right=1.8cm]{geometry}')
+    lines.push('\\renewcommand{\\arraystretch}{0.98}')
+    lines.push('\\setlength{\\tabcolsep}{6pt}')
     lines.push('')
     lines.push('\\begin{document}')
-    lines.push('\\maketitle')
+    lines.push('\\begin{center}')
+    lines.push(`  {\\Large\\textbf{${escapeLatex(title)}}}\\\\[0.25em]`)
+    lines.push('  {\\footnotesize\\today}')
+    lines.push('\\end{center}')
+    lines.push('\\vspace{-0.5em}')
     lines.push('')
   }
 
@@ -68,7 +69,7 @@ export function formatLatexReport(
   lines.push(
     '% ==============================================================================',
   )
-  lines.push('\\begin{table}[htbp]')
+  lines.push('\\begin{table}[!htbp]')
   lines.push('\\centering')
   lines.push(
     `\\caption{Design Implementation and Signoff Summary: ${escapeLatex(data.design.designName)}}`,

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.ts
@@ -12,11 +12,17 @@ function escapeLatex(text: string | null | undefined): string {
     .replace(/\^/g, '\\textasciicircum{}')
 }
 
-function fmtVal(val: number | string | null | undefined, unit = '', decimals = 2): string {
+function fmtVal(
+  val: number | string | null | undefined,
+  unit = '',
+  decimals = 2,
+): string {
   if (val === null || val === undefined) return '---'
   if (typeof val === 'number') {
     if (!Number.isFinite(val)) return '---'
-    const formatted = Number.isInteger(val) ? val.toLocaleString('en-US') : val.toFixed(decimals)
+    const formatted = Number.isInteger(val)
+      ? val.toLocaleString('en-US')
+      : val.toFixed(decimals)
     return unit ? `${formatted} ${unit}` : formatted
   }
   return unit ? `${escapeLatex(String(val))} ${unit}` : escapeLatex(String(val))
@@ -53,15 +59,23 @@ export function formatLatexReport(
   }
 
   // Section 1: Main Design & Summary Table
-  lines.push('% ==============================================================================')
+  lines.push(
+    '% ==============================================================================',
+  )
   lines.push('% ECOS STUDIO DESIGN SUMMARY TABLE')
   lines.push(`% Design: ${data.design.designName} | PDK: ${data.design.pdk}`)
   lines.push(`% Generated: ${data.design.generatedAt}`)
-  lines.push('% ==============================================================================')
+  lines.push(
+    '% ==============================================================================',
+  )
   lines.push('\\begin{table}[htbp]')
   lines.push('\\centering')
-  lines.push(`\\caption{Design Implementation and Signoff Summary: ${escapeLatex(data.design.designName)}}`)
-  lines.push(`\\label{tab:ecos_design_summary_${data.design.designName.toLowerCase().replace(/[^a-z0-9]/g, '_')}}`)
+  lines.push(
+    `\\caption{Design Implementation and Signoff Summary: ${escapeLatex(data.design.designName)}}`,
+  )
+  lines.push(
+    `\\label{tab:ecos_design_summary_${data.design.designName.toLowerCase().replace(/[^a-z0-9]/g, '_')}}`,
+  )
   lines.push('\\begin{tabular}{llr}')
   lines.push('\\toprule')
   lines.push('\\textbf{Category} & \\textbf{Metric} & \\textbf{Value} \\\\')
@@ -70,29 +84,54 @@ export function formatLatexReport(
   // Design & Technology
   lines.push('\\multicolumn{3}{l}{\\textbf{Design and Technology}} \\\\')
   lines.push(`  & Design Name & ${escapeLatex(data.design.designName)} \\\\`)
-  const pdkCommitShort = data.design.pdkCommit ? `@${data.design.pdkCommit.slice(0, 8)}` : null
-  const pdkSuffix = pdkCommitShort ? ` (${pdkCommitShort})` : (data.design.pdkVersion ? ` (${data.design.pdkVersion})` : '')
+  const pdkCommitShort = data.design.pdkCommit
+    ? `@${data.design.pdkCommit.slice(0, 8)}`
+    : null
+  const pdkSuffix = pdkCommitShort
+    ? ` (${pdkCommitShort})`
+    : data.design.pdkVersion
+      ? ` (${data.design.pdkVersion})`
+      : ''
   lines.push(`  & PDK & ${escapeLatex(data.design.pdk + pdkSuffix)} \\\\`)
   if (data.design.ecosStudioVersion) {
-    lines.push(`  & ECOS Studio Version & ${escapeLatex(data.design.ecosStudioVersion)} \\\\`)
+    lines.push(
+      `  & ECOS Studio Version & ${escapeLatex(data.design.ecosStudioVersion)} \\\\`,
+    )
   }
   if (data.design.gitCommit) {
-    lines.push(`  & Git Commit & \\texttt{${escapeLatex(data.design.gitCommit.slice(0, 8))}} \\\\`)
+    lines.push(
+      `  & Git Commit & \\texttt{${escapeLatex(data.design.gitCommit.slice(0, 8))}} \\\\`,
+    )
   }
   lines.push('\\midrule')
 
   // Area & Physical
   lines.push('\\multicolumn{3}{l}{\\textbf{Area and Physical Design}} \\\\')
-  lines.push(`  & Die Area & ${fmtVal(data.physical.dieAreaUm2, '$\\mu\\mathrm{m}^2$')}${data.physical.dieAreaMm2 !== null ? ` (${fmtVal(data.physical.dieAreaMm2, '$\\mathrm{mm}^2$', 4)})` : ''} \\\\`)
-  lines.push(`  & Core Area & ${fmtVal(data.physical.coreAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`)
-  lines.push(`  & Core Utilization & ${fmtVal(data.physical.coreUtilizationPct, '\\%')} \\\\`)
-  lines.push(`  & Standard Cell Area & ${fmtVal(data.physical.stdCellAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`)
+  lines.push(
+    `  & Die Area & ${fmtVal(data.physical.dieAreaUm2, '$\\mu\\mathrm{m}^2$')}${data.physical.dieAreaMm2 !== null ? ` (${fmtVal(data.physical.dieAreaMm2, '$\\mathrm{mm}^2$', 4)})` : ''} \\\\`,
+  )
+  lines.push(
+    `  & Core Area & ${fmtVal(data.physical.coreAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`,
+  )
+  lines.push(
+    `  & Core Utilization & ${fmtVal(data.physical.coreUtilizationPct, '\\%')} \\\\`,
+  )
+  lines.push(
+    `  & Standard Cell Area & ${fmtVal(data.physical.stdCellAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`,
+  )
   if (data.physical.macroCount !== null && data.physical.macroCount > 0) {
-    lines.push(`  & Macro Count / Area & ${fmtVal(data.physical.macroCount)} macros / ${fmtVal(data.physical.macroAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`)
+    lines.push(
+      `  & Macro Count / Area & ${fmtVal(data.physical.macroCount)} macros / ${fmtVal(data.physical.macroAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`,
+    )
   }
   lines.push(`  & Total Instances & ${fmtVal(data.physical.instanceCount)} \\\\`)
-  if (data.physical.sequentialCellCount !== null || data.physical.combinationalCellCount !== null) {
-    lines.push(`  & Sequential / Comb. Cells & ${fmtVal(data.physical.sequentialCellCount)} / ${fmtVal(data.physical.combinationalCellCount)} \\\\`)
+  if (
+    data.physical.sequentialCellCount !== null ||
+    data.physical.combinationalCellCount !== null
+  ) {
+    lines.push(
+      `  & Sequential / Comb. Cells & ${fmtVal(data.physical.sequentialCellCount)} / ${fmtVal(data.physical.combinationalCellCount)} \\\\`,
+    )
   }
   if (data.physical.ioPinCount !== null) {
     lines.push(`  & IO Pins & ${fmtVal(data.physical.ioPinCount)} \\\\`)
@@ -104,34 +143,67 @@ export function formatLatexReport(
 
   // Timing Closure
   lines.push('\\multicolumn{3}{l}{\\textbf{Timing Closure}} \\\\')
-  lines.push(`  & Target Clock Period & ${fmtVal(data.timing.targetClockPeriodNs, 'ns')}${data.timing.targetFrequencyMhz !== null ? ` (${fmtVal(data.timing.targetFrequencyMhz, 'MHz')})` : ''} \\\\`)
-  lines.push(`  & Achieved $F_{\\mathrm{max}}$ & ${fmtVal(data.timing.fmaxMhz, 'MHz')} \\\\`)
-  lines.push(`  & Setup WNS / TNS & ${fmtVal(data.timing.setupWnsNs, 'ns')} / ${fmtVal(data.timing.setupTnsNs, 'ns')} \\\\`)
-  lines.push(`  & Hold WNS / TNS & ${fmtVal(data.timing.holdWnsNs, 'ns')} / ${fmtVal(data.timing.holdTnsNs, 'ns')} \\\\`)
-  if (data.timing.violatingEndpointsSetup !== null || data.timing.violatingEndpointsHold !== null) {
-    lines.push(`  & Violating Endpoints (Setup / Hold) & ${fmtVal(data.timing.violatingEndpointsSetup, '', 0)} / ${fmtVal(data.timing.violatingEndpointsHold, '', 0)} \\\\`)
+  lines.push(
+    `  & Target Clock Period & ${fmtVal(data.timing.targetClockPeriodNs, 'ns')}${data.timing.targetFrequencyMhz !== null ? ` (${fmtVal(data.timing.targetFrequencyMhz, 'MHz')})` : ''} \\\\`,
+  )
+  lines.push(
+    `  & Achieved $F_{\\mathrm{max}}$ & ${fmtVal(data.timing.fmaxMhz, 'MHz')} \\\\`,
+  )
+  lines.push(
+    `  & Setup WNS / TNS & ${fmtVal(data.timing.setupWnsNs, 'ns')} / ${fmtVal(data.timing.setupTnsNs, 'ns')} \\\\`,
+  )
+  lines.push(
+    `  & Hold WNS / TNS & ${fmtVal(data.timing.holdWnsNs, 'ns')} / ${fmtVal(data.timing.holdTnsNs, 'ns')} \\\\`,
+  )
+  if (
+    data.timing.violatingEndpointsSetup !== null ||
+    data.timing.violatingEndpointsHold !== null
+  ) {
+    lines.push(
+      `  & Violating Endpoints (Setup / Hold) & ${fmtVal(data.timing.violatingEndpointsSetup, '', 0)} / ${fmtVal(data.timing.violatingEndpointsHold, '', 0)} \\\\`,
+    )
   }
   if (data.timing.criticalPathDelayNs !== null) {
-    lines.push(`  & Critical Path Delay & ${fmtVal(data.timing.criticalPathDelayNs, 'ns')} \\\\`)
+    lines.push(
+      `  & Critical Path Delay & ${fmtVal(data.timing.criticalPathDelayNs, 'ns')} \\\\`,
+    )
   }
-  if (data.timing.slewViolations !== null || data.timing.capViolations !== null || data.timing.fanoutViolations !== null) {
-    lines.push(`  & DRC Electrical (Slew / Cap / Fanout) & ${fmtVal(data.timing.slewViolations, '', 0)} / ${fmtVal(data.timing.capViolations, '', 0)} / ${fmtVal(data.timing.fanoutViolations, '', 0)} \\\\`)
+  if (
+    data.timing.slewViolations !== null ||
+    data.timing.capViolations !== null ||
+    data.timing.fanoutViolations !== null
+  ) {
+    lines.push(
+      `  & DRC Electrical (Slew / Cap / Fanout) & ${fmtVal(data.timing.slewViolations, '', 0)} / ${fmtVal(data.timing.capViolations, '', 0)} / ${fmtVal(data.timing.fanoutViolations, '', 0)} \\\\`,
+    )
   }
   lines.push('\\midrule')
 
   // Clock Tree & Quality
   lines.push('\\multicolumn{3}{l}{\\textbf{Clock Tree and Quality}} \\\\')
-  lines.push(`  & Clock Tree Depth & ${fmtVal(data.clock.clockTreeLevels, 'levels', 0)} \\\\`)
+  lines.push(
+    `  & Clock Tree Depth & ${fmtVal(data.clock.clockTreeLevels, 'levels', 0)} \\\\`,
+  )
   if (data.clock.clockBufferCount !== null || data.clock.clockTotalBuffers !== null) {
-    const bufCountStr = data.clock.clockBufferCount !== null ? `${data.clock.clockBufferCount}` : `${data.clock.clockTotalBuffers}`
-    const areaStr = data.clock.clockBufferAreaUm2 !== null ? ` (${fmtVal(data.clock.clockBufferAreaUm2, '$\\mu\\mathrm{m}^2$')})` : ''
+    const bufCountStr =
+      data.clock.clockBufferCount !== null
+        ? `${data.clock.clockBufferCount}`
+        : `${data.clock.clockTotalBuffers}`
+    const areaStr =
+      data.clock.clockBufferAreaUm2 !== null
+        ? ` (${fmtVal(data.clock.clockBufferAreaUm2, '$\\mu\\mathrm{m}^2$')})`
+        : ''
     lines.push(`  & Clock Buffers & ${bufCountStr}${areaStr} \\\\`)
   }
   if (data.clock.clockPathMinBuffer !== null || data.clock.clockPathMaxBuffer !== null) {
-    lines.push(`  & Clock Path Buffers (Min / Max) & ${fmtVal(data.clock.clockPathMinBuffer, '', 0)} / ${fmtVal(data.clock.clockPathMaxBuffer, '', 0)} \\\\`)
+    lines.push(
+      `  & Clock Path Buffers (Min / Max) & ${fmtVal(data.clock.clockPathMinBuffer, '', 0)} / ${fmtVal(data.clock.clockPathMaxBuffer, '', 0)} \\\\`,
+    )
   }
   if (data.clock.clockWirelengthUm !== null) {
-    lines.push(`  & Clock Wirelength & ${fmtVal(data.clock.clockWirelengthUm, '$\\mu\\mathrm{m}$')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmtVal(data.clock.clockMaxWirelengthUm, '$\\mu\\mathrm{m}$')})` : ''} \\\\`)
+    lines.push(
+      `  & Clock Wirelength & ${fmtVal(data.clock.clockWirelengthUm, '$\\mu\\mathrm{m}$')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmtVal(data.clock.clockMaxWirelengthUm, '$\\mu\\mathrm{m}$')})` : ''} \\\\`,
+    )
   }
   if (data.clock.clockNetsCount !== null) {
     lines.push(`  & Clock Nets & ${fmtVal(data.clock.clockNetsCount, 'nets', 0)} \\\\`)
@@ -140,17 +212,28 @@ export function formatLatexReport(
     lines.push(`  & Clock Skew & ${fmtVal(data.clock.clockSkewPs, 'ps')} \\\\`)
   }
   if (data.clock.clockLatencyNs !== null) {
-    lines.push(`  & Clock Insertion Latency & ${fmtVal(data.clock.clockLatencyNs, 'ns')} \\\\`)
+    lines.push(
+      `  & Clock Insertion Latency & ${fmtVal(data.clock.clockLatencyNs, 'ns')} \\\\`,
+    )
   }
   lines.push('\\midrule')
 
   // Routing & Congestion
   lines.push('\\multicolumn{3}{l}{\\textbf{Routing and Congestion}} \\\\')
-  lines.push(`  & Half-Perimeter Wirelength (HPWL) & ${fmtVal(data.routing.hpwlUm, '$\\mu\\mathrm{m}$')} \\\\`)
-  lines.push(`  & Routed Wirelength & ${fmtVal(data.routing.routedWirelengthUm, '$\\mu\\mathrm{m}$')} \\\\`)
+  lines.push(
+    `  & Half-Perimeter Wirelength (HPWL) & ${fmtVal(data.routing.hpwlUm, '$\\mu\\mathrm{m}$')} \\\\`,
+  )
+  lines.push(
+    `  & Routed Wirelength & ${fmtVal(data.routing.routedWirelengthUm, '$\\mu\\mathrm{m}$')} \\\\`,
+  )
   lines.push(`  & Via Count & ${fmtVal(data.routing.viaCount, '', 0)} \\\\`)
-  if (data.congestion.globalOverflowTotal !== null || data.congestion.globalOverflowPct !== null) {
-    lines.push(`  & Global Route Overflow & ${fmtVal(data.congestion.globalOverflowTotal, '', 0)}${data.congestion.globalOverflowPct !== null ? ` (${fmtVal(data.congestion.globalOverflowPct, '\\%')})` : ''} \\\\`)
+  if (
+    data.congestion.globalOverflowTotal !== null ||
+    data.congestion.globalOverflowPct !== null
+  ) {
+    lines.push(
+      `  & Global Route Overflow & ${fmtVal(data.congestion.globalOverflowTotal, '', 0)}${data.congestion.globalOverflowPct !== null ? ` (${fmtVal(data.congestion.globalOverflowPct, '\\%')})` : ''} \\\\`,
+    )
   }
   lines.push('\\midrule')
 
@@ -163,8 +246,12 @@ export function formatLatexReport(
 
   // Physical Verification
   lines.push('\\multicolumn{3}{l}{\\textbf{Physical Verification}} \\\\')
-  lines.push(`  & DRC Status & ${data.verification.drcStatus === 'clean' ? 'Clean (0 violations)' : data.verification.drcStatus === 'violations' ? `Violations (${fmtVal(data.verification.drcCount, '', 0)})` : 'Unrun'} \\\\`)
-  lines.push(`  & LVS Status & ${data.verification.lvsStatus === 'matched' ? 'Matched (Clean)' : data.verification.lvsStatus === 'mismatch' ? `Mismatches (${fmtVal(data.verification.lvsMismatchCount, '', 0)})` : 'Unrun'} \\\\`)
+  lines.push(
+    `  & DRC Status & ${data.verification.drcStatus === 'clean' ? 'Clean (0 violations)' : data.verification.drcStatus === 'violations' ? `Violations (${fmtVal(data.verification.drcCount, '', 0)})` : 'Unrun'} \\\\`,
+  )
+  lines.push(
+    `  & LVS Status & ${data.verification.lvsStatus === 'matched' ? 'Matched (Clean)' : data.verification.lvsStatus === 'mismatch' ? `Mismatches (${fmtVal(data.verification.lvsMismatchCount, '', 0)})` : 'Unrun'} \\\\`,
+  )
 
   lines.push('\\bottomrule')
   lines.push('\\end{tabular}')

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/latexFormatter.ts
@@ -1,0 +1,179 @@
+import type {
+  DesignReportData,
+  DesignReportExportOptions,
+} from '../../contracts/designReport.ts'
+
+function escapeLatex(text: string | null | undefined): string {
+  if (text === null || text === undefined || text === '') return '---'
+  return String(text)
+    .replace(/\\/g, '\\textbackslash{}')
+    .replace(/([&%$#_{}])/g, '\\$1')
+    .replace(/~/g, '\\textasciitilde{}')
+    .replace(/\^/g, '\\textasciicircum{}')
+}
+
+function fmtVal(val: number | string | null | undefined, unit = '', decimals = 2): string {
+  if (val === null || val === undefined) return '---'
+  if (typeof val === 'number') {
+    if (!Number.isFinite(val)) return '---'
+    const formatted = Number.isInteger(val) ? val.toLocaleString('en-US') : val.toFixed(decimals)
+    return unit ? `${formatted} ${unit}` : formatted
+  }
+  return unit ? `${escapeLatex(String(val))} ${unit}` : escapeLatex(String(val))
+}
+
+export function formatLatexReport(
+  data: DesignReportData,
+  options: DesignReportExportOptions = {},
+): string {
+  const {
+    latexStandalone = false,
+    title = `Design Summary Report: ${data.design.designName}`,
+  } = options
+
+  const lines: string[] = []
+
+  if (latexStandalone) {
+    lines.push('\\documentclass[10pt,a4paper]{article}')
+    lines.push('\\usepackage[utf8]{inputenc}')
+    lines.push('\\usepackage[T1]{fontenc}')
+    lines.push('\\usepackage{amsmath}')
+    lines.push('\\usepackage{amssymb}')
+    lines.push('\\usepackage{booktabs}')
+    lines.push('\\usepackage{geometry}')
+    lines.push('\\geometry{margin=1in}')
+    lines.push('')
+    lines.push(`\\title{\\textbf{${escapeLatex(title)}}}`)
+    lines.push('\\author{ECOS Studio Automated Signoff Report}')
+    lines.push('\\date{\\today}')
+    lines.push('')
+    lines.push('\\begin{document}')
+    lines.push('\\maketitle')
+    lines.push('')
+  }
+
+  // Section 1: Main Design & Summary Table
+  lines.push('% ==============================================================================')
+  lines.push('% ECOS STUDIO DESIGN SUMMARY TABLE')
+  lines.push(`% Design: ${data.design.designName} | PDK: ${data.design.pdk}`)
+  lines.push(`% Generated: ${data.design.generatedAt}`)
+  lines.push('% ==============================================================================')
+  lines.push('\\begin{table}[htbp]')
+  lines.push('\\centering')
+  lines.push(`\\caption{Design Implementation and Signoff Summary: ${escapeLatex(data.design.designName)}}`)
+  lines.push(`\\label{tab:ecos_design_summary_${data.design.designName.toLowerCase().replace(/[^a-z0-9]/g, '_')}}`)
+  lines.push('\\begin{tabular}{llr}')
+  lines.push('\\toprule')
+  lines.push('\\textbf{Category} & \\textbf{Metric} & \\textbf{Value} \\\\')
+  lines.push('\\midrule')
+
+  // Design & Technology
+  lines.push('\\multicolumn{3}{l}{\\textbf{Design and Technology}} \\\\')
+  lines.push(`  & Design Name & ${escapeLatex(data.design.designName)} \\\\`)
+  const pdkCommitShort = data.design.pdkCommit ? `@${data.design.pdkCommit.slice(0, 8)}` : null
+  const pdkSuffix = pdkCommitShort ? ` (${pdkCommitShort})` : (data.design.pdkVersion ? ` (${data.design.pdkVersion})` : '')
+  lines.push(`  & PDK & ${escapeLatex(data.design.pdk + pdkSuffix)} \\\\`)
+  if (data.design.ecosStudioVersion) {
+    lines.push(`  & ECOS Studio Version & ${escapeLatex(data.design.ecosStudioVersion)} \\\\`)
+  }
+  if (data.design.gitCommit) {
+    lines.push(`  & Git Commit & \\texttt{${escapeLatex(data.design.gitCommit.slice(0, 8))}} \\\\`)
+  }
+  lines.push('\\midrule')
+
+  // Area & Physical
+  lines.push('\\multicolumn{3}{l}{\\textbf{Area and Physical Design}} \\\\')
+  lines.push(`  & Die Area & ${fmtVal(data.physical.dieAreaUm2, '$\\mu\\mathrm{m}^2$')}${data.physical.dieAreaMm2 !== null ? ` (${fmtVal(data.physical.dieAreaMm2, '$\\mathrm{mm}^2$', 4)})` : ''} \\\\`)
+  lines.push(`  & Core Area & ${fmtVal(data.physical.coreAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`)
+  lines.push(`  & Core Utilization & ${fmtVal(data.physical.coreUtilizationPct, '\\%')} \\\\`)
+  lines.push(`  & Standard Cell Area & ${fmtVal(data.physical.stdCellAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`)
+  if (data.physical.macroCount !== null && data.physical.macroCount > 0) {
+    lines.push(`  & Macro Count / Area & ${fmtVal(data.physical.macroCount)} macros / ${fmtVal(data.physical.macroAreaUm2, '$\\mu\\mathrm{m}^2$')} \\\\`)
+  }
+  lines.push(`  & Total Instances & ${fmtVal(data.physical.instanceCount)} \\\\`)
+  if (data.physical.sequentialCellCount !== null || data.physical.combinationalCellCount !== null) {
+    lines.push(`  & Sequential / Comb. Cells & ${fmtVal(data.physical.sequentialCellCount)} / ${fmtVal(data.physical.combinationalCellCount)} \\\\`)
+  }
+  if (data.physical.ioPinCount !== null) {
+    lines.push(`  & IO Pins & ${fmtVal(data.physical.ioPinCount)} \\\\`)
+  }
+  if (data.physical.netCount !== null) {
+    lines.push(`  & Total Nets & ${fmtVal(data.physical.netCount)} \\\\`)
+  }
+  lines.push('\\midrule')
+
+  // Timing Closure
+  lines.push('\\multicolumn{3}{l}{\\textbf{Timing Closure}} \\\\')
+  lines.push(`  & Target Clock Period & ${fmtVal(data.timing.targetClockPeriodNs, 'ns')}${data.timing.targetFrequencyMhz !== null ? ` (${fmtVal(data.timing.targetFrequencyMhz, 'MHz')})` : ''} \\\\`)
+  lines.push(`  & Achieved $F_{\\mathrm{max}}$ & ${fmtVal(data.timing.fmaxMhz, 'MHz')} \\\\`)
+  lines.push(`  & Setup WNS / TNS & ${fmtVal(data.timing.setupWnsNs, 'ns')} / ${fmtVal(data.timing.setupTnsNs, 'ns')} \\\\`)
+  lines.push(`  & Hold WNS / TNS & ${fmtVal(data.timing.holdWnsNs, 'ns')} / ${fmtVal(data.timing.holdTnsNs, 'ns')} \\\\`)
+  if (data.timing.violatingEndpointsSetup !== null || data.timing.violatingEndpointsHold !== null) {
+    lines.push(`  & Violating Endpoints (Setup / Hold) & ${fmtVal(data.timing.violatingEndpointsSetup, '', 0)} / ${fmtVal(data.timing.violatingEndpointsHold, '', 0)} \\\\`)
+  }
+  if (data.timing.criticalPathDelayNs !== null) {
+    lines.push(`  & Critical Path Delay & ${fmtVal(data.timing.criticalPathDelayNs, 'ns')} \\\\`)
+  }
+  if (data.timing.slewViolations !== null || data.timing.capViolations !== null || data.timing.fanoutViolations !== null) {
+    lines.push(`  & DRC Electrical (Slew / Cap / Fanout) & ${fmtVal(data.timing.slewViolations, '', 0)} / ${fmtVal(data.timing.capViolations, '', 0)} / ${fmtVal(data.timing.fanoutViolations, '', 0)} \\\\`)
+  }
+  lines.push('\\midrule')
+
+  // Clock Tree & Quality
+  lines.push('\\multicolumn{3}{l}{\\textbf{Clock Tree and Quality}} \\\\')
+  lines.push(`  & Clock Tree Depth & ${fmtVal(data.clock.clockTreeLevels, 'levels', 0)} \\\\`)
+  if (data.clock.clockBufferCount !== null || data.clock.clockTotalBuffers !== null) {
+    const bufCountStr = data.clock.clockBufferCount !== null ? `${data.clock.clockBufferCount}` : `${data.clock.clockTotalBuffers}`
+    const areaStr = data.clock.clockBufferAreaUm2 !== null ? ` (${fmtVal(data.clock.clockBufferAreaUm2, '$\\mu\\mathrm{m}^2$')})` : ''
+    lines.push(`  & Clock Buffers & ${bufCountStr}${areaStr} \\\\`)
+  }
+  if (data.clock.clockPathMinBuffer !== null || data.clock.clockPathMaxBuffer !== null) {
+    lines.push(`  & Clock Path Buffers (Min / Max) & ${fmtVal(data.clock.clockPathMinBuffer, '', 0)} / ${fmtVal(data.clock.clockPathMaxBuffer, '', 0)} \\\\`)
+  }
+  if (data.clock.clockWirelengthUm !== null) {
+    lines.push(`  & Clock Wirelength & ${fmtVal(data.clock.clockWirelengthUm, '$\\mu\\mathrm{m}$')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmtVal(data.clock.clockMaxWirelengthUm, '$\\mu\\mathrm{m}$')})` : ''} \\\\`)
+  }
+  if (data.clock.clockNetsCount !== null) {
+    lines.push(`  & Clock Nets & ${fmtVal(data.clock.clockNetsCount, 'nets', 0)} \\\\`)
+  }
+  if (data.clock.clockSkewPs !== null) {
+    lines.push(`  & Clock Skew & ${fmtVal(data.clock.clockSkewPs, 'ps')} \\\\`)
+  }
+  if (data.clock.clockLatencyNs !== null) {
+    lines.push(`  & Clock Insertion Latency & ${fmtVal(data.clock.clockLatencyNs, 'ns')} \\\\`)
+  }
+  lines.push('\\midrule')
+
+  // Routing & Congestion
+  lines.push('\\multicolumn{3}{l}{\\textbf{Routing and Congestion}} \\\\')
+  lines.push(`  & Half-Perimeter Wirelength (HPWL) & ${fmtVal(data.routing.hpwlUm, '$\\mu\\mathrm{m}$')} \\\\`)
+  lines.push(`  & Routed Wirelength & ${fmtVal(data.routing.routedWirelengthUm, '$\\mu\\mathrm{m}$')} \\\\`)
+  lines.push(`  & Via Count & ${fmtVal(data.routing.viaCount, '', 0)} \\\\`)
+  if (data.congestion.globalOverflowTotal !== null || data.congestion.globalOverflowPct !== null) {
+    lines.push(`  & Global Route Overflow & ${fmtVal(data.congestion.globalOverflowTotal, '', 0)}${data.congestion.globalOverflowPct !== null ? ` (${fmtVal(data.congestion.globalOverflowPct, '\\%')})` : ''} \\\\`)
+  }
+  lines.push('\\midrule')
+
+  // Power Analysis
+  lines.push('\\multicolumn{3}{l}{\\textbf{Power Analysis}} \\\\')
+  lines.push(`  & Total Power & ${fmtVal(data.power.totalPowerMw, 'mW')} \\\\`)
+  lines.push(`  & Dynamic Power & ${fmtVal(data.power.dynamicPowerMw, 'mW')} \\\\`)
+  lines.push(`  & Leakage Power & ${fmtVal(data.power.leakagePowerMw, 'mW')} \\\\`)
+  lines.push('\\midrule')
+
+  // Physical Verification
+  lines.push('\\multicolumn{3}{l}{\\textbf{Physical Verification}} \\\\')
+  lines.push(`  & DRC Status & ${data.verification.drcStatus === 'clean' ? 'Clean (0 violations)' : data.verification.drcStatus === 'violations' ? `Violations (${fmtVal(data.verification.drcCount, '', 0)})` : 'Unrun'} \\\\`)
+  lines.push(`  & LVS Status & ${data.verification.lvsStatus === 'matched' ? 'Matched (Clean)' : data.verification.lvsStatus === 'mismatch' ? `Mismatches (${fmtVal(data.verification.lvsMismatchCount, '', 0)})` : 'Unrun'} \\\\`)
+
+  lines.push('\\bottomrule')
+  lines.push('\\end{tabular}')
+  lines.push('\\end{table}')
+  lines.push('')
+
+  if (latexStandalone) {
+    lines.push('\\end{document}')
+  }
+
+  return lines.join('\n')
+}

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/markdownFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/markdownFormatter.test.ts
@@ -15,7 +15,13 @@ describe('markdownFormatter', () => {
     },
     flow: {
       steps: [
-        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:1:15', 'peak memory (mb)': 220 },
+        {
+          name: 'Synthesis_yosys',
+          tool: 'Yosys',
+          state: 'Success',
+          runtime: '0:1:15',
+          'peak memory (mb)': 220,
+        },
       ],
     },
     stepMetrics: {
@@ -52,7 +58,9 @@ describe('markdownFormatter', () => {
     expect(md).toContain('52 %')
     expect(md).toContain('Pass')
     expect(md).toContain('| Clock Tree Depth | 3 | levels | Maximum clock tree level |')
-    expect(md).toContain('| Clock Buffers | 5 (14.20 μm²) | count | CTS inserted clock buffers |')
+    expect(md).toContain(
+      '| Clock Buffers | 5 (14.20 μm²) | count | CTS inserted clock buffers |',
+    )
   })
 
   it('renders multi-corner table with timing measurements only', () => {
@@ -69,13 +77,17 @@ describe('markdownFormatter', () => {
           setupTnsNs: 0,
           holdWnsNs: 0.05,
           holdTnsNs: 0,
+          violatingEndpointsSetup: 0,
+          violatingEndpointsHold: 0,
           status: 'pass' as const,
         },
       ],
     }
     const md = formatMarkdownReport(dataWithCorners)
     expect(md).toContain('## 4. Multi-Corner Timing Analysis')
-    expect(md).toContain('| Corner | Setup WNS (ns) | Setup TNS (ns) | Hold WNS (ns) | Hold TNS (ns) | Status |')
+    expect(md).toContain(
+      '| Corner | Setup WNS (ns) | Setup TNS (ns) | Hold WNS (ns) | Hold TNS (ns) | Status |',
+    )
     expect(md).toContain('| `WCL_m40_RCworst` | 0.12 | 0 | 0.05 | 0 | PASS |')
     expect(md).not.toContain('| Corner | Process |')
   })

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/markdownFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/markdownFormatter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { extractDesignReportData } from '../designReportExtract.ts'
+import { formatMarkdownReport } from './markdownFormatter.ts'
+
+describe('markdownFormatter', () => {
+  const sampleData = extractDesignReportData({
+    workspacePath: '/projects/aes/ws_002',
+    parameters: {
+      Design: 'aes_128',
+      PDK: 'ic55',
+      PDK_VERSION: 'v1.0.0',
+      ECC_TOOL: 'ecc-fe',
+      ECC_VERSION: '1.4.2',
+      ECOS_STUDIO_VERSION: '0.1.0-alpha.8',
+    },
+    flow: {
+      steps: [
+        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:1:15', 'peak memory (mb)': 220 },
+      ],
+    },
+    stepMetrics: {
+      Harden: {
+        die_area_um2: 450000,
+        core_area_um2: 380000,
+        utilization: 52.0,
+      },
+      CTS: {
+        cts_clock_tree_max_level: 3,
+        cts_buffer_count: 5,
+        cts_buffer_area: 14.2,
+      },
+      STA: {
+        clock_period: 20.0,
+        setup_wns: 1.25,
+        setup_tns: 0.0,
+        hold_wns: 0.22,
+        hold_tns: 0.0,
+      },
+      DRC: { drc_violations: 0 },
+      LVS: { lvs_mismatches: 0 },
+    },
+  })
+
+  it('generates structured Markdown tables without redundant ECC tool and without emojis', () => {
+    const md = formatMarkdownReport(sampleData)
+    expect(md).toContain('# Design Summary Report: aes_128')
+    expect(md).toContain('**ECOS Studio Version**: `0.1.0-alpha.8`')
+    expect(md).toContain('## 1. Design Summary')
+    expect(md).toContain('## 2. Area & Physical Metrics')
+    expect(md).toContain('## 3. Timing & Clock Quality')
+    expect(md).toContain('450,000')
+    expect(md).toContain('52 %')
+    expect(md).toContain('Pass')
+    expect(md).toContain('| Clock Tree Depth | 3 | levels | Maximum clock tree level |')
+    expect(md).toContain('| Clock Buffers | 5 (14.20 μm²) | count | CTS inserted clock buffers |')
+  })
+
+  it('renders multi-corner table with timing measurements only', () => {
+    const dataWithCorners = {
+      ...sampleData,
+      multiCornerTiming: [
+        {
+          corner: 'WCL_m40_RCworst',
+          processCorner: 'WCL',
+          rcCorner: 'RCworst',
+          temperatureC: -40,
+          voltageV: 0.9,
+          setupWnsNs: 0.12,
+          setupTnsNs: 0,
+          holdWnsNs: 0.05,
+          holdTnsNs: 0,
+          status: 'pass' as const,
+        },
+      ],
+    }
+    const md = formatMarkdownReport(dataWithCorners)
+    expect(md).toContain('## 4. Multi-Corner Timing Analysis')
+    expect(md).toContain('| Corner | Setup WNS (ns) | Setup TNS (ns) | Hold WNS (ns) | Hold TNS (ns) | Status |')
+    expect(md).toContain('| `WCL_m40_RCworst` | 0.12 | 0 | 0.05 | 0 | PASS |')
+    expect(md).not.toContain('| Corner | Process |')
+  })
+})

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/markdownFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/markdownFormatter.ts
@@ -3,12 +3,18 @@ import type {
   DesignReportExportOptions,
 } from '../../contracts/designReport.ts'
 
-function fmt(val: number | string | boolean | null | undefined, unit = '', decimals = 2): string {
+function fmt(
+  val: number | string | boolean | null | undefined,
+  unit = '',
+  decimals = 2,
+): string {
   if (val === null || val === undefined) return '—'
   if (typeof val === 'boolean') return val ? 'true' : 'false'
   if (typeof val === 'number') {
     if (!Number.isFinite(val)) return '—'
-    const formatted = Number.isInteger(val) ? val.toLocaleString('en-US') : val.toFixed(decimals)
+    const formatted = Number.isInteger(val)
+      ? val.toLocaleString('en-US')
+      : val.toFixed(decimals)
     return unit ? `${formatted} ${unit}` : formatted
   }
   return unit ? `${val} ${unit}` : String(val)
@@ -30,8 +36,14 @@ export function formatMarkdownReport(
   lines.push('')
 
   const metaParts: string[] = []
-  const pdkCommitShort = data.design.pdkCommit ? `@${data.design.pdkCommit.slice(0, 8)}` : null
-  const pdkSuffix = pdkCommitShort ? ` (${pdkCommitShort})` : (data.design.pdkVersion ? ` (${data.design.pdkVersion})` : '')
+  const pdkCommitShort = data.design.pdkCommit
+    ? `@${data.design.pdkCommit.slice(0, 8)}`
+    : null
+  const pdkSuffix = pdkCommitShort
+    ? ` (${pdkCommitShort})`
+    : data.design.pdkVersion
+      ? ` (${data.design.pdkVersion})`
+      : ''
   metaParts.push(`**PDK**: \`${data.design.pdk}${pdkSuffix}\``)
   if (data.design.ecosStudioVersion) {
     metaParts.push(`**ECOS Studio Version**: \`${data.design.ecosStudioVersion}\``)
@@ -80,21 +92,51 @@ export function formatMarkdownReport(
   lines.push('')
   lines.push('| Metric | Value | Reference Unit | Status / Notes |')
   lines.push('| :--- | :--- | :--- | :--- |')
-  lines.push(`| **Die Area** | ${fmt(data.physical.dieAreaUm2)}${data.physical.dieAreaMm2 !== null ? ` (${fmt(data.physical.dieAreaMm2, 'mm²', 4)})` : ''} | $\\mu\\text{m}^2$ | Physical boundary |`)
-  lines.push(`| **Core Area** | ${fmt(data.physical.coreAreaUm2)} | $\\mu\\text{m}^2$ | Core boundary |`)
-  lines.push(`| **Core Utilization** | ${fmt(data.physical.coreUtilizationPct, '%')} | % | Placement density |`)
-  lines.push(`| **Instance Count** | ${fmt(data.physical.instanceCount)} | cells | Total standard cells & macros |`)
-  lines.push(`| **Target Frequency** | ${fmt(data.timing.targetFrequencyMhz, 'MHz')} | MHz | ${data.timing.targetClockPeriodNs !== null ? `Clock period: ${fmt(data.timing.targetClockPeriodNs, 'ns')}` : '—'} |`)
-  lines.push(`| **Achieved $F_{\\text{max}}$** | ${fmt(data.timing.fmaxMhz, 'MHz')} | MHz | Based on worst setup slack |`)
-  lines.push(`| **Setup Slack (WNS / TNS)** | ${fmt(data.timing.setupWnsNs, 'ns')} / ${fmt(data.timing.setupTnsNs, 'ns')} | ns | ${setupStatus} |`)
-  lines.push(`| **Hold Slack (WNS / TNS)** | ${fmt(data.timing.holdWnsNs, 'ns')} / ${fmt(data.timing.holdTnsNs, 'ns')} | ns | ${holdStatus} |`)
-  lines.push(`| **Clock Tree QoR** | ${clockTreeSummary} | levels / count | Clock tree structure & buffers |`)
-  lines.push(`| **Routed Wirelength** | ${fmt(data.routing.routedWirelengthUm, 'μm')} | $\\mu\\text{m}$ | Total detailed route wirelength |`)
-  lines.push(`| **Via Count** | ${fmt(data.routing.viaCount)} | count | Total routing vias |`)
-  lines.push(`| **Global Route Overflow** | ${fmt(data.congestion.globalOverflowTotal)}${data.congestion.globalOverflowPct !== null ? ` (${fmt(data.congestion.globalOverflowPct, '%')})` : ''} | tracks | Congestion state |`)
-  lines.push(`| **Total Power** | ${fmt(data.power.totalPowerMw, 'mW')} | mW | Dynamic: ${fmt(data.power.dynamicPowerMw, 'mW')}, Leakage: ${fmt(data.power.leakagePowerMw, 'mW')} |`)
-  lines.push(`| **DRC / LVS Status** | ${data.verification.drcStatus === 'clean' ? 'DRC Clean (0)' : `DRC Violations (${fmt(data.verification.drcCount)})`} / ${data.verification.lvsStatus === 'matched' ? 'LVS Matched' : `LVS Mismatch (${fmt(data.verification.lvsMismatchCount)})`} | status | Signoff verification |`)
-  lines.push(`| **Total Runtime** | ${data.execution.totalRuntimeFormatted || fmt(data.execution.totalRuntimeSeconds, 's')} | time | Peak Memory: ${fmt(data.execution.peakMemoryMb, 'MB')} |`)
+  lines.push(
+    `| **Die Area** | ${fmt(data.physical.dieAreaUm2)}${data.physical.dieAreaMm2 !== null ? ` (${fmt(data.physical.dieAreaMm2, 'mm²', 4)})` : ''} | $\\mu\\text{m}^2$ | Physical boundary |`,
+  )
+  lines.push(
+    `| **Core Area** | ${fmt(data.physical.coreAreaUm2)} | $\\mu\\text{m}^2$ | Core boundary |`,
+  )
+  lines.push(
+    `| **Core Utilization** | ${fmt(data.physical.coreUtilizationPct, '%')} | % | Placement density |`,
+  )
+  lines.push(
+    `| **Instance Count** | ${fmt(data.physical.instanceCount)} | cells | Total standard cells & macros |`,
+  )
+  lines.push(
+    `| **Target Frequency** | ${fmt(data.timing.targetFrequencyMhz, 'MHz')} | MHz | ${data.timing.targetClockPeriodNs !== null ? `Clock period: ${fmt(data.timing.targetClockPeriodNs, 'ns')}` : '—'} |`,
+  )
+  lines.push(
+    `| **Achieved $F_{\\text{max}}$** | ${fmt(data.timing.fmaxMhz, 'MHz')} | MHz | Based on worst setup slack |`,
+  )
+  lines.push(
+    `| **Setup Slack (WNS / TNS)** | ${fmt(data.timing.setupWnsNs, 'ns')} / ${fmt(data.timing.setupTnsNs, 'ns')} | ns | ${setupStatus} |`,
+  )
+  lines.push(
+    `| **Hold Slack (WNS / TNS)** | ${fmt(data.timing.holdWnsNs, 'ns')} / ${fmt(data.timing.holdTnsNs, 'ns')} | ns | ${holdStatus} |`,
+  )
+  lines.push(
+    `| **Clock Tree QoR** | ${clockTreeSummary} | levels / count | Clock tree structure & buffers |`,
+  )
+  lines.push(
+    `| **Routed Wirelength** | ${fmt(data.routing.routedWirelengthUm, 'μm')} | $\\mu\\text{m}$ | Total detailed route wirelength |`,
+  )
+  lines.push(
+    `| **Via Count** | ${fmt(data.routing.viaCount)} | count | Total routing vias |`,
+  )
+  lines.push(
+    `| **Global Route Overflow** | ${fmt(data.congestion.globalOverflowTotal)}${data.congestion.globalOverflowPct !== null ? ` (${fmt(data.congestion.globalOverflowPct, '%')})` : ''} | tracks | Congestion state |`,
+  )
+  lines.push(
+    `| **Total Power** | ${fmt(data.power.totalPowerMw, 'mW')} | mW | Dynamic: ${fmt(data.power.dynamicPowerMw, 'mW')}, Leakage: ${fmt(data.power.leakagePowerMw, 'mW')} |`,
+  )
+  lines.push(
+    `| **DRC / LVS Status** | ${data.verification.drcStatus === 'clean' ? 'DRC Clean (0)' : `DRC Violations (${fmt(data.verification.drcCount)})`} / ${data.verification.lvsStatus === 'matched' ? 'LVS Matched' : `LVS Mismatch (${fmt(data.verification.lvsMismatchCount)})`} | status | Signoff verification |`,
+  )
+  lines.push(
+    `| **Total Runtime** | ${data.execution.totalRuntimeFormatted || fmt(data.execution.totalRuntimeSeconds, 's')} | time | Peak Memory: ${fmt(data.execution.peakMemoryMb, 'MB')} |`,
+  )
   lines.push('')
 
   //Area & Physical Breakdown
@@ -102,16 +144,36 @@ export function formatMarkdownReport(
   lines.push('')
   lines.push('| Metric | Value | Unit | Description |')
   lines.push('| :--- | :--- | :--- | :--- |')
-  lines.push(`| Die Area | ${fmt(data.physical.dieAreaUm2)} | $\\mu\\text{m}^2$ | Overall die boundary area |`)
-  lines.push(`| Core Area | ${fmt(data.physical.coreAreaUm2)} | $\\mu\\text{m}^2$ | Standard cell placement area |`)
-  lines.push(`| Core Utilization | ${fmt(data.physical.coreUtilizationPct, '%')} | % | Ratio of cell area to core area |`)
-  lines.push(`| Standard Cell Area | ${fmt(data.physical.stdCellAreaUm2)} | $\\mu\\text{m}^2$ | Sum of standard cell areas |`)
-  lines.push(`| Macro Area / Count | ${fmt(data.physical.macroAreaUm2, 'μm²')} / ${fmt(data.physical.macroCount)} | $\\mu\\text{m}^2$ / count | Hard macros & memory blocks |`)
-  lines.push(`| Total Instances | ${fmt(data.physical.instanceCount)} | count | Total placed cell instances |`)
-  lines.push(`| Sequential Cells | ${fmt(data.physical.sequentialCellCount)} | count | Flip-flops and latches |`)
-  lines.push(`| Combinational Cells | ${fmt(data.physical.combinationalCellCount)} | count | Logic gates |`)
-  lines.push(`| IO Pins | ${fmt(data.physical.ioPinCount)} | count | Boundary IO pin count |`)
-  lines.push(`| Total Nets | ${fmt(data.physical.netCount)} | count | Logical and physical net count |`)
+  lines.push(
+    `| Die Area | ${fmt(data.physical.dieAreaUm2)} | $\\mu\\text{m}^2$ | Overall die boundary area |`,
+  )
+  lines.push(
+    `| Core Area | ${fmt(data.physical.coreAreaUm2)} | $\\mu\\text{m}^2$ | Standard cell placement area |`,
+  )
+  lines.push(
+    `| Core Utilization | ${fmt(data.physical.coreUtilizationPct, '%')} | % | Ratio of cell area to core area |`,
+  )
+  lines.push(
+    `| Standard Cell Area | ${fmt(data.physical.stdCellAreaUm2)} | $\\mu\\text{m}^2$ | Sum of standard cell areas |`,
+  )
+  lines.push(
+    `| Macro Area / Count | ${fmt(data.physical.macroAreaUm2, 'μm²')} / ${fmt(data.physical.macroCount)} | $\\mu\\text{m}^2$ / count | Hard macros & memory blocks |`,
+  )
+  lines.push(
+    `| Total Instances | ${fmt(data.physical.instanceCount)} | count | Total placed cell instances |`,
+  )
+  lines.push(
+    `| Sequential Cells | ${fmt(data.physical.sequentialCellCount)} | count | Flip-flops and latches |`,
+  )
+  lines.push(
+    `| Combinational Cells | ${fmt(data.physical.combinationalCellCount)} | count | Logic gates |`,
+  )
+  lines.push(
+    `| IO Pins | ${fmt(data.physical.ioPinCount)} | count | Boundary IO pin count |`,
+  )
+  lines.push(
+    `| Total Nets | ${fmt(data.physical.netCount)} | count | Logical and physical net count |`,
+  )
   lines.push('')
 
   //Timing & Clock Quality
@@ -119,38 +181,91 @@ export function formatMarkdownReport(
   lines.push('')
   lines.push('| Parameter | Target / Value | Unit | Status |')
   lines.push('| :--- | :--- | :--- | :--- |')
-  lines.push(`| Target Clock Period | ${fmt(data.timing.targetClockPeriodNs)} | ns | ${data.timing.targetFrequencyMhz !== null ? `Target frequency: ${fmt(data.timing.targetFrequencyMhz, 'MHz')}` : '—'} |`)
-  lines.push(`| Maximum Frequency ($F_{\\text{max}}$) | ${fmt(data.timing.fmaxMhz)} | MHz | Maximum achievable clock rate |`)
-  lines.push(`| Setup Worst Negative Slack (WNS) | ${fmt(data.timing.setupWnsNs)} | ns | ${setupStatus === 'Pass' ? 'Pass' : setupStatus === 'Violation' ? 'Fail' : '—'} |`)
-  lines.push(`| Setup Total Negative Slack (TNS) | ${fmt(data.timing.setupTnsNs)} | ns | Cumulative setup violation |`)
-  lines.push(`| Hold Worst Negative Slack (WNS) | ${fmt(data.timing.holdWnsNs)} | ns | ${holdStatus === 'Pass' ? 'Pass' : holdStatus === 'Violation' ? 'Fail' : '—'} |`)
-  lines.push(`| Hold Total Negative Slack (TNS) | ${fmt(data.timing.holdTnsNs)} | ns | Cumulative hold violation |`)
-  lines.push(`| Critical Path Delay | ${fmt(data.timing.criticalPathDelayNs)} | ns | Worst data path propagation time |`)
-  lines.push(`| Setup Violating Endpoints | ${fmt(data.timing.violatingEndpointsSetup)} | endpoints | Endpoints failing setup check |`)
-  const slewStr = data.timing.slewViolations !== null ? `${data.timing.slewViolations}` : (data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0 ? '0' : '—')
-  const capStr = data.timing.capViolations !== null ? `${data.timing.capViolations}` : (data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0 ? '0' : '—')
-  const fanoutStr = data.timing.fanoutViolations !== null ? `${data.timing.fanoutViolations}` : (data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0 ? '0' : '—')
-  lines.push(`| Max Slew / Cap / Fanout Violations | ${slewStr} / ${capStr} / ${fanoutStr} | violations | Design rule electrical violations |`)
-  lines.push(`| Clock Tree Depth | ${fmt(data.clock.clockTreeLevels)} | levels | Maximum clock tree level |`)
+  lines.push(
+    `| Target Clock Period | ${fmt(data.timing.targetClockPeriodNs)} | ns | ${data.timing.targetFrequencyMhz !== null ? `Target frequency: ${fmt(data.timing.targetFrequencyMhz, 'MHz')}` : '—'} |`,
+  )
+  lines.push(
+    `| Maximum Frequency ($F_{\\text{max}}$) | ${fmt(data.timing.fmaxMhz)} | MHz | Maximum achievable clock rate |`,
+  )
+  lines.push(
+    `| Setup Worst Negative Slack (WNS) | ${fmt(data.timing.setupWnsNs)} | ns | ${setupStatus === 'Pass' ? 'Pass' : setupStatus === 'Violation' ? 'Fail' : '—'} |`,
+  )
+  lines.push(
+    `| Setup Total Negative Slack (TNS) | ${fmt(data.timing.setupTnsNs)} | ns | Cumulative setup violation |`,
+  )
+  lines.push(
+    `| Hold Worst Negative Slack (WNS) | ${fmt(data.timing.holdWnsNs)} | ns | ${holdStatus === 'Pass' ? 'Pass' : holdStatus === 'Violation' ? 'Fail' : '—'} |`,
+  )
+  lines.push(
+    `| Hold Total Negative Slack (TNS) | ${fmt(data.timing.holdTnsNs)} | ns | Cumulative hold violation |`,
+  )
+  lines.push(
+    `| Critical Path Delay | ${fmt(data.timing.criticalPathDelayNs)} | ns | Worst data path propagation time |`,
+  )
+  lines.push(
+    `| Setup Violating Endpoints | ${fmt(data.timing.violatingEndpointsSetup)} | endpoints | Endpoints failing setup check |`,
+  )
+  const slewStr =
+    data.timing.slewViolations !== null
+      ? `${data.timing.slewViolations}`
+      : data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0
+        ? '0'
+        : '—'
+  const capStr =
+    data.timing.capViolations !== null
+      ? `${data.timing.capViolations}`
+      : data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0
+        ? '0'
+        : '—'
+  const fanoutStr =
+    data.timing.fanoutViolations !== null
+      ? `${data.timing.fanoutViolations}`
+      : data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0
+        ? '0'
+        : '—'
+  lines.push(
+    `| Max Slew / Cap / Fanout Violations | ${slewStr} / ${capStr} / ${fanoutStr} | violations | Design rule electrical violations |`,
+  )
+  lines.push(
+    `| Clock Tree Depth | ${fmt(data.clock.clockTreeLevels)} | levels | Maximum clock tree level |`,
+  )
   if (data.clock.clockBufferCount !== null || data.clock.clockTotalBuffers !== null) {
-    const bufCountStr = data.clock.clockBufferCount !== null ? `${data.clock.clockBufferCount}` : `${data.clock.clockTotalBuffers}`
-    const areaStr = data.clock.clockBufferAreaUm2 !== null ? ` (${fmt(data.clock.clockBufferAreaUm2, 'μm²')})` : ''
-    lines.push(`| Clock Buffers | ${bufCountStr}${areaStr} | count | CTS inserted clock buffers |`)
+    const bufCountStr =
+      data.clock.clockBufferCount !== null
+        ? `${data.clock.clockBufferCount}`
+        : `${data.clock.clockTotalBuffers}`
+    const areaStr =
+      data.clock.clockBufferAreaUm2 !== null
+        ? ` (${fmt(data.clock.clockBufferAreaUm2, 'μm²')})`
+        : ''
+    lines.push(
+      `| Clock Buffers | ${bufCountStr}${areaStr} | count | CTS inserted clock buffers |`,
+    )
   }
   if (data.clock.clockPathMinBuffer !== null || data.clock.clockPathMaxBuffer !== null) {
-    lines.push(`| Clock Path Buffers (Min / Max) | ${fmt(data.clock.clockPathMinBuffer)} / ${fmt(data.clock.clockPathMaxBuffer)} | count | Buffer count per path range |`)
+    lines.push(
+      `| Clock Path Buffers (Min / Max) | ${fmt(data.clock.clockPathMinBuffer)} / ${fmt(data.clock.clockPathMaxBuffer)} | count | Buffer count per path range |`,
+    )
   }
   if (data.clock.clockWirelengthUm !== null) {
-    lines.push(`| Clock Wirelength | ${fmt(data.clock.clockWirelengthUm, 'μm')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmt(data.clock.clockMaxWirelengthUm, 'μm')})` : ''} | $\\mu\\text{m}$ | Total clock routing length |`)
+    lines.push(
+      `| Clock Wirelength | ${fmt(data.clock.clockWirelengthUm, 'μm')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmt(data.clock.clockMaxWirelengthUm, 'μm')})` : ''} | $\\mu\\text{m}$ | Total clock routing length |`,
+    )
   }
   if (data.clock.clockNetsCount !== null) {
-    lines.push(`| Clock Nets | ${fmt(data.clock.clockNetsCount)} | nets | Dedicated clock nets |`)
+    lines.push(
+      `| Clock Nets | ${fmt(data.clock.clockNetsCount)} | nets | Dedicated clock nets |`,
+    )
   }
   if (data.clock.clockSkewPs !== null) {
-    lines.push(`| Clock Skew | ${fmt(data.clock.clockSkewPs, 'ps')} | ps | Worst arrival difference across sinks |`)
+    lines.push(
+      `| Clock Skew | ${fmt(data.clock.clockSkewPs, 'ps')} | ps | Worst arrival difference across sinks |`,
+    )
   }
   if (data.clock.clockLatencyNs !== null) {
-    lines.push(`| Clock Insertion Latency | ${fmt(data.clock.clockLatencyNs, 'ns')} | ns | Delay from root clock to leaf registers |`)
+    lines.push(
+      `| Clock Insertion Latency | ${fmt(data.clock.clockLatencyNs, 'ns')} | ns | Delay from root clock to leaf registers |`,
+    )
   }
   lines.push('')
 
@@ -158,10 +273,14 @@ export function formatMarkdownReport(
   if (includeMultiCorner && data.multiCornerTiming.length > 0) {
     lines.push('## 4. Multi-Corner Timing Analysis')
     lines.push('')
-    lines.push('| Corner | Setup WNS (ns) | Setup TNS (ns) | Hold WNS (ns) | Hold TNS (ns) | Status |')
+    lines.push(
+      '| Corner | Setup WNS (ns) | Setup TNS (ns) | Hold WNS (ns) | Hold TNS (ns) | Status |',
+    )
     lines.push('| :--- | :--- | :--- | :--- | :--- | :--- |')
     for (const c of data.multiCornerTiming) {
-      lines.push(`| \`${c.corner}\` | ${fmt(c.setupWnsNs)} | ${fmt(c.setupTnsNs)} | ${fmt(c.holdWnsNs)} | ${fmt(c.holdTnsNs)} | ${c.status === 'pass' ? 'PASS' : c.status === 'fail' ? 'FAIL' : '—'} |`)
+      lines.push(
+        `| \`${c.corner}\` | ${fmt(c.setupWnsNs)} | ${fmt(c.setupTnsNs)} | ${fmt(c.holdWnsNs)} | ${fmt(c.holdTnsNs)} | ${c.status === 'pass' ? 'PASS' : c.status === 'fail' ? 'FAIL' : '—'} |`,
+      )
     }
     lines.push('')
   }
@@ -171,11 +290,19 @@ export function formatMarkdownReport(
   lines.push('')
   lines.push('| Category | Metric | Value | Unit |')
   lines.push('| :--- | :--- | :--- | :--- |')
-  lines.push(`| Routing | Half-Perimeter Wirelength (HPWL) | ${fmt(data.routing.hpwlUm)} | $\\mu\\text{m}$ |`)
-  lines.push(`| Routing | Routed Wirelength | ${fmt(data.routing.routedWirelengthUm)} | $\\mu\\text{m}$ |`)
+  lines.push(
+    `| Routing | Half-Perimeter Wirelength (HPWL) | ${fmt(data.routing.hpwlUm)} | $\\mu\\text{m}$ |`,
+  )
+  lines.push(
+    `| Routing | Routed Wirelength | ${fmt(data.routing.routedWirelengthUm)} | $\\mu\\text{m}$ |`,
+  )
   lines.push(`| Routing | Total Via Count | ${fmt(data.routing.viaCount)} | count |`)
-  lines.push(`| Congestion | Global Route Overflow | ${fmt(data.congestion.globalOverflowTotal)} | tracks |`)
-  lines.push(`| Congestion | Max Overflow | ${fmt(data.congestion.maxOverflow)} | tracks |`)
+  lines.push(
+    `| Congestion | Global Route Overflow | ${fmt(data.congestion.globalOverflowTotal)} | tracks |`,
+  )
+  lines.push(
+    `| Congestion | Max Overflow | ${fmt(data.congestion.maxOverflow)} | tracks |`,
+  )
   lines.push(`| Power | Total Power | ${fmt(data.power.totalPowerMw)} | mW |`)
   lines.push(`| Power | Dynamic Power | ${fmt(data.power.dynamicPowerMw)} | mW |`)
   lines.push(`| Power | Switching Power | ${fmt(data.power.switchingPowerMw)} | mW |`)
@@ -189,8 +316,12 @@ export function formatMarkdownReport(
     lines.push('')
     lines.push('| Verification Check | Result | Violation Count | Status |')
     lines.push('| :--- | :--- | :--- | :--- |')
-    lines.push(`| Design Rule Check (DRC) | ${data.verification.drcStatus === 'clean' ? 'Clean' : data.verification.drcStatus === 'violations' ? 'Violations Found' : 'Unrun'} | ${fmt(data.verification.drcCount)} | ${data.verification.drcStatus === 'clean' ? 'PASS' : data.verification.drcStatus === 'violations' ? 'FAIL' : '—'} |`)
-    lines.push(`| Layout vs Schematic (LVS) | ${data.verification.lvsStatus === 'matched' ? 'Netlist Matched' : data.verification.lvsStatus === 'mismatch' ? 'Mismatches Found' : 'Unrun'} | ${fmt(data.verification.lvsMismatchCount)} | ${data.verification.lvsStatus === 'matched' ? 'PASS' : data.verification.lvsStatus === 'mismatch' ? 'FAIL' : '—'} |`)
+    lines.push(
+      `| Design Rule Check (DRC) | ${data.verification.drcStatus === 'clean' ? 'Clean' : data.verification.drcStatus === 'violations' ? 'Violations Found' : 'Unrun'} | ${fmt(data.verification.drcCount)} | ${data.verification.drcStatus === 'clean' ? 'PASS' : data.verification.drcStatus === 'violations' ? 'FAIL' : '—'} |`,
+    )
+    lines.push(
+      `| Layout vs Schematic (LVS) | ${data.verification.lvsStatus === 'matched' ? 'Netlist Matched' : data.verification.lvsStatus === 'mismatch' ? 'Mismatches Found' : 'Unrun'} | ${fmt(data.verification.lvsMismatchCount)} | ${data.verification.lvsStatus === 'matched' ? 'PASS' : data.verification.lvsStatus === 'mismatch' ? 'FAIL' : '—'} |`,
+    )
     lines.push('')
   }
 
@@ -201,7 +332,9 @@ export function formatMarkdownReport(
     lines.push('| Stage | Tool | Runtime | Peak Memory (MB) | State |')
     lines.push('| :--- | :--- | :--- | :--- | :--- |')
     for (const s of data.execution.stages) {
-      lines.push(`| **${s.stage}** | \`${s.tool}\` | ${s.runtimeFormatted || fmt(s.runtimeSeconds, 's')} | ${fmt(s.peakMemoryMb)} | ${s.state} |`)
+      lines.push(
+        `| **${s.stage}** | \`${s.tool}\` | ${s.runtimeFormatted || fmt(s.runtimeSeconds, 's')} | ${fmt(s.peakMemoryMb)} | ${s.state} |`,
+      )
     }
     lines.push('')
   }

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/markdownFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/markdownFormatter.ts
@@ -1,0 +1,210 @@
+import type {
+  DesignReportData,
+  DesignReportExportOptions,
+} from '../../contracts/designReport.ts'
+
+function fmt(val: number | string | boolean | null | undefined, unit = '', decimals = 2): string {
+  if (val === null || val === undefined) return '—'
+  if (typeof val === 'boolean') return val ? 'true' : 'false'
+  if (typeof val === 'number') {
+    if (!Number.isFinite(val)) return '—'
+    const formatted = Number.isInteger(val) ? val.toLocaleString('en-US') : val.toFixed(decimals)
+    return unit ? `${formatted} ${unit}` : formatted
+  }
+  return unit ? `${val} ${unit}` : String(val)
+}
+
+export function formatMarkdownReport(
+  data: DesignReportData,
+  options: DesignReportExportOptions = {},
+): string {
+  const {
+    includeMultiCorner = true,
+    includeStageBreakdown = true,
+    includeVerificationBreakdown = true,
+  } = options
+
+  const lines: string[] = []
+
+  lines.push(`# Design Summary Report: ${data.design.designName}`)
+  lines.push('')
+
+  const metaParts: string[] = []
+  const pdkCommitShort = data.design.pdkCommit ? `@${data.design.pdkCommit.slice(0, 8)}` : null
+  const pdkSuffix = pdkCommitShort ? ` (${pdkCommitShort})` : (data.design.pdkVersion ? ` (${data.design.pdkVersion})` : '')
+  metaParts.push(`**PDK**: \`${data.design.pdk}${pdkSuffix}\``)
+  if (data.design.ecosStudioVersion) {
+    metaParts.push(`**ECOS Studio Version**: \`${data.design.ecosStudioVersion}\``)
+  }
+  metaParts.push(`**Generated**: \`${data.design.generatedAt}\``)
+  lines.push(`> ${metaParts.join(' | ')}`)
+
+  if (data.design.gitCommit || data.design.runId) {
+    const trackingParts: string[] = []
+    if (data.design.gitCommit) {
+      trackingParts.push(`**Git Commit**: \`${data.design.gitCommit.slice(0, 8)}\``)
+    }
+    if (data.design.runId) {
+      trackingParts.push(`**Run ID**: \`${data.design.runId}\``)
+    }
+    lines.push(`> ${trackingParts.join(' | ')}`)
+  }
+  lines.push('')
+
+  const setupStatus =
+    data.timing.setupWnsNs === null
+      ? '—'
+      : data.timing.setupWnsNs >= 0
+        ? 'Pass'
+        : 'Violation'
+  const holdStatus =
+    data.timing.holdWnsNs === null
+      ? '—'
+      : data.timing.holdWnsNs >= 0
+        ? 'Pass'
+        : 'Violation'
+
+  const clockTreeSummary =
+    data.clock.clockTreeLevels !== null
+      ? `${data.clock.clockTreeLevels} levels${data.clock.clockBufferCount !== null ? `, ${data.clock.clockBufferCount} buffers` : ''}`
+      : data.clock.clockBufferCount !== null
+        ? `${data.clock.clockBufferCount} buffers`
+        : data.clock.clockCellCount !== null
+          ? `${data.clock.clockCellCount} clock cells`
+          : data.clock.clockSkewPs !== null
+            ? `${data.clock.clockSkewPs} ps skew`
+            : '—'
+
+  //Design Summary
+  lines.push('## 1. Design Summary')
+  lines.push('')
+  lines.push('| Metric | Value | Reference Unit | Status / Notes |')
+  lines.push('| :--- | :--- | :--- | :--- |')
+  lines.push(`| **Die Area** | ${fmt(data.physical.dieAreaUm2)}${data.physical.dieAreaMm2 !== null ? ` (${fmt(data.physical.dieAreaMm2, 'mm²', 4)})` : ''} | $\\mu\\text{m}^2$ | Physical boundary |`)
+  lines.push(`| **Core Area** | ${fmt(data.physical.coreAreaUm2)} | $\\mu\\text{m}^2$ | Core boundary |`)
+  lines.push(`| **Core Utilization** | ${fmt(data.physical.coreUtilizationPct, '%')} | % | Placement density |`)
+  lines.push(`| **Instance Count** | ${fmt(data.physical.instanceCount)} | cells | Total standard cells & macros |`)
+  lines.push(`| **Target Frequency** | ${fmt(data.timing.targetFrequencyMhz, 'MHz')} | MHz | ${data.timing.targetClockPeriodNs !== null ? `Clock period: ${fmt(data.timing.targetClockPeriodNs, 'ns')}` : '—'} |`)
+  lines.push(`| **Achieved $F_{\\text{max}}$** | ${fmt(data.timing.fmaxMhz, 'MHz')} | MHz | Based on worst setup slack |`)
+  lines.push(`| **Setup Slack (WNS / TNS)** | ${fmt(data.timing.setupWnsNs, 'ns')} / ${fmt(data.timing.setupTnsNs, 'ns')} | ns | ${setupStatus} |`)
+  lines.push(`| **Hold Slack (WNS / TNS)** | ${fmt(data.timing.holdWnsNs, 'ns')} / ${fmt(data.timing.holdTnsNs, 'ns')} | ns | ${holdStatus} |`)
+  lines.push(`| **Clock Tree QoR** | ${clockTreeSummary} | levels / count | Clock tree structure & buffers |`)
+  lines.push(`| **Routed Wirelength** | ${fmt(data.routing.routedWirelengthUm, 'μm')} | $\\mu\\text{m}$ | Total detailed route wirelength |`)
+  lines.push(`| **Via Count** | ${fmt(data.routing.viaCount)} | count | Total routing vias |`)
+  lines.push(`| **Global Route Overflow** | ${fmt(data.congestion.globalOverflowTotal)}${data.congestion.globalOverflowPct !== null ? ` (${fmt(data.congestion.globalOverflowPct, '%')})` : ''} | tracks | Congestion state |`)
+  lines.push(`| **Total Power** | ${fmt(data.power.totalPowerMw, 'mW')} | mW | Dynamic: ${fmt(data.power.dynamicPowerMw, 'mW')}, Leakage: ${fmt(data.power.leakagePowerMw, 'mW')} |`)
+  lines.push(`| **DRC / LVS Status** | ${data.verification.drcStatus === 'clean' ? 'DRC Clean (0)' : `DRC Violations (${fmt(data.verification.drcCount)})`} / ${data.verification.lvsStatus === 'matched' ? 'LVS Matched' : `LVS Mismatch (${fmt(data.verification.lvsMismatchCount)})`} | status | Signoff verification |`)
+  lines.push(`| **Total Runtime** | ${data.execution.totalRuntimeFormatted || fmt(data.execution.totalRuntimeSeconds, 's')} | time | Peak Memory: ${fmt(data.execution.peakMemoryMb, 'MB')} |`)
+  lines.push('')
+
+  //Area & Physical Breakdown
+  lines.push('## 2. Area & Physical Metrics')
+  lines.push('')
+  lines.push('| Metric | Value | Unit | Description |')
+  lines.push('| :--- | :--- | :--- | :--- |')
+  lines.push(`| Die Area | ${fmt(data.physical.dieAreaUm2)} | $\\mu\\text{m}^2$ | Overall die boundary area |`)
+  lines.push(`| Core Area | ${fmt(data.physical.coreAreaUm2)} | $\\mu\\text{m}^2$ | Standard cell placement area |`)
+  lines.push(`| Core Utilization | ${fmt(data.physical.coreUtilizationPct, '%')} | % | Ratio of cell area to core area |`)
+  lines.push(`| Standard Cell Area | ${fmt(data.physical.stdCellAreaUm2)} | $\\mu\\text{m}^2$ | Sum of standard cell areas |`)
+  lines.push(`| Macro Area / Count | ${fmt(data.physical.macroAreaUm2, 'μm²')} / ${fmt(data.physical.macroCount)} | $\\mu\\text{m}^2$ / count | Hard macros & memory blocks |`)
+  lines.push(`| Total Instances | ${fmt(data.physical.instanceCount)} | count | Total placed cell instances |`)
+  lines.push(`| Sequential Cells | ${fmt(data.physical.sequentialCellCount)} | count | Flip-flops and latches |`)
+  lines.push(`| Combinational Cells | ${fmt(data.physical.combinationalCellCount)} | count | Logic gates |`)
+  lines.push(`| IO Pins | ${fmt(data.physical.ioPinCount)} | count | Boundary IO pin count |`)
+  lines.push(`| Total Nets | ${fmt(data.physical.netCount)} | count | Logical and physical net count |`)
+  lines.push('')
+
+  //Timing & Clock Quality
+  lines.push('## 3. Timing & Clock Quality')
+  lines.push('')
+  lines.push('| Parameter | Target / Value | Unit | Status |')
+  lines.push('| :--- | :--- | :--- | :--- |')
+  lines.push(`| Target Clock Period | ${fmt(data.timing.targetClockPeriodNs)} | ns | ${data.timing.targetFrequencyMhz !== null ? `Target frequency: ${fmt(data.timing.targetFrequencyMhz, 'MHz')}` : '—'} |`)
+  lines.push(`| Maximum Frequency ($F_{\\text{max}}$) | ${fmt(data.timing.fmaxMhz)} | MHz | Maximum achievable clock rate |`)
+  lines.push(`| Setup Worst Negative Slack (WNS) | ${fmt(data.timing.setupWnsNs)} | ns | ${setupStatus === 'Pass' ? 'Pass' : setupStatus === 'Violation' ? 'Fail' : '—'} |`)
+  lines.push(`| Setup Total Negative Slack (TNS) | ${fmt(data.timing.setupTnsNs)} | ns | Cumulative setup violation |`)
+  lines.push(`| Hold Worst Negative Slack (WNS) | ${fmt(data.timing.holdWnsNs)} | ns | ${holdStatus === 'Pass' ? 'Pass' : holdStatus === 'Violation' ? 'Fail' : '—'} |`)
+  lines.push(`| Hold Total Negative Slack (TNS) | ${fmt(data.timing.holdTnsNs)} | ns | Cumulative hold violation |`)
+  lines.push(`| Critical Path Delay | ${fmt(data.timing.criticalPathDelayNs)} | ns | Worst data path propagation time |`)
+  lines.push(`| Setup Violating Endpoints | ${fmt(data.timing.violatingEndpointsSetup)} | endpoints | Endpoints failing setup check |`)
+  const slewStr = data.timing.slewViolations !== null ? `${data.timing.slewViolations}` : (data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0 ? '0' : '—')
+  const capStr = data.timing.capViolations !== null ? `${data.timing.capViolations}` : (data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0 ? '0' : '—')
+  const fanoutStr = data.timing.fanoutViolations !== null ? `${data.timing.fanoutViolations}` : (data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0 ? '0' : '—')
+  lines.push(`| Max Slew / Cap / Fanout Violations | ${slewStr} / ${capStr} / ${fanoutStr} | violations | Design rule electrical violations |`)
+  lines.push(`| Clock Tree Depth | ${fmt(data.clock.clockTreeLevels)} | levels | Maximum clock tree level |`)
+  if (data.clock.clockBufferCount !== null || data.clock.clockTotalBuffers !== null) {
+    const bufCountStr = data.clock.clockBufferCount !== null ? `${data.clock.clockBufferCount}` : `${data.clock.clockTotalBuffers}`
+    const areaStr = data.clock.clockBufferAreaUm2 !== null ? ` (${fmt(data.clock.clockBufferAreaUm2, 'μm²')})` : ''
+    lines.push(`| Clock Buffers | ${bufCountStr}${areaStr} | count | CTS inserted clock buffers |`)
+  }
+  if (data.clock.clockPathMinBuffer !== null || data.clock.clockPathMaxBuffer !== null) {
+    lines.push(`| Clock Path Buffers (Min / Max) | ${fmt(data.clock.clockPathMinBuffer)} / ${fmt(data.clock.clockPathMaxBuffer)} | count | Buffer count per path range |`)
+  }
+  if (data.clock.clockWirelengthUm !== null) {
+    lines.push(`| Clock Wirelength | ${fmt(data.clock.clockWirelengthUm, 'μm')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmt(data.clock.clockMaxWirelengthUm, 'μm')})` : ''} | $\\mu\\text{m}$ | Total clock routing length |`)
+  }
+  if (data.clock.clockNetsCount !== null) {
+    lines.push(`| Clock Nets | ${fmt(data.clock.clockNetsCount)} | nets | Dedicated clock nets |`)
+  }
+  if (data.clock.clockSkewPs !== null) {
+    lines.push(`| Clock Skew | ${fmt(data.clock.clockSkewPs, 'ps')} | ps | Worst arrival difference across sinks |`)
+  }
+  if (data.clock.clockLatencyNs !== null) {
+    lines.push(`| Clock Insertion Latency | ${fmt(data.clock.clockLatencyNs, 'ns')} | ns | Delay from root clock to leaf registers |`)
+  }
+  lines.push('')
+
+  //Multi-Corner Timing
+  if (includeMultiCorner && data.multiCornerTiming.length > 0) {
+    lines.push('## 4. Multi-Corner Timing Analysis')
+    lines.push('')
+    lines.push('| Corner | Setup WNS (ns) | Setup TNS (ns) | Hold WNS (ns) | Hold TNS (ns) | Status |')
+    lines.push('| :--- | :--- | :--- | :--- | :--- | :--- |')
+    for (const c of data.multiCornerTiming) {
+      lines.push(`| \`${c.corner}\` | ${fmt(c.setupWnsNs)} | ${fmt(c.setupTnsNs)} | ${fmt(c.holdWnsNs)} | ${fmt(c.holdTnsNs)} | ${c.status === 'pass' ? 'PASS' : c.status === 'fail' ? 'FAIL' : '—'} |`)
+    }
+    lines.push('')
+  }
+
+  //Routing, Congestion & Power
+  lines.push('## 5. Routing, Congestion & Power')
+  lines.push('')
+  lines.push('| Category | Metric | Value | Unit |')
+  lines.push('| :--- | :--- | :--- | :--- |')
+  lines.push(`| Routing | Half-Perimeter Wirelength (HPWL) | ${fmt(data.routing.hpwlUm)} | $\\mu\\text{m}$ |`)
+  lines.push(`| Routing | Routed Wirelength | ${fmt(data.routing.routedWirelengthUm)} | $\\mu\\text{m}$ |`)
+  lines.push(`| Routing | Total Via Count | ${fmt(data.routing.viaCount)} | count |`)
+  lines.push(`| Congestion | Global Route Overflow | ${fmt(data.congestion.globalOverflowTotal)} | tracks |`)
+  lines.push(`| Congestion | Max Overflow | ${fmt(data.congestion.maxOverflow)} | tracks |`)
+  lines.push(`| Power | Total Power | ${fmt(data.power.totalPowerMw)} | mW |`)
+  lines.push(`| Power | Dynamic Power | ${fmt(data.power.dynamicPowerMw)} | mW |`)
+  lines.push(`| Power | Switching Power | ${fmt(data.power.switchingPowerMw)} | mW |`)
+  lines.push(`| Power | Internal Power | ${fmt(data.power.internalPowerMw)} | mW |`)
+  lines.push(`| Power | Leakage Power | ${fmt(data.power.leakagePowerMw)} | mW |`)
+  lines.push('')
+
+  //Physical Verification
+  if (includeVerificationBreakdown) {
+    lines.push('## 6. Physical Verification & Signoff')
+    lines.push('')
+    lines.push('| Verification Check | Result | Violation Count | Status |')
+    lines.push('| :--- | :--- | :--- | :--- |')
+    lines.push(`| Design Rule Check (DRC) | ${data.verification.drcStatus === 'clean' ? 'Clean' : data.verification.drcStatus === 'violations' ? 'Violations Found' : 'Unrun'} | ${fmt(data.verification.drcCount)} | ${data.verification.drcStatus === 'clean' ? 'PASS' : data.verification.drcStatus === 'violations' ? 'FAIL' : '—'} |`)
+    lines.push(`| Layout vs Schematic (LVS) | ${data.verification.lvsStatus === 'matched' ? 'Netlist Matched' : data.verification.lvsStatus === 'mismatch' ? 'Mismatches Found' : 'Unrun'} | ${fmt(data.verification.lvsMismatchCount)} | ${data.verification.lvsStatus === 'matched' ? 'PASS' : data.verification.lvsStatus === 'mismatch' ? 'FAIL' : '—'} |`)
+    lines.push('')
+  }
+
+  //Stage Breakdown
+  if (includeStageBreakdown && data.execution.stages.length > 0) {
+    lines.push('## 7. Flow Stage Execution Breakdown')
+    lines.push('')
+    lines.push('| Stage | Tool | Runtime | Peak Memory (MB) | State |')
+    lines.push('| :--- | :--- | :--- | :--- | :--- |')
+    for (const s of data.execution.stages) {
+      lines.push(`| **${s.stage}** | \`${s.tool}\` | ${s.runtimeFormatted || fmt(s.runtimeSeconds, 's')} | ${fmt(s.peakMemoryMb)} | ${s.state} |`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/textFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/textFormatter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { extractDesignReportData } from '../designReportExtract.ts'
+import { formatTextReport } from './textFormatter.ts'
+
+describe('textFormatter', () => {
+  const sampleData = extractDesignReportData({
+    workspacePath: '/projects/ibex/ws_004',
+    parameters: {
+      Design: 'ibex_core',
+      PDK: 'ic55',
+      PDK_VERSION: 'v0.12.0',
+      ECC_TOOL: 'ecc-fe',
+      ECC_VERSION: '1.4.2',
+      ECOS_STUDIO_VERSION: '0.1.0-alpha.8',
+    },
+    flow: {
+      steps: [
+        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:2:30', 'peak memory (mb)': 350 },
+      ],
+    },
+    stepMetrics: {
+      Harden: {
+        die_area_um2: 620000,
+        core_area_um2: 500000,
+        utilization: 49.2,
+      },
+      CTS: {
+        cts_clock_tree_max_level: 2,
+        cts_buffer_count: 4,
+        cts_buffer_area: 11.2,
+      },
+      STA: {
+        clock_period: 15.0,
+        setup_wns: 0.35,
+        setup_tns: 0.0,
+        hold_wns: 0.08,
+        hold_tns: 0.0,
+      },
+      DRC: { drc_violations: 0 },
+      LVS: { lvs_mismatches: 0 },
+    },
+  })
+
+  it('generates an aligned ASCII table report with ECOS studio version, rich clock metrics, and no emojis', () => {
+    const txt = formatTextReport(sampleData)
+    expect(txt).toContain('ECOS STUDIO — DESIGN SUMMARY REPORT')
+    expect(txt).toContain('Design Name        : ibex_core')
+    expect(txt).toContain('ECOS Studio Version: 0.1.0-alpha.8')
+    expect(txt).toContain('[ 1. PHYSICAL & AREA METRICS ]')
+    expect(txt).toContain('[ 2. TIMING CLOSURE & PERFORMANCE ]')
+    expect(txt).toContain('[ 3. CLOCK TREE & QUALITY ]')
+    expect(txt).toContain('620,000')
+    expect(txt).toContain('49.20 %')
+    expect(txt).toContain('2 levels')
+    expect(txt).toContain('4 (11.20 um²)')
+    expect(txt).toContain('END OF REPORT')
+  })
+})

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/textFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/textFormatter.test.ts
@@ -15,7 +15,13 @@ describe('textFormatter', () => {
     },
     flow: {
       steps: [
-        { name: 'Synthesis_yosys', tool: 'Yosys', state: 'Success', runtime: '0:2:30', 'peak memory (mb)': 350 },
+        {
+          name: 'Synthesis_yosys',
+          tool: 'Yosys',
+          state: 'Success',
+          runtime: '0:2:30',
+          'peak memory (mb)': 350,
+        },
       ],
     },
     stepMetrics: {

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/textFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/textFormatter.ts
@@ -1,0 +1,209 @@
+import type {
+  DesignReportData,
+  DesignReportExportOptions,
+} from '../../contracts/designReport.ts'
+
+function padRight(str: string, width: number): string {
+  return str.length >= width ? str : str + ' '.repeat(width - str.length)
+}
+
+function padLeft(str: string, width: number): string {
+  return str.length >= width ? str : ' '.repeat(width - str.length) + str
+}
+
+function fmt(val: number | string | null | undefined, unit = '', decimals = 2): string {
+  if (val === null || val === undefined) return '—'
+  if (typeof val === 'number') {
+    if (!Number.isFinite(val)) return '—'
+    const formatted = Number.isInteger(val) ? val.toLocaleString('en-US') : val.toFixed(decimals)
+    return unit ? `${formatted} ${unit}` : formatted
+  }
+  return unit ? `${val} ${unit}` : String(val)
+}
+
+export function formatTextReport(
+  data: DesignReportData,
+  options: DesignReportExportOptions = {},
+): string {
+  const {
+    includeMultiCorner = true,
+    includeStageBreakdown = true,
+  } = options
+
+  const lines: string[] = []
+  const WIDTH = 78
+
+  function separator(char = '-') {
+    return char.repeat(WIDTH)
+  }
+
+  function titleBar(text: string) {
+    const padded = `  ${text}  `
+    const side = Math.max(0, Math.floor((WIDTH - padded.length) / 2))
+    return '='.repeat(side) + padded + '='.repeat(WIDTH - side - padded.length)
+  }
+
+  function sectionHeader(text: string) {
+    return `[ ${text} ]`
+  }
+
+  function row(metric: string, value: string, notes = '') {
+    const col1 = padRight(`  ${metric}`, 38)
+    const col2 = padRight(value, 20)
+    const col3 = notes
+    return `${col1} ${col2} ${col3}`
+  }
+
+  lines.push(titleBar('ECOS STUDIO — DESIGN SUMMARY REPORT'))
+  lines.push(`Design Name        : ${data.design.designName}`)
+  const pdkCommitShort = data.design.pdkCommit ? `@${data.design.pdkCommit.slice(0, 8)}` : null
+  const pdkSuffix = pdkCommitShort ? ` (${pdkCommitShort})` : (data.design.pdkVersion ? ` (${data.design.pdkVersion})` : '')
+  lines.push(`PDK / Node         : ${data.design.pdk}${pdkSuffix}`)
+  if (data.design.ecosStudioVersion) {
+    lines.push(`ECOS Studio Version: ${data.design.ecosStudioVersion}`)
+  }
+  if (data.design.gitCommit) {
+    lines.push(`Git Commit         : ${data.design.gitCommit}`)
+  }
+  lines.push(`Generated          : ${data.design.generatedAt}`)
+  lines.push(separator('='))
+  lines.push('')
+
+  //Physical Design
+  lines.push(sectionHeader('1. PHYSICAL & AREA METRICS'))
+  lines.push(separator('-'))
+  lines.push(row('Die Area', `${fmt(data.physical.dieAreaUm2, 'um²')}${data.physical.dieAreaMm2 !== null ? ` (${fmt(data.physical.dieAreaMm2, 'mm²', 4)})` : ''}`, 'Physical boundary'))
+  lines.push(row('Core Area', fmt(data.physical.coreAreaUm2, 'um²'), 'Placement boundary'))
+  lines.push(row('Core Utilization', fmt(data.physical.coreUtilizationPct, '%'), 'Placed cell density'))
+  lines.push(row('Standard Cell Area', fmt(data.physical.stdCellAreaUm2, 'um²'), 'Total stdcell area'))
+  if (data.physical.macroCount !== null && data.physical.macroCount > 0) {
+    lines.push(row('Macro Count / Area', `${fmt(data.physical.macroCount)} macros / ${fmt(data.physical.macroAreaUm2, 'um²')}`, 'Hard macros'))
+  }
+  lines.push(row('Total Instances', fmt(data.physical.instanceCount), 'Cells placed'))
+  if (data.physical.sequentialCellCount !== null || data.physical.combinationalCellCount !== null) {
+    lines.push(row('Sequential / Comb. Cells', `${fmt(data.physical.sequentialCellCount)} / ${fmt(data.physical.combinationalCellCount)}`, 'Flops / Gates'))
+  }
+  if (data.physical.ioPinCount !== null) {
+    lines.push(row('IO Pins', fmt(data.physical.ioPinCount), 'Chip IOs'))
+  }
+  if (data.physical.netCount !== null) {
+    lines.push(row('Total Nets', fmt(data.physical.netCount), 'Nets'))
+  }
+  lines.push('')
+
+  //Timing Closure
+  lines.push(sectionHeader('2. TIMING CLOSURE & PERFORMANCE'))
+  lines.push(separator('-'))
+  lines.push(row('Target Clock Period', fmt(data.timing.targetClockPeriodNs, 'ns'), `Target freq: ${fmt(data.timing.targetFrequencyMhz, 'MHz')}`))
+  lines.push(row('Achieved Fmax', fmt(data.timing.fmaxMhz, 'MHz'), 'Max operating frequency'))
+  lines.push(row('Setup Slack (WNS / TNS)', `${fmt(data.timing.setupWnsNs, 'ns')} / ${fmt(data.timing.setupTnsNs, 'ns')}`, data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0 ? 'TIMING MET' : 'VIOLATION'))
+  lines.push(row('Hold Slack (WNS / TNS)', `${fmt(data.timing.holdWnsNs, 'ns')} / ${fmt(data.timing.holdTnsNs, 'ns')}`, data.timing.holdWnsNs !== null && data.timing.holdWnsNs >= 0 ? 'TIMING MET' : 'VIOLATION'))
+  if (data.timing.criticalPathDelayNs !== null) {
+    lines.push(row('Critical Path Delay', fmt(data.timing.criticalPathDelayNs, 'ns'), 'Data path delay'))
+  }
+  if (data.timing.violatingEndpointsSetup !== null || data.timing.violatingEndpointsHold !== null) {
+    lines.push(row('Violating Endpoints (Setup/Hold)', `${fmt(data.timing.violatingEndpointsSetup)} / ${fmt(data.timing.violatingEndpointsHold)}`, 'Failing paths'))
+  }
+  if (data.timing.slewViolations !== null || data.timing.capViolations !== null || data.timing.fanoutViolations !== null) {
+    lines.push(row('DRC Violations (Slew/Cap/Fanout)', `${fmt(data.timing.slewViolations)} / ${fmt(data.timing.capViolations)} / ${fmt(data.timing.fanoutViolations)}`, 'Electrical DRC'))
+  }
+  lines.push('')
+
+  //Clock Tree & Quality
+  lines.push(sectionHeader('3. CLOCK TREE & QUALITY'))
+  lines.push(separator('-'))
+  lines.push(row('Clock Tree Depth', `${fmt(data.clock.clockTreeLevels)} levels`, 'Max tree depth'))
+  if (data.clock.clockBufferCount !== null || data.clock.clockTotalBuffers !== null) {
+    const bufStr = data.clock.clockBufferCount !== null ? `${data.clock.clockBufferCount}` : `${data.clock.clockTotalBuffers}`
+    const areaStr = data.clock.clockBufferAreaUm2 !== null ? ` (${fmt(data.clock.clockBufferAreaUm2, 'um²')})` : ''
+    lines.push(row('Clock Buffers', `${bufStr}${areaStr}`, 'CTS buffers'))
+  }
+  if (data.clock.clockPathMinBuffer !== null || data.clock.clockPathMaxBuffer !== null) {
+    lines.push(row('Clock Path Buffers (Min/Max)', `${fmt(data.clock.clockPathMinBuffer)} / ${fmt(data.clock.clockPathMaxBuffer)}`, 'Buffers per path range'))
+  }
+  if (data.clock.clockWirelengthUm !== null) {
+    lines.push(row('Clock Wirelength', `${fmt(data.clock.clockWirelengthUm, 'um')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmt(data.clock.clockMaxWirelengthUm, 'um')})` : ''}`, 'Total clock routing'))
+  }
+  if (data.clock.clockNetsCount !== null) {
+    lines.push(row('Clock Nets', `${fmt(data.clock.clockNetsCount)} nets`, 'Clock net count'))
+  }
+  if (data.clock.clockSkewPs !== null) {
+    lines.push(row('Clock Skew', fmt(data.clock.clockSkewPs, 'ps'), 'Max skew'))
+  }
+  if (data.clock.clockLatencyNs !== null) {
+    lines.push(row('Clock Insertion Latency', fmt(data.clock.clockLatencyNs, 'ns'), 'Insertion delay'))
+  }
+  lines.push('')
+
+  //Multi-Corner Timing
+  if (includeMultiCorner && data.multiCornerTiming.length > 0) {
+    lines.push(sectionHeader('4. MULTI-CORNER TIMING'))
+    lines.push(separator('-'))
+    lines.push(
+      `  ${padRight('Corner', 24)} ${padLeft('Setup WNS', 11)} ${padLeft('Setup TNS', 11)} ${padLeft('Hold WNS', 11)} ${padLeft('Hold TNS', 11)}  Status`,
+    )
+    lines.push('  ' + '-'.repeat(WIDTH - 4))
+    for (const c of data.multiCornerTiming) {
+      const cName = padRight(c.corner, 24)
+      const sWns = padLeft(fmt(c.setupWnsNs, 'ns'), 11)
+      const sTns = padLeft(fmt(c.setupTnsNs, 'ns'), 11)
+      const hWns = padLeft(fmt(c.holdWnsNs, 'ns'), 11)
+      const hTns = padLeft(fmt(c.holdTnsNs, 'ns'), 11)
+      const st = c.status === 'pass' ? 'PASS' : c.status === 'fail' ? 'FAIL' : '—'
+      lines.push(`  ${cName} ${sWns} ${sTns} ${hWns} ${hTns}  ${st}`)
+    }
+    lines.push('')
+  }
+
+  //Routing & Congestion
+  lines.push(sectionHeader('5. ROUTING & CONGESTION'))
+  lines.push(separator('-'))
+  lines.push(row('HPWL', fmt(data.routing.hpwlUm, 'um'), 'Estimated wirelength'))
+  lines.push(row('Routed Wirelength', fmt(data.routing.routedWirelengthUm, 'um'), 'Final routed wirelength'))
+  lines.push(row('Via Count', fmt(data.routing.viaCount), 'Vias'))
+  if (data.congestion.globalOverflowTotal !== null || data.congestion.globalOverflowPct !== null) {
+    lines.push(row('Global Route Overflow', `${fmt(data.congestion.globalOverflowTotal)}${data.congestion.globalOverflowPct !== null ? ` (${fmt(data.congestion.globalOverflowPct, '%')})` : ''}`, 'Tracks overflow'))
+  }
+  lines.push('')
+
+  //Power Analysis
+  lines.push(sectionHeader('6. POWER ANALYSIS'))
+  lines.push(separator('-'))
+  lines.push(row('Total Power', fmt(data.power.totalPowerMw, 'mW'), 'Total dissipation'))
+  lines.push(row('Dynamic Power', fmt(data.power.dynamicPowerMw, 'mW'), 'Switching + Internal'))
+  lines.push(row('Leakage Power', fmt(data.power.leakagePowerMw, 'mW'), 'Static power'))
+  lines.push('')
+
+  //Physical Verification
+  lines.push(sectionHeader('7. PHYSICAL VERIFICATION'))
+  lines.push(separator('-'))
+  lines.push(row('DRC Status', data.verification.drcStatus === 'clean' ? 'CLEAN (0 violations)' : data.verification.drcStatus === 'violations' ? `VIOLATIONS (${fmt(data.verification.drcCount)})` : 'UNRUN', data.verification.drcStatus === 'clean' ? 'PASS' : 'FAIL'))
+  lines.push(row('LVS Status', data.verification.lvsStatus === 'matched' ? 'MATCHED (Clean)' : data.verification.lvsStatus === 'mismatch' ? `MISMATCHES (${fmt(data.verification.lvsMismatchCount)})` : 'UNRUN', data.verification.lvsStatus === 'matched' ? 'PASS' : 'FAIL'))
+  lines.push('')
+
+  //Execution Cost
+  lines.push(sectionHeader('8. FLOW EXECUTION COST'))
+  lines.push(separator('-'))
+  lines.push(row('Total Runtime', data.execution.totalRuntimeFormatted || fmt(data.execution.totalRuntimeSeconds, 's'), 'Wall clock time'))
+  lines.push(row('Peak Memory Usage', fmt(data.execution.peakMemoryMb, 'MB'), 'Max resident memory'))
+  if (includeStageBreakdown && data.execution.stages.length > 0) {
+    lines.push('')
+    lines.push(
+      `  ${padRight('Stage', 18)} ${padRight('Tool', 16)} ${padLeft('Runtime', 12)} ${padLeft('Peak Mem', 12)}  State`,
+    )
+    lines.push('  ' + '-'.repeat(WIDTH - 4))
+    for (const s of data.execution.stages) {
+      const stg = padRight(s.stage, 18)
+      const tl = padRight(s.tool, 16)
+      const rt = padLeft(s.runtimeFormatted || fmt(s.runtimeSeconds, 's'), 12)
+      const mem = padLeft(fmt(s.peakMemoryMb, 'MB'), 12)
+      lines.push(`  ${stg} ${tl} ${rt} ${mem}  ${s.state}`)
+    }
+  }
+
+  lines.push('')
+  lines.push(separator('='))
+  lines.push('END OF REPORT')
+
+  return lines.join('\n')
+}

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/textFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/textFormatter.ts
@@ -15,7 +15,9 @@ function fmt(val: number | string | null | undefined, unit = '', decimals = 2): 
   if (val === null || val === undefined) return '—'
   if (typeof val === 'number') {
     if (!Number.isFinite(val)) return '—'
-    const formatted = Number.isInteger(val) ? val.toLocaleString('en-US') : val.toFixed(decimals)
+    const formatted = Number.isInteger(val)
+      ? val.toLocaleString('en-US')
+      : val.toFixed(decimals)
     return unit ? `${formatted} ${unit}` : formatted
   }
   return unit ? `${val} ${unit}` : String(val)
@@ -25,10 +27,7 @@ export function formatTextReport(
   data: DesignReportData,
   options: DesignReportExportOptions = {},
 ): string {
-  const {
-    includeMultiCorner = true,
-    includeStageBreakdown = true,
-  } = options
+  const { includeMultiCorner = true, includeStageBreakdown = true } = options
 
   const lines: string[] = []
   const WIDTH = 78
@@ -56,8 +55,14 @@ export function formatTextReport(
 
   lines.push(titleBar('ECOS STUDIO — DESIGN SUMMARY REPORT'))
   lines.push(`Design Name        : ${data.design.designName}`)
-  const pdkCommitShort = data.design.pdkCommit ? `@${data.design.pdkCommit.slice(0, 8)}` : null
-  const pdkSuffix = pdkCommitShort ? ` (${pdkCommitShort})` : (data.design.pdkVersion ? ` (${data.design.pdkVersion})` : '')
+  const pdkCommitShort = data.design.pdkCommit
+    ? `@${data.design.pdkCommit.slice(0, 8)}`
+    : null
+  const pdkSuffix = pdkCommitShort
+    ? ` (${pdkCommitShort})`
+    : data.design.pdkVersion
+      ? ` (${data.design.pdkVersion})`
+      : ''
   lines.push(`PDK / Node         : ${data.design.pdk}${pdkSuffix}`)
   if (data.design.ecosStudioVersion) {
     lines.push(`ECOS Studio Version: ${data.design.ecosStudioVersion}`)
@@ -72,16 +77,51 @@ export function formatTextReport(
   //Physical Design
   lines.push(sectionHeader('1. PHYSICAL & AREA METRICS'))
   lines.push(separator('-'))
-  lines.push(row('Die Area', `${fmt(data.physical.dieAreaUm2, 'um²')}${data.physical.dieAreaMm2 !== null ? ` (${fmt(data.physical.dieAreaMm2, 'mm²', 4)})` : ''}`, 'Physical boundary'))
-  lines.push(row('Core Area', fmt(data.physical.coreAreaUm2, 'um²'), 'Placement boundary'))
-  lines.push(row('Core Utilization', fmt(data.physical.coreUtilizationPct, '%'), 'Placed cell density'))
-  lines.push(row('Standard Cell Area', fmt(data.physical.stdCellAreaUm2, 'um²'), 'Total stdcell area'))
+  lines.push(
+    row(
+      'Die Area',
+      `${fmt(data.physical.dieAreaUm2, 'um²')}${data.physical.dieAreaMm2 !== null ? ` (${fmt(data.physical.dieAreaMm2, 'mm²', 4)})` : ''}`,
+      'Physical boundary',
+    ),
+  )
+  lines.push(
+    row('Core Area', fmt(data.physical.coreAreaUm2, 'um²'), 'Placement boundary'),
+  )
+  lines.push(
+    row(
+      'Core Utilization',
+      fmt(data.physical.coreUtilizationPct, '%'),
+      'Placed cell density',
+    ),
+  )
+  lines.push(
+    row(
+      'Standard Cell Area',
+      fmt(data.physical.stdCellAreaUm2, 'um²'),
+      'Total stdcell area',
+    ),
+  )
   if (data.physical.macroCount !== null && data.physical.macroCount > 0) {
-    lines.push(row('Macro Count / Area', `${fmt(data.physical.macroCount)} macros / ${fmt(data.physical.macroAreaUm2, 'um²')}`, 'Hard macros'))
+    lines.push(
+      row(
+        'Macro Count / Area',
+        `${fmt(data.physical.macroCount)} macros / ${fmt(data.physical.macroAreaUm2, 'um²')}`,
+        'Hard macros',
+      ),
+    )
   }
   lines.push(row('Total Instances', fmt(data.physical.instanceCount), 'Cells placed'))
-  if (data.physical.sequentialCellCount !== null || data.physical.combinationalCellCount !== null) {
-    lines.push(row('Sequential / Comb. Cells', `${fmt(data.physical.sequentialCellCount)} / ${fmt(data.physical.combinationalCellCount)}`, 'Flops / Gates'))
+  if (
+    data.physical.sequentialCellCount !== null ||
+    data.physical.combinationalCellCount !== null
+  ) {
+    lines.push(
+      row(
+        'Sequential / Comb. Cells',
+        `${fmt(data.physical.sequentialCellCount)} / ${fmt(data.physical.combinationalCellCount)}`,
+        'Flops / Gates',
+      ),
+    )
   }
   if (data.physical.ioPinCount !== null) {
     lines.push(row('IO Pins', fmt(data.physical.ioPinCount), 'Chip IOs'))
@@ -94,44 +134,125 @@ export function formatTextReport(
   //Timing Closure
   lines.push(sectionHeader('2. TIMING CLOSURE & PERFORMANCE'))
   lines.push(separator('-'))
-  lines.push(row('Target Clock Period', fmt(data.timing.targetClockPeriodNs, 'ns'), `Target freq: ${fmt(data.timing.targetFrequencyMhz, 'MHz')}`))
-  lines.push(row('Achieved Fmax', fmt(data.timing.fmaxMhz, 'MHz'), 'Max operating frequency'))
-  lines.push(row('Setup Slack (WNS / TNS)', `${fmt(data.timing.setupWnsNs, 'ns')} / ${fmt(data.timing.setupTnsNs, 'ns')}`, data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0 ? 'TIMING MET' : 'VIOLATION'))
-  lines.push(row('Hold Slack (WNS / TNS)', `${fmt(data.timing.holdWnsNs, 'ns')} / ${fmt(data.timing.holdTnsNs, 'ns')}`, data.timing.holdWnsNs !== null && data.timing.holdWnsNs >= 0 ? 'TIMING MET' : 'VIOLATION'))
+  lines.push(
+    row(
+      'Target Clock Period',
+      fmt(data.timing.targetClockPeriodNs, 'ns'),
+      `Target freq: ${fmt(data.timing.targetFrequencyMhz, 'MHz')}`,
+    ),
+  )
+  lines.push(
+    row('Achieved Fmax', fmt(data.timing.fmaxMhz, 'MHz'), 'Max operating frequency'),
+  )
+  lines.push(
+    row(
+      'Setup Slack (WNS / TNS)',
+      `${fmt(data.timing.setupWnsNs, 'ns')} / ${fmt(data.timing.setupTnsNs, 'ns')}`,
+      data.timing.setupWnsNs !== null && data.timing.setupWnsNs >= 0
+        ? 'TIMING MET'
+        : 'VIOLATION',
+    ),
+  )
+  lines.push(
+    row(
+      'Hold Slack (WNS / TNS)',
+      `${fmt(data.timing.holdWnsNs, 'ns')} / ${fmt(data.timing.holdTnsNs, 'ns')}`,
+      data.timing.holdWnsNs !== null && data.timing.holdWnsNs >= 0
+        ? 'TIMING MET'
+        : 'VIOLATION',
+    ),
+  )
   if (data.timing.criticalPathDelayNs !== null) {
-    lines.push(row('Critical Path Delay', fmt(data.timing.criticalPathDelayNs, 'ns'), 'Data path delay'))
+    lines.push(
+      row(
+        'Critical Path Delay',
+        fmt(data.timing.criticalPathDelayNs, 'ns'),
+        'Data path delay',
+      ),
+    )
   }
-  if (data.timing.violatingEndpointsSetup !== null || data.timing.violatingEndpointsHold !== null) {
-    lines.push(row('Violating Endpoints (Setup/Hold)', `${fmt(data.timing.violatingEndpointsSetup)} / ${fmt(data.timing.violatingEndpointsHold)}`, 'Failing paths'))
+  if (
+    data.timing.violatingEndpointsSetup !== null ||
+    data.timing.violatingEndpointsHold !== null
+  ) {
+    lines.push(
+      row(
+        'Violating Endpoints (Setup/Hold)',
+        `${fmt(data.timing.violatingEndpointsSetup)} / ${fmt(data.timing.violatingEndpointsHold)}`,
+        'Failing paths',
+      ),
+    )
   }
-  if (data.timing.slewViolations !== null || data.timing.capViolations !== null || data.timing.fanoutViolations !== null) {
-    lines.push(row('DRC Violations (Slew/Cap/Fanout)', `${fmt(data.timing.slewViolations)} / ${fmt(data.timing.capViolations)} / ${fmt(data.timing.fanoutViolations)}`, 'Electrical DRC'))
+  if (
+    data.timing.slewViolations !== null ||
+    data.timing.capViolations !== null ||
+    data.timing.fanoutViolations !== null
+  ) {
+    lines.push(
+      row(
+        'DRC Violations (Slew/Cap/Fanout)',
+        `${fmt(data.timing.slewViolations)} / ${fmt(data.timing.capViolations)} / ${fmt(data.timing.fanoutViolations)}`,
+        'Electrical DRC',
+      ),
+    )
   }
   lines.push('')
 
   //Clock Tree & Quality
   lines.push(sectionHeader('3. CLOCK TREE & QUALITY'))
   lines.push(separator('-'))
-  lines.push(row('Clock Tree Depth', `${fmt(data.clock.clockTreeLevels)} levels`, 'Max tree depth'))
+  lines.push(
+    row(
+      'Clock Tree Depth',
+      `${fmt(data.clock.clockTreeLevels)} levels`,
+      'Max tree depth',
+    ),
+  )
   if (data.clock.clockBufferCount !== null || data.clock.clockTotalBuffers !== null) {
-    const bufStr = data.clock.clockBufferCount !== null ? `${data.clock.clockBufferCount}` : `${data.clock.clockTotalBuffers}`
-    const areaStr = data.clock.clockBufferAreaUm2 !== null ? ` (${fmt(data.clock.clockBufferAreaUm2, 'um²')})` : ''
+    const bufStr =
+      data.clock.clockBufferCount !== null
+        ? `${data.clock.clockBufferCount}`
+        : `${data.clock.clockTotalBuffers}`
+    const areaStr =
+      data.clock.clockBufferAreaUm2 !== null
+        ? ` (${fmt(data.clock.clockBufferAreaUm2, 'um²')})`
+        : ''
     lines.push(row('Clock Buffers', `${bufStr}${areaStr}`, 'CTS buffers'))
   }
   if (data.clock.clockPathMinBuffer !== null || data.clock.clockPathMaxBuffer !== null) {
-    lines.push(row('Clock Path Buffers (Min/Max)', `${fmt(data.clock.clockPathMinBuffer)} / ${fmt(data.clock.clockPathMaxBuffer)}`, 'Buffers per path range'))
+    lines.push(
+      row(
+        'Clock Path Buffers (Min/Max)',
+        `${fmt(data.clock.clockPathMinBuffer)} / ${fmt(data.clock.clockPathMaxBuffer)}`,
+        'Buffers per path range',
+      ),
+    )
   }
   if (data.clock.clockWirelengthUm !== null) {
-    lines.push(row('Clock Wirelength', `${fmt(data.clock.clockWirelengthUm, 'um')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmt(data.clock.clockMaxWirelengthUm, 'um')})` : ''}`, 'Total clock routing'))
+    lines.push(
+      row(
+        'Clock Wirelength',
+        `${fmt(data.clock.clockWirelengthUm, 'um')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmt(data.clock.clockMaxWirelengthUm, 'um')})` : ''}`,
+        'Total clock routing',
+      ),
+    )
   }
   if (data.clock.clockNetsCount !== null) {
-    lines.push(row('Clock Nets', `${fmt(data.clock.clockNetsCount)} nets`, 'Clock net count'))
+    lines.push(
+      row('Clock Nets', `${fmt(data.clock.clockNetsCount)} nets`, 'Clock net count'),
+    )
   }
   if (data.clock.clockSkewPs !== null) {
     lines.push(row('Clock Skew', fmt(data.clock.clockSkewPs, 'ps'), 'Max skew'))
   }
   if (data.clock.clockLatencyNs !== null) {
-    lines.push(row('Clock Insertion Latency', fmt(data.clock.clockLatencyNs, 'ns'), 'Insertion delay'))
+    lines.push(
+      row(
+        'Clock Insertion Latency',
+        fmt(data.clock.clockLatencyNs, 'ns'),
+        'Insertion delay',
+      ),
+    )
   }
   lines.push('')
 
@@ -159,10 +280,25 @@ export function formatTextReport(
   lines.push(sectionHeader('5. ROUTING & CONGESTION'))
   lines.push(separator('-'))
   lines.push(row('HPWL', fmt(data.routing.hpwlUm, 'um'), 'Estimated wirelength'))
-  lines.push(row('Routed Wirelength', fmt(data.routing.routedWirelengthUm, 'um'), 'Final routed wirelength'))
+  lines.push(
+    row(
+      'Routed Wirelength',
+      fmt(data.routing.routedWirelengthUm, 'um'),
+      'Final routed wirelength',
+    ),
+  )
   lines.push(row('Via Count', fmt(data.routing.viaCount), 'Vias'))
-  if (data.congestion.globalOverflowTotal !== null || data.congestion.globalOverflowPct !== null) {
-    lines.push(row('Global Route Overflow', `${fmt(data.congestion.globalOverflowTotal)}${data.congestion.globalOverflowPct !== null ? ` (${fmt(data.congestion.globalOverflowPct, '%')})` : ''}`, 'Tracks overflow'))
+  if (
+    data.congestion.globalOverflowTotal !== null ||
+    data.congestion.globalOverflowPct !== null
+  ) {
+    lines.push(
+      row(
+        'Global Route Overflow',
+        `${fmt(data.congestion.globalOverflowTotal)}${data.congestion.globalOverflowPct !== null ? ` (${fmt(data.congestion.globalOverflowPct, '%')})` : ''}`,
+        'Tracks overflow',
+      ),
+    )
   }
   lines.push('')
 
@@ -170,22 +306,57 @@ export function formatTextReport(
   lines.push(sectionHeader('6. POWER ANALYSIS'))
   lines.push(separator('-'))
   lines.push(row('Total Power', fmt(data.power.totalPowerMw, 'mW'), 'Total dissipation'))
-  lines.push(row('Dynamic Power', fmt(data.power.dynamicPowerMw, 'mW'), 'Switching + Internal'))
+  lines.push(
+    row('Dynamic Power', fmt(data.power.dynamicPowerMw, 'mW'), 'Switching + Internal'),
+  )
   lines.push(row('Leakage Power', fmt(data.power.leakagePowerMw, 'mW'), 'Static power'))
   lines.push('')
 
   //Physical Verification
   lines.push(sectionHeader('7. PHYSICAL VERIFICATION'))
   lines.push(separator('-'))
-  lines.push(row('DRC Status', data.verification.drcStatus === 'clean' ? 'CLEAN (0 violations)' : data.verification.drcStatus === 'violations' ? `VIOLATIONS (${fmt(data.verification.drcCount)})` : 'UNRUN', data.verification.drcStatus === 'clean' ? 'PASS' : 'FAIL'))
-  lines.push(row('LVS Status', data.verification.lvsStatus === 'matched' ? 'MATCHED (Clean)' : data.verification.lvsStatus === 'mismatch' ? `MISMATCHES (${fmt(data.verification.lvsMismatchCount)})` : 'UNRUN', data.verification.lvsStatus === 'matched' ? 'PASS' : 'FAIL'))
+  lines.push(
+    row(
+      'DRC Status',
+      data.verification.drcStatus === 'clean'
+        ? 'CLEAN (0 violations)'
+        : data.verification.drcStatus === 'violations'
+          ? `VIOLATIONS (${fmt(data.verification.drcCount)})`
+          : 'UNRUN',
+      data.verification.drcStatus === 'clean' ? 'PASS' : 'FAIL',
+    ),
+  )
+  lines.push(
+    row(
+      'LVS Status',
+      data.verification.lvsStatus === 'matched'
+        ? 'MATCHED (Clean)'
+        : data.verification.lvsStatus === 'mismatch'
+          ? `MISMATCHES (${fmt(data.verification.lvsMismatchCount)})`
+          : 'UNRUN',
+      data.verification.lvsStatus === 'matched' ? 'PASS' : 'FAIL',
+    ),
+  )
   lines.push('')
 
   //Execution Cost
   lines.push(sectionHeader('8. FLOW EXECUTION COST'))
   lines.push(separator('-'))
-  lines.push(row('Total Runtime', data.execution.totalRuntimeFormatted || fmt(data.execution.totalRuntimeSeconds, 's'), 'Wall clock time'))
-  lines.push(row('Peak Memory Usage', fmt(data.execution.peakMemoryMb, 'MB'), 'Max resident memory'))
+  lines.push(
+    row(
+      'Total Runtime',
+      data.execution.totalRuntimeFormatted ||
+        fmt(data.execution.totalRuntimeSeconds, 's'),
+      'Wall clock time',
+    ),
+  )
+  lines.push(
+    row(
+      'Peak Memory Usage',
+      fmt(data.execution.peakMemoryMb, 'MB'),
+      'Max resident memory',
+    ),
+  )
   if (includeStageBreakdown && data.execution.stages.length > 0) {
     lines.push('')
     lines.push(

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/typstFormatter.test.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/typstFormatter.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { extractDesignReportData } from '../designReportExtract.ts'
+import { formatTypstReport } from './typstFormatter.ts'
+
+describe('typstFormatter', () => {
+  const sampleData = extractDesignReportData({
+    workspacePath: '/projects/aes/ws_002',
+    parameters: {
+      Design: 'aes_128',
+      PDK: 'ic55',
+      PDK_VERSION: 'v1.0.0',
+      PDK_COMMIT: 'e83fa201b9',
+      ECC_TOOL: 'ecc-fe',
+      ECC_VERSION: '1.4.2',
+      ECOS_STUDIO_VERSION: '0.1.0-alpha.8',
+    },
+    flow: {
+      steps: [
+        {
+          name: 'Synthesis_yosys',
+          tool: 'Yosys',
+          state: 'Success',
+          runtime: '0:1:15',
+          'peak memory (mb)': 220,
+        },
+      ],
+    },
+    stepMetrics: {
+      Harden: {
+        die_area_um2: 450000,
+        core_area_um2: 380000,
+        utilization: 52.0,
+      },
+      CTS: {
+        cts_clock_tree_max_level: 3,
+        cts_buffer_count: 5,
+        cts_buffer_area: 14.2,
+      },
+      STA: {
+        clock_period: 20.0,
+        setup_wns: 1.25,
+        setup_tns: 0.0,
+        hold_wns: 0.22,
+        hold_tns: 0.0,
+      },
+      DRC: { drc_violations: 0 },
+      LVS: { lvs_mismatches: 0 },
+    },
+  })
+
+  it('generates structured Typst publication table with inline PDK commit matching LaTeX 1:1', () => {
+    const typ = formatTypstReport(sampleData)
+    expect(typ).toContain('#figure(')
+    expect(typ).toContain(
+      'caption: [Design Implementation and Signoff Summary: aes\\_128]',
+    )
+    expect(typ).toContain('table.header([*Category*], [*Metric*], [*Value*])')
+    expect(typ).toContain('table.cell(colspan: 3)[*Design and Technology*]')
+    expect(typ).toContain('ic55 (@e83fa201)')
+    expect(typ).toContain('0.1.0-alpha.8')
+    expect(typ).toContain('table.cell(colspan: 3)[*Area and Physical Design*]')
+    expect(typ).toContain('450,000 $mu"m"^2$')
+    expect(typ).toContain('52 %')
+    expect(typ).toContain('table.cell(colspan: 3)[*Timing Closure*]')
+    expect(typ).toContain('Target Clock Period')
+    expect(typ).toContain('table.cell(colspan: 3)[*Physical Verification*]')
+    expect(typ).toContain('Clean (0 violations)')
+    expect(typ).toContain('Matched (Clean)')
+  })
+
+  it('renders standalone Typst document with New Computer Modern font matching LaTeX article geometry', () => {
+    const typ = formatTypstReport(sampleData, { typstStandalone: true })
+    expect(typ).toContain('#set page(')
+    expect(typ).toContain('paper: "a4"')
+    expect(typ).toContain('font: "New Computer Modern"')
+    expect(typ).toContain('#align(center)[')
+    expect(typ).toContain('#text(14pt, weight: "bold")[Design Summary Report: aes\\_128]')
+  })
+})

--- a/ecos/gui/packages/shared/src/utils/designReportFormatters/typstFormatter.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportFormatters/typstFormatter.ts
@@ -1,0 +1,267 @@
+import type {
+  DesignReportData,
+  DesignReportExportOptions,
+} from '../../contracts/designReport.ts'
+
+function escapeTypst(text: string | null | undefined): string {
+  if (text === null || text === undefined || text === '') return '---'
+  return String(text)
+    .replace(/\\/g, '\\\\')
+    .replace(/([#$*_`[\]"])/g, '\\$1')
+}
+
+function fmtVal(
+  val: number | string | null | undefined,
+  unit = '',
+  decimals = 2,
+): string {
+  if (val === null || val === undefined) return '---'
+  if (typeof val === 'number') {
+    if (!Number.isFinite(val)) return '---'
+    const formatted = Number.isInteger(val)
+      ? val.toLocaleString('en-US')
+      : val.toFixed(decimals)
+    return unit ? `${formatted} ${unit}` : formatted
+  }
+  return unit ? `${escapeTypst(String(val))} ${unit}` : escapeTypst(String(val))
+}
+
+export function formatTypstReport(
+  data: DesignReportData,
+  options: DesignReportExportOptions = {},
+): string {
+  const {
+    typstStandalone = false,
+    title = `Design Summary Report: ${data.design.designName}`,
+  } = options
+
+  const lines: string[] = []
+
+  if (typstStandalone) {
+    lines.push('#set page(')
+    lines.push('  paper: "a4",')
+    lines.push('  margin: (x: 1.8cm, top: 1.5cm, bottom: 1.5cm),')
+    lines.push(')')
+    lines.push('#set text(')
+    lines.push('  font: "New Computer Modern",')
+    lines.push('  size: 9.5pt,')
+    lines.push(')')
+    lines.push('#set par(justify: true)')
+    lines.push('')
+    lines.push('#align(center)[')
+    lines.push(`  #text(14pt, weight: "bold")[${escapeTypst(title)}] \\`)
+    lines.push('  #v(0.25em)')
+    lines.push(
+      '  #text(9pt, fill: luma(90))[#datetime.today().display("[month repr:long] [day], [year]")]',
+    )
+    lines.push(']')
+    lines.push('#v(0.4em)')
+    lines.push('')
+  }
+
+  // Section 1: Main Design & Summary Table (1:1 with LaTeX table)
+  lines.push(
+    '// ==============================================================================',
+  )
+  lines.push('// ECOS STUDIO DESIGN SUMMARY TABLE')
+  lines.push(`// Design: ${data.design.designName} | PDK: ${data.design.pdk}`)
+  lines.push(`// Generated: ${data.design.generatedAt}`)
+  lines.push(
+    '// ==============================================================================',
+  )
+  lines.push('#figure(')
+  lines.push(
+    `  caption: [Design Implementation and Signoff Summary: ${escapeTypst(data.design.designName)}],`,
+  )
+  lines.push('  gap: 0.6em,')
+  lines.push('  table(')
+  lines.push('    columns: (1.2fr, 2fr, 1.2fr),')
+  lines.push('    align: (left, left, right),')
+  lines.push('    inset: (x: 5.5pt, y: 3pt),')
+  lines.push('    stroke: none,')
+  lines.push('    table.hline(stroke: 1.2pt),')
+  lines.push('    table.header([*Category*], [*Metric*], [*Value*]),')
+  lines.push('    table.hline(stroke: 0.6pt),')
+  lines.push('')
+
+  // Design & Technology
+  lines.push('    table.cell(colspan: 3)[*Design and Technology*],')
+  lines.push(`    [], [Design Name], [${escapeTypst(data.design.designName)}],`)
+  const pdkCommitShort = data.design.pdkCommit
+    ? `@${data.design.pdkCommit.slice(0, 8)}`
+    : null
+  const pdkSuffix = pdkCommitShort
+    ? ` (${pdkCommitShort})`
+    : data.design.pdkVersion
+      ? ` (${data.design.pdkVersion})`
+      : ''
+  lines.push(`    [], [PDK], [${escapeTypst(data.design.pdk + pdkSuffix)}],`)
+  if (data.design.ecosStudioVersion) {
+    lines.push(
+      `    [], [ECOS Studio Version], [${escapeTypst(data.design.ecosStudioVersion)}],`,
+    )
+  }
+  if (data.design.gitCommit) {
+    lines.push(
+      `    [], [Git Commit], [\`${data.design.gitCommit.slice(0, 8).replace(/`/g, '')}\`],`,
+    )
+  }
+  lines.push('    table.hline(stroke: 0.6pt),')
+  lines.push('')
+
+  // Area & Physical
+  lines.push('    table.cell(colspan: 3)[*Area and Physical Design*],')
+  lines.push(
+    `    [], [Die Area], [${fmtVal(data.physical.dieAreaUm2, '$mu"m"^2$')}${data.physical.dieAreaMm2 !== null ? ` (${fmtVal(data.physical.dieAreaMm2, '$"mm"^2$', 4)})` : ''}],`,
+  )
+  lines.push(`    [], [Core Area], [${fmtVal(data.physical.coreAreaUm2, '$mu"m"^2$')}],`)
+  lines.push(
+    `    [], [Core Utilization], [${fmtVal(data.physical.coreUtilizationPct, '%')}],`,
+  )
+  lines.push(
+    `    [], [Standard Cell Area], [${fmtVal(data.physical.stdCellAreaUm2, '$mu"m"^2$')}],`,
+  )
+  if (data.physical.macroCount !== null && data.physical.macroCount > 0) {
+    lines.push(
+      `    [], [Macro Count / Area], [${fmtVal(data.physical.macroCount)} macros / ${fmtVal(data.physical.macroAreaUm2, '$mu"m"^2$')}],`,
+    )
+  }
+  lines.push(`    [], [Total Instances], [${fmtVal(data.physical.instanceCount)}],`)
+  if (
+    data.physical.sequentialCellCount !== null ||
+    data.physical.combinationalCellCount !== null
+  ) {
+    lines.push(
+      `    [], [Sequential / Comb. Cells], [${fmtVal(data.physical.sequentialCellCount)} / ${fmtVal(data.physical.combinationalCellCount)}],`,
+    )
+  }
+  if (data.physical.ioPinCount !== null) {
+    lines.push(`    [], [IO Pins], [${fmtVal(data.physical.ioPinCount)}],`)
+  }
+  if (data.physical.netCount !== null) {
+    lines.push(`    [], [Total Nets], [${fmtVal(data.physical.netCount)}],`)
+  }
+  lines.push('    table.hline(stroke: 0.6pt),')
+  lines.push('')
+
+  // Timing Closure
+  lines.push('    table.cell(colspan: 3)[*Timing Closure*],')
+  lines.push(
+    `    [], [Target Clock Period], [${fmtVal(data.timing.targetClockPeriodNs, 'ns')}${data.timing.targetFrequencyMhz !== null ? ` (${fmtVal(data.timing.targetFrequencyMhz, 'MHz')})` : ''}],`,
+  )
+  lines.push(`    [], [Achieved $F_"max"$], [${fmtVal(data.timing.fmaxMhz, 'MHz')}],`)
+  lines.push(
+    `    [], [Setup WNS / TNS], [${fmtVal(data.timing.setupWnsNs, 'ns')} / ${fmtVal(data.timing.setupTnsNs, 'ns')}],`,
+  )
+  lines.push(
+    `    [], [Hold WNS / TNS], [${fmtVal(data.timing.holdWnsNs, 'ns')} / ${fmtVal(data.timing.holdTnsNs, 'ns')}],`,
+  )
+  if (
+    data.timing.violatingEndpointsSetup !== null ||
+    data.timing.violatingEndpointsHold !== null
+  ) {
+    lines.push(
+      `    [], [Violating Endpoints (Setup / Hold)], [${fmtVal(data.timing.violatingEndpointsSetup, '', 0)} / ${fmtVal(data.timing.violatingEndpointsHold, '', 0)}],`,
+    )
+  }
+  if (data.timing.criticalPathDelayNs !== null) {
+    lines.push(
+      `    [], [Critical Path Delay], [${fmtVal(data.timing.criticalPathDelayNs, 'ns')}],`,
+    )
+  }
+  if (
+    data.timing.slewViolations !== null ||
+    data.timing.capViolations !== null ||
+    data.timing.fanoutViolations !== null
+  ) {
+    lines.push(
+      `    [], [DRC Electrical (Slew / Cap / Fanout)], [${fmtVal(data.timing.slewViolations, '', 0)} / ${fmtVal(data.timing.capViolations, '', 0)} / ${fmtVal(data.timing.fanoutViolations, '', 0)}],`,
+    )
+  }
+  lines.push('    table.hline(stroke: 0.6pt),')
+  lines.push('')
+
+  // Clock Tree & Quality
+  lines.push('    table.cell(colspan: 3)[*Clock Tree and Quality*],')
+  lines.push(
+    `    [], [Clock Tree Depth], [${fmtVal(data.clock.clockTreeLevels, 'levels', 0)}],`,
+  )
+  if (data.clock.clockBufferCount !== null || data.clock.clockTotalBuffers !== null) {
+    const bufCountStr =
+      data.clock.clockBufferCount !== null
+        ? `${data.clock.clockBufferCount}`
+        : `${data.clock.clockTotalBuffers}`
+    const areaStr =
+      data.clock.clockBufferAreaUm2 !== null
+        ? ` (${fmtVal(data.clock.clockBufferAreaUm2, '$mu"m"^2$')})`
+        : ''
+    lines.push(`    [], [Clock Buffers], [${bufCountStr}${areaStr}],`)
+  }
+  if (data.clock.clockPathMinBuffer !== null || data.clock.clockPathMaxBuffer !== null) {
+    lines.push(
+      `    [], [Clock Path Buffers (Min / Max)], [${fmtVal(data.clock.clockPathMinBuffer, '', 0)} / ${fmtVal(data.clock.clockPathMaxBuffer, '', 0)}],`,
+    )
+  }
+  if (data.clock.clockWirelengthUm !== null) {
+    lines.push(
+      `    [], [Clock Wirelength], [${fmtVal(data.clock.clockWirelengthUm, '$mu"m"$')}${data.clock.clockMaxWirelengthUm !== null ? ` (Max: ${fmtVal(data.clock.clockMaxWirelengthUm, '$mu"m"$')})` : ''}],`,
+    )
+  }
+  if (data.clock.clockNetsCount !== null) {
+    lines.push(`    [], [Clock Nets], [${fmtVal(data.clock.clockNetsCount, 'nets', 0)}],`)
+  }
+  if (data.clock.clockSkewPs !== null) {
+    lines.push(`    [], [Clock Skew], [${fmtVal(data.clock.clockSkewPs, 'ps')}],`)
+  }
+  if (data.clock.clockLatencyNs !== null) {
+    lines.push(
+      `    [], [Clock Insertion Latency], [${fmtVal(data.clock.clockLatencyNs, 'ns')}],`,
+    )
+  }
+  lines.push('    table.hline(stroke: 0.6pt),')
+  lines.push('')
+
+  // Routing & Congestion
+  lines.push('    table.cell(colspan: 3)[*Routing and Congestion*],')
+  lines.push(
+    `    [], [Half-Perimeter Wirelength (HPWL)], [${fmtVal(data.routing.hpwlUm, '$mu"m"$')}],`,
+  )
+  lines.push(
+    `    [], [Routed Wirelength], [${fmtVal(data.routing.routedWirelengthUm, '$mu"m"$')}],`,
+  )
+  lines.push(`    [], [Via Count], [${fmtVal(data.routing.viaCount, '', 0)}],`)
+  if (
+    data.congestion.globalOverflowTotal !== null ||
+    data.congestion.globalOverflowPct !== null
+  ) {
+    lines.push(
+      `    [], [Global Route Overflow], [${fmtVal(data.congestion.globalOverflowTotal, '', 0)}${data.congestion.globalOverflowPct !== null ? ` (${fmtVal(data.congestion.globalOverflowPct, '%')})` : ''}],`,
+    )
+  }
+  lines.push('    table.hline(stroke: 0.6pt),')
+  lines.push('')
+
+  // Power Analysis
+  lines.push('    table.cell(colspan: 3)[*Power Analysis*],')
+  lines.push(`    [], [Total Power], [${fmtVal(data.power.totalPowerMw, 'mW')}],`)
+  lines.push(`    [], [Dynamic Power], [${fmtVal(data.power.dynamicPowerMw, 'mW')}],`)
+  lines.push(`    [], [Leakage Power], [${fmtVal(data.power.leakagePowerMw, 'mW')}],`)
+  lines.push('    table.hline(stroke: 0.6pt),')
+  lines.push('')
+
+  // Physical Verification
+  lines.push('    table.cell(colspan: 3)[*Physical Verification*],')
+  lines.push(
+    `    [], [DRC Status], [${data.verification.drcStatus === 'clean' ? 'Clean (0 violations)' : data.verification.drcStatus === 'violations' ? `Violations (${fmtVal(data.verification.drcCount, '', 0)})` : 'Unrun'}],`,
+  )
+  lines.push(
+    `    [], [LVS Status], [${data.verification.lvsStatus === 'matched' ? 'Matched (Clean)' : data.verification.lvsStatus === 'mismatch' ? `Mismatches (${fmtVal(data.verification.lvsMismatchCount, '', 0)})` : 'Unrun'}],`,
+  )
+
+  lines.push('    table.hline(stroke: 1.2pt),')
+  lines.push('  )')
+  lines.push(')')
+  lines.push('')
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary

- Added a dedicated **Export Design Summary** dialog supporting 4 export formats: Markdown (`.md`), LaTeX (`.tex`), CSV (`.csv`), and Plain Text (`.txt`).
- Automatically bundles all four design summary formats alongside the `.tar.gz` archive during **Signoff Package Export**.
## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [x] `cd ecos/gui && pnpm run build`
- [ ] `make build` (N/A - frontend GUI changes only)
- [ ] `make demo-gcd` (N/A)
- [ ] `make demo-retrosoc` (N/A)
- [x] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

- Backend demo flows skipped as changes are strictly within `ecos/gui` frontend and desktop report formatters.

## Screenshots or Recordings

<img width="1438" height="959" alt="image" src="https://github.com/user-attachments/assets/77adf495-b462-4f4d-b78d-64bf36e41f13" />


## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- None.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.