### PR TITLE
chore: bump version to v0.1.0-alpha.9

### DIFF
--- a/ecos/gui/apps/desktop-electron/package.json
+++ b/ecos/gui/apps/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecos-studio/desktop-electron",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "private": true,
   "description": "ECOS Studio desktop shell built with Electron.",
   "homepage": "https://github.com/openecos-projects/ecos-studio",

--- a/ecos/gui/apps/renderer/package.json
+++ b/ecos/gui/apps/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecos-studio/renderer",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ecos/gui/default.nix
+++ b/ecos/gui/default.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ecos-studio";
-  version = "0.1.0-alpha.8";
+  version = "0.1.0-alpha.9";
 
   src =
     with lib.fileset;

--- a/ecos/gui/package.json
+++ b/ecos/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecos-studio-gui",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.0.9",

--- a/ecos/gui/packages/shared/package.json
+++ b/ecos/gui/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecos-studio/shared",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/ecos/gui/packages/shared/src/utils/designReportExtract.ts
+++ b/ecos/gui/packages/shared/src/utils/designReportExtract.ts
@@ -505,7 +505,7 @@ export function extractDesignReportData(
     input.versionInfo?.gui ||
     (typeof params.ECOS_STUDIO_VERSION === 'string' && params.ECOS_STUDIO_VERSION) ||
     (typeof params.ecos_studio_version === 'string' && params.ecos_studio_version) ||
-    '0.1.0-alpha.8'
+    '0.1.0-alpha.9'
 
   const gitCommit =
     (typeof params.GIT_COMMIT === 'string' && params.GIT_COMMIT) ||


### PR DESCRIPTION
## Summary



## Scope

Select the areas touched by this PR:

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [ ] Other:

Skipped checks and reason:

-

## Screenshots or Recordings

Required for visible GUI changes.

-

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to the affected component.
- [ ] I updated docs or user-facing text where behavior changed.
- [ ] I included lockfile changes for dependency updates.
- [ ] I documented intentional submodule updates.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained any skipped validation and remaining risk.
