### PR TITLE
feat(gui): add experimental warning banner to frontend design

### DIFF
--- a/ecos/gui/apps/renderer/src/components/FrontendProjectWizard.vue
+++ b/ecos/gui/apps/renderer/src/components/FrontendProjectWizard.vue
@@ -96,6 +96,10 @@
         </aside>
 
         <main class="relative flex min-h-0 min-w-0 flex-1 flex-col bg-transparent">
+          <div class="shrink-0 px-8 pt-6 md:px-12">
+            <FrontendExperimentalBanner />
+          </div>
+
           <div
             ref="wizardScrollRef"
             class="custom-scrollbar flex-1 overflow-y-auto p-8 md:p-12"
@@ -842,6 +846,7 @@ import {
   type FrontendValidationResult,
 } from '@/api/frontendCatalog'
 import { waitForDesktopApi } from '@/platform/desktop'
+import FrontendExperimentalBanner from '@/components/frontend/FrontendExperimentalBanner.vue'
 import type { WorkspaceConfig } from '../types'
 import {
   formatCpuTopModule,

--- a/ecos/gui/apps/renderer/src/components/frontend/FrontendExperimentalBanner.vue
+++ b/ecos/gui/apps/renderer/src/components/frontend/FrontendExperimentalBanner.vue
@@ -1,0 +1,16 @@
+<template>
+  <div
+    class="flex shrink-0 items-center gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3.5 py-2.5"
+  >
+    <i class="ri-error-warning-line shrink-0 text-base text-amber-500"></i>
+    <span
+      class="shrink-0 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-amber-600 uppercase dark:text-amber-400"
+    >
+      Experimental
+    </span>
+    <p class="min-w-0 flex-1 text-xs leading-relaxed text-amber-700 dark:text-amber-300">
+      Chip frontend design is under rapid iteration and may be unstable — expect bugs,
+      incomplete features, and breaking changes.
+    </p>
+  </div>
+</template>

--- a/ecos/gui/apps/renderer/src/components/frontend/FrontendSrcWorkspace.vue
+++ b/ecos/gui/apps/renderer/src/components/frontend/FrontendSrcWorkspace.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="frontend-workspace src-workspace-clean">
+    <FrontendExperimentalBanner class="m-3" />
     <section class="source-layout source-layout-clean">
       <aside class="source-list">
         <div class="source-list-body">
@@ -47,6 +48,7 @@
 
 <script setup lang="ts">
 import FrontendSourceEditor from '@/components/FrontendSourceEditor.vue'
+import FrontendExperimentalBanner from '@/components/frontend/FrontendExperimentalBanner.vue'
 
 interface PathItem {
   label: string

--- a/ecos/gui/apps/renderer/src/components/frontend/FrontendWaveWorkspace.vue
+++ b/ecos/gui/apps/renderer/src/components/frontend/FrontendWaveWorkspace.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="frontend-workspace wave-workspace-clean">
+    <FrontendExperimentalBanner class="m-3" />
     <section class="wave-workspace-layout">
       <aside class="wave-list">
         <button
@@ -76,6 +77,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import FrontendExperimentalBanner from '@/components/frontend/FrontendExperimentalBanner.vue'
 
 interface WaveSelection {
   path: string

--- a/ecos/gui/apps/renderer/src/views/FEView.vue
+++ b/ecos/gui/apps/renderer/src/views/FEView.vue
@@ -25,6 +25,10 @@
         </div>
       </div>
 
+      <div class="mb-12 w-full max-w-3xl px-4">
+        <FrontendExperimentalBanner />
+      </div>
+
       <div class="mb-16 flex gap-5">
         <button
           @click="handleOpenWorkspace"
@@ -198,6 +202,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import type { Project, ProjectStatus, WorkspaceConfig } from '../types'
 import FrontendProjectWizard from '../components/FrontendProjectWizard.vue'
+import FrontendExperimentalBanner from '../components/frontend/FrontendExperimentalBanner.vue'
 import { useWorkspace } from '../composables/useWorkspace'
 
 const router = useRouter()

--- a/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.vue
+++ b/ecos/gui/apps/renderer/src/views/FrontendWorkspaceView.vue
@@ -29,6 +29,8 @@
   />
 
   <div v-show="!isGlobalSrcView && !isGlobalWaveView" class="frontend-workspace">
+    <FrontendExperimentalBanner />
+
     <div class="frontend-header">
       <div>
         <p class="frontend-kicker">
@@ -1924,6 +1926,7 @@ import {
 } from '@/utils/simRunContext'
 import { getDesktopApi } from '@/platform/desktop'
 import FrontendDisassemblyViewer from '@/components/frontend/FrontendDisassemblyViewer.vue'
+import FrontendExperimentalBanner from '@/components/frontend/FrontendExperimentalBanner.vue'
 import FrontendSrcWorkspace from '@/components/frontend/FrontendSrcWorkspace.vue'
 import FrontendWaveWorkspace from '@/components/frontend/FrontendWaveWorkspace.vue'
 import MonacoLogViewer from '@/components/MonacoLogViewer.vue'


### PR DESCRIPTION
## Summary

- Add experimental warning banner

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [x] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

<img width="2888" height="1924" alt="图片" src="https://github.com/user-attachments/assets/61be3982-f303-41e2-a864-85d8288c4e47" />

<img width="2888" height="1924" alt="图片" src="https://github.com/user-attachments/assets/a0ce282f-3b7c-4537-ac07-d2050122ea8b" />


## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
