### PR TITLE
docs: document AppImage libfuse2 requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ result
 .trellis/
 .humanize*
 .humanize/
-docs/
+/docs/
 .superpowers/
 .worktrees/
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ chmod +x <latest-release-file>.AppImage
 ./<latest-release-file>.AppImage
 ```
 
+**Note:** The AppImage runtime requires FUSE 2 (`libfuse.so.2`). Most distributions ship it by default, but FUSE-3-only systems (e.g. Ubuntu 24.04) do not. Either install it — `sudo apt install libfuse2` on Debian/Ubuntu — or bypass FUSE by running `./<latest-release-file>.AppImage --appimage-extract-and-run`. See [#173](https://github.com/openecos-projects/ecos-studio/issues/173) for details.
+
 ## Quick Start (For Developers)
 
 ```bash

--- a/ecos/docs/FAQ.md
+++ b/ecos/docs/FAQ.md
@@ -40,11 +40,29 @@ chmod +x ECOS-Studio_*.AppImage
 ./ECOS-Studio_*.AppImage
 ```
 
+The AppImage runtime requires FUSE 2 (`libfuse2`), which most distributions ship by default. On FUSE-3-only systems such as Ubuntu 24.04, see the Troubleshooting section below if the app fails to launch.
+
 ## Usage
 
 See the [User Guide](user-guide.md) for detailed instructions on creating workspaces, running the RTL-to-GDS flow, and viewing results.
 
 ## Troubleshooting
+
+**Q: AppImage fails to launch with `dlopen(): error loading libfuse.so.2`**
+
+The AppImage runtime requires FUSE 2, but some distributions (e.g. Ubuntu 24.04) only ship FUSE 3. Either install FUSE 2:
+
+```bash
+sudo apt install libfuse2  # Debian/Ubuntu
+```
+
+or run the AppImage without FUSE by extracting and running it directly:
+
+```bash
+./ECOS-Studio_*.AppImage --appimage-extract-and-run
+```
+
+See [#173](https://github.com/openecos-projects/ecos-studio/issues/173) for details.
 
 **Q: AppImage fails to launch on a virtual machine (GL / GVFS / ATK errors)**
 


### PR DESCRIPTION
## Summary

See: https://github.com/openecos-projects/ecos-studio/issues/173

## Scope

Select the areas touched by this PR:

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [x] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
