### PR TITLE
docs(agent): add scoped repository instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# ECOS Studio
+
+ECOS Studio is an integrated RTL-to-silicon design environment. This repository
+combines the desktop application, chip-design runtimes, native visualization,
+open-source IP, and PDK resources.
+
+For setup, contribution, submodule, and release workflows, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Technology Stack
+
+- Electron, Vue 3, TypeScript, and pnpm for the desktop application.
+- Python 3.11 and uv for ECC, ECC-FE, and the ECOS Agent.
+- Rust and Cargo for the native Chip Viewer.
+- Nix for reproducible development and packaging environments.
+- Git submodules for independently maintained toolchains, IP, and PDK sources.
+
+## Repository Structure
+
+- `ecos/`: ECOS Studio application code and integration scripts.
+- `ecc/`: RTL-to-GDS toolchain submodule.
+- `ecc-fe/`: front-end chip-design runtime submodule.
+- `ip/`: open-source IP submodules.
+- `pdk/`: PDK submodules.
+- `.github/`: CI, release, version, and packaging automation.
+
+## Repository Ownership
+
+- The parent repository owns product integration, packaging, and release
+  validation.
+- `ecos/` owns the desktop product, its built-in Agent, and native Chip Viewer.
+- ECC and ECC-FE remain independent repositories so their source, tests, and
+  releases are maintained by the toolchain owners.
+- IP and PDK repositories remain pinned inputs rather than parent-repository
+  source trees.
+
+## Scoped Instructions
+
+Before working in a component, read its scoped instructions:
+
+- `ecos/**`: `ecos/AGENTS.md`
+- `ecos/gui/**`: `ecos/AGENTS.md`, then `ecos/gui/AGENTS.md`
+- `ecos/agent/**`: `ecos/AGENTS.md`, then `ecos/agent/AGENTS.md`
+- `ecos/chip-viewer/**`: `ecos/AGENTS.md`, then `ecos/chip-viewer/AGENTS.md`
+- `ecc/**`: `ecc/AGENTS.md`
+- Other submodules: follow that repository's own instructions and README.
+
+## Setup
+
+From the repository root:
+
+```bash
+make setup
+cd ecc
+nix develop
+uv sync --no-build-isolation-package ecc-dreamplace \
+  --no-build-isolation-package ecc-tools-bin --verbose
+cd ../ecos/gui
+pnpm install --frozen-lockfile
+pnpm run dev
+```
+
+If Nix is unavailable, skip `nix develop`.
+
+## Code Changes
+
+- Understand the existing implementation and tests before editing.
+- Make the smallest coherent change that satisfies the request.
+- Reuse existing code, platform capabilities, and installed dependencies before
+  adding new implementations or dependencies.
+- Keep changes scoped to the owning component and preserve unrelated worktree
+  changes.
+- New hand-written production files should target fewer than 500 LoC.
+- At roughly 800 LoC, split by a real responsibility boundary or explain why the
+  file must remain cohesive.
+- If an implementation approaches 200 lines while an equally clear and correct
+  direct solution could be about 50, reconsider the design.
+- Do not reduce line count by removing validation, error handling, security, or
+  readability. Generated code, vendored code, fixtures, snapshots, lockfiles,
+  and declarative data are exempt from source-size guidance.
+
+## Submodules
+
+- Commit source changes in the submodule repository first, then update the
+  parent gitlink explicitly.
+- Before merge, every changed gitlink must reference a commit available from the
+  submodule's remote repository.
+- Record the new commit, why it is needed, and the checks run in both the
+  submodule and parent integration.
+
+## Dependencies And Generated Files
+
+- Use the owning package manager and update its lockfile; do not hand-edit
+  lockfiles.
+- Do not hand-edit generated build, release, packaged-resource, cache, or virtual
+  environment contents.
+
+## Validation
+
+- Run the narrowest relevant check first, then the affected component's full
+  check from its scoped instructions.
+- For release, packaging, version, or native-resource changes, run `make build`
+  or report why the Linux x86_64 release build was not run.
+- Report every relevant check that was not run and the remaining risk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,11 +38,11 @@ For setup, contribution, submodule, and release workflows, see
 
 Before working in a component, read its scoped instructions:
 
-- `ecos/**`: `ecos/AGENTS.md`
-- `ecos/gui/**`: `ecos/AGENTS.md`, then `ecos/gui/AGENTS.md`
-- `ecos/agent/**`: `ecos/AGENTS.md`, then `ecos/agent/AGENTS.md`
-- `ecos/chip-viewer/**`: `ecos/AGENTS.md`, then `ecos/chip-viewer/AGENTS.md`
-- `ecc/**`: `ecc/AGENTS.md`
+- `ecos/**`: @ecos/AGENTS.md
+- `ecos/gui/**`: @ecos/gui/AGENTS.md
+- `ecos/agent/**`: @ecos/agent/AGENTS.md
+- `ecos/chip-viewer/**`: @ecos/chip-viewer/AGENTS.md
+- `ecc/**`: @ecc/AGENTS.md
 - Other submodules: follow that repository's own instructions and README.
 
 ## Setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,25 +4,8 @@ ECOS Studio is an integrated RTL-to-silicon design environment. This repository
 combines the desktop application, chip-design runtimes, native visualization,
 open-source IP, and PDK resources.
 
-For setup, contribution, submodule, and release workflows, see
-[CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Technology Stack
-
-- Electron, Vue 3, TypeScript, and pnpm for the desktop application.
-- Python 3.11 and uv for ECC, ECC-FE, and the ECOS Agent.
-- Rust and Cargo for the native Chip Viewer.
-- Nix for reproducible development and packaging environments.
-- Git submodules for independently maintained toolchains, IP, and PDK sources.
-
-## Repository Structure
-
-- `ecos/`: ECOS Studio application code and integration scripts.
-- `ecc/`: RTL-to-GDS toolchain submodule.
-- `ecc-fe/`: front-end chip-design runtime submodule.
-- `ip/`: open-source IP submodules.
-- `pdk/`: PDK submodules.
-- `.github/`: CI, release, version, and packaging automation.
+See [Repository Layout](CONTRIBUTING.md#repository-layout) for the monorepo map
+and [CONTRIBUTING.md](CONTRIBUTING.md) for setup and development workflows.
 
 ## Repository Ownership
 
@@ -36,69 +19,53 @@ For setup, contribution, submodule, and release workflows, see
 
 ## Scoped Instructions
 
-Before working in a component, read its scoped instructions:
-
 - `ecos/**`: @ecos/AGENTS.md
 - `ecos/gui/**`: @ecos/gui/AGENTS.md
 - `ecos/agent/**`: @ecos/agent/AGENTS.md
 - `ecos/chip-viewer/**`: @ecos/chip-viewer/AGENTS.md
 - `ecc/**`: @ecc/AGENTS.md
-- Other submodules: follow that repository's own instructions and README.
+- Other submodules follow their own instructions and README.
 
-## Setup
+## Submodules And Dependencies
 
-From the repository root:
-
-```bash
-make setup
-cd ecc
-nix develop
-uv sync --no-build-isolation-package ecc-dreamplace \
-  --no-build-isolation-package ecc-tools-bin --verbose
-cd ../ecos/gui
-pnpm install --frozen-lockfile
-pnpm run dev
-```
-
-If Nix is unavailable, skip `nix develop`.
-
-## Code Changes
-
-- Understand the existing implementation and tests before editing.
-- Make the smallest coherent change that satisfies the request.
-- Reuse existing code, platform capabilities, and installed dependencies before
-  adding new implementations or dependencies.
-- Keep changes scoped to the owning component and preserve unrelated worktree
-  changes.
-- New hand-written production files should target fewer than 500 LoC.
-- At roughly 800 LoC, split by a real responsibility boundary or explain why the
-  file must remain cohesive.
-- If an implementation approaches 200 lines while an equally clear and correct
-  direct solution could be about 50, reconsider the design.
-- Do not reduce line count by removing validation, error handling, security, or
-  readability. Generated code, vendored code, fixtures, snapshots, lockfiles,
-  and declarative data are exempt from source-size guidance.
-
-## Submodules
-
-- Commit source changes in the submodule repository first, then update the
-  parent gitlink explicitly.
-- Before merge, every changed gitlink must reference a commit available from the
-  submodule's remote repository.
-- Record the new commit, why it is needed, and the checks run in both the
-  submodule and parent integration.
-
-## Dependencies And Generated Files
-
-- Use the owning package manager and update its lockfile; do not hand-edit
-  lockfiles.
+- Follow [Working With Submodules](CONTRIBUTING.md#working-with-submodules). Do
+  not prepare a parent PR whose gitlink depends on an unpublished submodule
+  commit.
+- Follow [Dependency and Lockfile Changes](CONTRIBUTING.md#dependency-and-lockfile-changes).
+  Use the owning package manager and do not hand-edit lockfiles.
 - Do not hand-edit generated build, release, packaged-resource, cache, or virtual
   environment contents.
 
-## Validation
+## Validation And CI
 
-- Run the narrowest relevant check first, then the affected component's full
-  check from its scoped instructions.
+- Treat `.github/workflows/ci.yml` as the source of truth for required CI jobs.
+- Run the narrowest relevant check while iterating, then run the local equivalent
+  of every non-packaging CI job enabled by the changed paths. Use the commands in
+  the affected component's scoped instructions.
 - For release, packaging, version, or native-resource changes, run `make build`
   or report why the Linux x86_64 release build was not run.
-- Report every relevant check that was not run and the remaining risk.
+- Reproduce CI failures with the same command, working directory, mode, and
+  relevant environment before treating them as unrelated or flaky.
+- When reporting PR status, report blocking reviews and failed or pending CI
+  checks separately.
+- Report the exact checks run, every relevant check not run, and the remaining
+  risk.
+
+## Pull Requests And Review
+
+- Follow [Commit Messages](CONTRIBUTING.md#commit-messages),
+  [Pull Requests](CONTRIBUTING.md#pull-requests), and the repository
+  [PR template](.github/pull_request_template.md).
+- When inspecting an unrelated branch or PR while the current checkout has
+  changes, use a separate Git worktree instead of switching branches or stashing
+  the user's work.
+- Before publishing, inspect the complete diff and working tree for unrelated
+  changes, generated output, caches, credentials, and unintended gitlinks.
+- In the PR body, identify the affected components, list exact validation
+  commands, explain skipped checks, and record any GUI, release, packaging,
+  runtime, dependency, or submodule impact.
+- Include screenshots or recordings for visible GUI changes.
+- Review cross-process contracts, persisted formats, filesystem and subprocess
+  boundaries, resource downloads, and user-controlled paths for compatibility,
+  failure handling, and security impact.
+- Resolve blocking CI failures before non-blocking cleanup or style feedback.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/ecos/AGENTS.md
+++ b/ecos/AGENTS.md
@@ -3,14 +3,6 @@
 These instructions apply to the application code under `ecos/` and supplement
 the repository-root `AGENTS.md`.
 
-## Application Layout
-
-- `gui/`: Electron desktop shell, Vue renderer, and shared TypeScript contracts.
-- `agent/`: Python Agent provider and its packaged plugin manifests.
-- `chip-viewer/`: Rust workspace for native layout inspection.
-- `scripts/`: runtime wrappers and integration smoke tests.
-- `docs/`: user-facing application documentation.
-
 ## Architecture
 
 - The Vue renderer presents workspaces and flows but delegates privileged work
@@ -26,11 +18,17 @@ the repository-root `AGENTS.md`.
 - Chip Viewer remains a native process so Rust rendering and large layout data
   stay outside the Electron renderer.
 
-## Component Instructions
+## Implementation Guidance
 
-- GUI work: read `gui/AGENTS.md`.
-- Agent work: read `agent/AGENTS.md`.
-- Chip Viewer work: read `chip-viewer/AGENTS.md`.
+- Add new behavior to focused modules instead of growing central orchestration
+  files.
+- Target new hand-written production files under 500 LoC.
+- When a file exceeds roughly 800 LoC, add new functionality in a separate
+  responsibility-focused module unless there is a strong reason to keep it
+  cohesive.
+- Do not reduce file size by removing validation, error handling, security, or
+  readability. Generated code, vendored code, fixtures, snapshots, lockfiles,
+  and declarative data are exempt.
 
 ## Cross-Component Changes
 

--- a/ecos/AGENTS.md
+++ b/ecos/AGENTS.md
@@ -1,0 +1,52 @@
+# ECOS Studio Application
+
+These instructions apply to the application code under `ecos/` and supplement
+the repository-root `AGENTS.md`.
+
+## Application Layout
+
+- `gui/`: Electron desktop shell, Vue renderer, and shared TypeScript contracts.
+- `agent/`: Python Agent provider and its packaged plugin manifests.
+- `chip-viewer/`: Rust workspace for native layout inspection.
+- `scripts/`: runtime wrappers and integration smoke tests.
+- `docs/`: user-facing application documentation.
+
+## Architecture
+
+- The Vue renderer presents workspaces and flows but delegates privileged work
+  through the Electron desktop bridge.
+- Electron main owns filesystem access, workspace mutation, subprocess
+  lifecycle, and integration with ECC, ECC-FE, the Agent, and Chip Viewer.
+- ECC supplies the packaged RTL-to-GDS runtime.
+- ECC-FE runs as a process-isolated front-end runtime. Packaged installations
+  use the runtime installed by Resource Manager; source development requires an
+  explicit override.
+- The Agent produces bounded proposals while ECOS Studio retains validation,
+  confirmation, execution, and result recording.
+- Chip Viewer remains a native process so Rust rendering and large layout data
+  stay outside the Electron renderer.
+
+## Component Instructions
+
+- GUI work: read `gui/AGENTS.md`.
+- Agent work: read `agent/AGENTS.md`.
+- Chip Viewer work: read `chip-viewer/AGENTS.md`.
+
+## Cross-Component Changes
+
+- Trace a contract through every producer and consumer before changing it.
+- Keep cross-process validation at the authoritative backend boundary.
+- When a change spans Python, TypeScript, Rust, or a submodule, run the focused
+  checks in every affected component.
+- Treat persisted workspace and project formats as integration contracts; update
+  migration and recovery tests when their shapes change.
+
+## Packaging
+
+- `.github/scripts/build-binaries.sh` builds and stages ECC, Chip Viewer, and the
+  packaged Agent before Electron packaging.
+- Do not edit `gui/apps/desktop-electron/resources/`, `release/`, `dist/`,
+  `build/`, or `target/` outputs by hand.
+- For changes to integration scripts, packaged binaries, manifests, or Electron
+  release inputs, run `make build` from the repository root or report why it was
+  not run.

--- a/ecos/CLAUDE.md
+++ b/ecos/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/ecos/agent/AGENTS.md
+++ b/ecos/agent/AGENTS.md
@@ -1,0 +1,68 @@
+# ECOS Agent
+
+These instructions apply to `ecos/agent/` and supplement the parent instruction
+files.
+
+## Package Layout
+
+- Python 3.11, Pydantic, uv, and pytest implement the in-tree Agent provider.
+- `src/ecos_agent/` contains provider state, typed contracts, Codex integration,
+  workspace setup and rerun logic, optimization, and knowledge retrieval.
+- `tests/` contains provider, protocol, workspace, optimization, and retrieval
+  tests.
+- `knowledge/` contains the production knowledge bundles loaded by the provider.
+- `agent-provider.json` launches the development provider through uv.
+- `agent-provider.packaged.json` launches the packaged `ecos-agent` executable.
+
+## Execution Boundaries
+
+- Codex produces read-only, schema-constrained proposals; it does not execute
+  shell commands, mutate workspaces, or run ECC directly.
+- ECOS Studio validates proposals, obtains user confirmation, performs workspace
+  mutations, invokes ECC, and records terminal results.
+- Source workspaces are preserved during isolated reruns, and execution success
+  is reported only from terminal ECC evidence.
+- The subprocess protocol keeps the Python provider replaceable while Electron
+  owns process lifecycle and GUI delivery.
+
+## Setup And Development
+
+```bash
+cd ecos/agent
+uv sync --locked
+uv run python -m ecos_agent.provider
+```
+
+## Validation
+
+- Focused test: `uv run pytest -q tests/<test_file>.py`
+- Full Agent suite: `uv run pytest -q`
+
+Run the focused test while iterating, then the full suite for provider, protocol,
+state-machine, permission, or shared-contract changes.
+
+## When Changing Agent Contracts
+
+- Keep Python provider payloads and
+  `ecos/gui/packages/shared/src/contracts/desktopAgent.ts` behaviorally aligned.
+- Update Electron provider/IPC tests and renderer contract tests when the
+  transport-visible shape changes.
+- Keep protocol version and development/packaged manifests aligned with the
+  runtime that consumes them.
+
+## When Changing Workspace Actions
+
+- Preserve local validation and explicit user confirmation before execution.
+- Do not grant Codex a direct write or ECC execution path.
+- Do not overwrite a source workspace when the operation requires an isolated
+  rerun target.
+- Do not report success without terminal execution evidence.
+- Read `PERMISSION_MODEL.md` before changing permission, path, network, parameter
+  authorization, or audit behavior.
+
+## Dependencies And Packaging
+
+- Use uv and commit the corresponding `uv.lock` update.
+- The release build packages the provider with PyInstaller through
+  `.github/scripts/build-binaries.sh`; do not edit `build/` or `dist/` outputs by
+  hand.

--- a/ecos/agent/AGENTS.md
+++ b/ecos/agent/AGENTS.md
@@ -3,17 +3,6 @@
 These instructions apply to `ecos/agent/` and supplement the parent instruction
 files.
 
-## Package Layout
-
-- Python 3.11, Pydantic, uv, and pytest implement the in-tree Agent provider.
-- `src/ecos_agent/` contains provider state, typed contracts, Codex integration,
-  workspace setup and rerun logic, optimization, and knowledge retrieval.
-- `tests/` contains provider, protocol, workspace, optimization, and retrieval
-  tests.
-- `knowledge/` contains the production knowledge bundles loaded by the provider.
-- `agent-provider.json` launches the development provider through uv.
-- `agent-provider.packaged.json` launches the packaged `ecos-agent` executable.
-
 ## Execution Boundaries
 
 - Codex produces read-only, schema-constrained proposals; it does not execute

--- a/ecos/agent/CLAUDE.md
+++ b/ecos/agent/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/ecos/chip-viewer/AGENTS.md
+++ b/ecos/chip-viewer/AGENTS.md
@@ -1,0 +1,57 @@
+# ECOS Chip Viewer
+
+These instructions apply to `ecos/chip-viewer/` and supplement the parent
+instruction files.
+
+## Workspace Layout
+
+- This is a Rust 2021 Cargo workspace.
+- `crates/chipgeom-format/` defines shared geometry records and schema constants.
+- `crates/chipgeom-reader/` reads geometry manifests and memory-mapped data.
+- `crates/chip-view-db/` owns the queryable layout database and spatial indexes.
+- `crates/chip-display/` owns display roles, themes, and presentation metadata.
+- `crates/chip-render/` converts database geometry into render data.
+- `apps/chipgeom-probe-cli/` provides inspection and benchmark commands.
+- `apps/chip-viewer-native/` provides the egui/wgpu native viewer.
+
+## Architecture
+
+- Geometry format, reading, indexing, display policy, and rendering are separate
+  crates so lower layers do not depend on the GUI application.
+- The native viewer runs outside Electron and is launched through the desktop
+  Chip Viewer service.
+- The probe CLI exercises the same format and database layers without starting
+  the GUI.
+
+## Validation
+
+```bash
+cd ecos/chip-viewer
+cargo fmt --all -- --check
+cargo test --workspace
+```
+
+Build the packaged native viewer with:
+
+```bash
+cargo build --release -p chip-viewer-native
+```
+
+## When Changing Geometry Contracts
+
+- Treat `chipgeom-format` as the source of shared record and schema definitions.
+- Check `chipgeom-reader`, `chip-view-db`, the probe CLI, and native viewer
+  consumers together.
+- Update focused fixtures and compatibility tests with any intentional format
+  change.
+
+## When Changing Native Integration
+
+- Check `ecos/gui/apps/desktop-electron/electron/services/chipViewerService.ts`
+  and `ecos/scripts/chip-viewer-native-wrapper.sh`.
+- Verify both the Rust workspace and the Electron-side launch tests.
+
+## Dependencies And Generated Files
+
+- Use Cargo and commit the corresponding `Cargo.lock` update.
+- Do not hand-edit `target/` or packaged binary outputs.

--- a/ecos/chip-viewer/AGENTS.md
+++ b/ecos/chip-viewer/AGENTS.md
@@ -12,7 +12,12 @@ instruction files.
 - The probe CLI exercises the same format and database layers without starting
   the GUI.
 
-## Validation
+## Development Workflow
+
+- Run `cargo fmt --all` after making Rust changes.
+- While iterating, run the affected package or test with
+  `cargo test -p <package> [<test-name>]`.
+- Before publishing, run:
 
 ```bash
 cd ecos/chip-viewer
@@ -20,11 +25,28 @@ cargo fmt --all -- --check
 cargo test --workspace
 ```
 
-Build the packaged native viewer with:
+- Build the packaged native viewer after changing startup, rendering, native
+  resources, or packaging integration:
 
 ```bash
 cargo build --release -p chip-viewer-native
 ```
+
+- Keep the workspace building on Linux, macOS, and Windows unless a change is
+  explicitly platform-specific.
+
+## Rust Conventions
+
+- Inline variables in `format!` arguments when possible.
+- Collapse nested `if` statements and prefer method references over redundant
+  closures.
+- Prefer exhaustive `match` statements when the variants are known.
+- Avoid boolean or ambiguous `Option` parameters when an enum, named method, or
+  newtype makes the call site clearer.
+- Keep modules private by default and expose only the crate API required by
+  consumers.
+- Add documentation to new traits describing their role and implementation
+  expectations.
 
 ## When Changing Geometry Contracts
 
@@ -39,6 +61,20 @@ cargo build --release -p chip-viewer-native
 - Check `ecos/gui/apps/desktop-electron/electron/services/chipViewerService.ts`
   and `ecos/scripts/chip-viewer-native-wrapper.sh`.
 - Verify both the Rust workspace and the Electron-side launch tests.
+
+## Review Guidelines
+
+- Do not add substantial new behavior to
+  `apps/chip-viewer-native/src/app.rs`; add a focused module and move related
+  tests and documentation with the implementation.
+- Apply the same rule to existing large `lib.rs` and rendering modules: extend
+  them only for small changes that belong to their current responsibility.
+- Treat geometry schemas, persisted edit records, CLI arguments and output, and
+  the Electron launch contract as compatibility surfaces.
+- For reader, index, query, or rendering hot paths, review allocations,
+  full-dataset copies, and loss of memory-mapped or spatially bounded behavior.
+- Prefer assertions on complete values or records instead of checking fields
+  individually when practical.
 
 ## Dependencies And Generated Files
 

--- a/ecos/chip-viewer/AGENTS.md
+++ b/ecos/chip-viewer/AGENTS.md
@@ -3,17 +3,6 @@
 These instructions apply to `ecos/chip-viewer/` and supplement the parent
 instruction files.
 
-## Workspace Layout
-
-- This is a Rust 2021 Cargo workspace.
-- `crates/chipgeom-format/` defines shared geometry records and schema constants.
-- `crates/chipgeom-reader/` reads geometry manifests and memory-mapped data.
-- `crates/chip-view-db/` owns the queryable layout database and spatial indexes.
-- `crates/chip-display/` owns display roles, themes, and presentation metadata.
-- `crates/chip-render/` converts database geometry into render data.
-- `apps/chipgeom-probe-cli/` provides inspection and benchmark commands.
-- `apps/chip-viewer-native/` provides the egui/wgpu native viewer.
-
 ## Architecture
 
 - Geometry format, reading, indexing, display policy, and rendering are separate

--- a/ecos/chip-viewer/CLAUDE.md
+++ b/ecos/chip-viewer/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/ecos/gui/AGENTS.md
+++ b/ecos/gui/AGENTS.md
@@ -3,17 +3,13 @@
 These instructions apply to `ecos/gui/` and supplement the parent instruction
 files.
 
-## Stack And Layout
+## Architecture Map
 
-- Electron 41 and electron-vite provide the desktop shell and packaging.
-- Vue 3, Pinia, Vue Router, PrimeVue, Tailwind CSS, and Vite provide the renderer.
-- pnpm manages the workspace and lockfile.
-- `apps/desktop-electron/` contains Electron main, preload, services, and release
-  configuration.
-- `apps/renderer/` contains the Vue application, views, components, stores,
-  composables, and desktop API wrappers.
-- `packages/shared/` contains the desktop bridge, event, runtime, and Agent
-  contracts shared across processes.
+- `apps/desktop-electron/electron/` owns Electron main, preload, IPC handlers,
+  filesystem access, subprocesses, and native integrations.
+- `apps/renderer/src/` owns the Vue UI, Pinia state, and desktop API consumers.
+- `packages/shared/src/` is the canonical source for IPC channels, desktop API
+  contracts, events, and serialized cross-process types.
 
 ## Runtime Boundaries
 
@@ -25,7 +21,7 @@ files.
 - ECC and ECC-FE run as sidecars so their Python runtimes remain replaceable and
   isolated from the UI process.
 
-## Setup And Development
+## Development
 
 ```bash
 cd ecos/gui
@@ -38,18 +34,53 @@ use an ECC-FE source checkout, start with
 `ECOS_FE_DEV_ROOT=/absolute/path/to/ecc-fe pnpm run dev`; nearby checkouts do not
 override the installed runtime automatically.
 
-## Validation
+Use pnpm workspace scripts instead of invoking local binaries directly. Run a
+focused Vitest file while iterating, for example:
+
+```bash
+pnpm --filter @ecos-studio/renderer exec vitest run src/path/to/file.test.ts
+pnpm --filter @ecos-studio/desktop-electron exec vitest run electron/path/to/file.test.ts
+```
+
+## Development Tips
+
+- After switching branches or pulling changes to `package.json` or
+  `pnpm-lock.yaml`, run `pnpm install --frozen-lockfile`.
+- Use the repository package scripts for type checking, linting, formatting, and
+  tests. Do not create ad hoc TypeScript or Vitest configurations that bypass
+  workspace settings.
+- Use typecheck and focused tests while iterating; do not run a production build
+  only to discover TypeScript errors.
+
+## Validation By Scope
 
 - Full GUI gate: `pnpm run check`
 - Renderer only: `pnpm run renderer:typecheck && pnpm run renderer:test`
 - Electron only: `pnpm run desktop:typecheck && pnpm run desktop:test`
+- Shared contracts only: `pnpm --filter @ecos-studio/shared run typecheck &&`
+  `pnpm --filter @ecos-studio/shared run test`
 - Build: `pnpm run build`
 - Environment diagnostics: `pnpm run doctor`
 - Electron smoke: `pnpm run desktop:build && pnpm run desktop:smoke`
 
-Run targeted Vitest files while iterating, then the affected package's checks.
-Run the full GUI gate when shared contracts or workspace-wide configuration
-change.
+Before publishing GUI source or configuration changes, run `pnpm run check`.
+Also run the production build when changing build configuration, preload/main
+bundling, package resources, or shared workspace resolution. Run the Electron
+smoke test after changing startup, preload exposure, or a critical IPC path.
+
+## Writing Tests
+
+- Place focused `*.test.ts` files beside the implementation and follow existing
+  Vitest and Vue Test Utils patterns.
+- For asynchronous UI or state changes, use `vi.waitFor()`, `flushPromises()`,
+  or `nextTick()` instead of fixed-delay `setTimeout()` waits.
+- Use fake timers when timer, retry, debounce, or timeout behavior is itself
+  under test.
+- Prefer real temporary directories or fixture files for filesystem, workspace,
+  packaging, and process-integration tests. Keep small self-contained payloads
+  inline when that is clearer.
+- Test observable behavior and contracts. When changing IPC, cover the shared
+  contract, preload exposure, Electron handler, and renderer consumer together.
 
 ## When Changing The Desktop Bridge
 
@@ -58,6 +89,28 @@ change.
   contract tests together.
 - Validate untrusted values in Electron main; renderer validation is only
   defensive UX.
+- Keep the exposed preload API minimal; do not expose raw `ipcRenderer`, Node
+  APIs, filesystem handles, or subprocess access to the renderer.
+
+## When Changing Workspace Data
+
+- Treat `project.json`, workspace manifests, flow state, and shared serialized
+  contracts as compatibility surfaces.
+- Preserve unknown extension fields when normalizing persisted documents unless
+  an explicit migration removes them.
+- Update parsing, migration, recovery, and producer/consumer tests together when
+  a persisted shape changes.
+- Canonicalize and authorize user-controlled paths in Electron main before
+  filesystem access; renderer-side path checks are not authoritative.
+
+## When Changing Sidecars Or Native Tools
+
+- Keep shared contracts, Electron lifecycle and error handling, renderer state,
+  and the affected Agent, ECC, ECC-FE, or Chip Viewer integration aligned.
+- Test cancellation, process failure, malformed output, and unavailable runtime
+  behavior when those paths are affected.
+- Run the repository packaging build or report why it was not run when changing
+  staged binaries, wrappers, manifests, or packaged resource paths.
 
 ## When Changing Visible UI
 
@@ -66,8 +119,22 @@ change.
 - Verify the actual Electron view at relevant desktop sizes and include visual
   evidence when preparing a PR.
 
+## Review Guidelines
+
+- Treat new IPC channels, filesystem writes, subprocess arguments, downloads,
+  archive extraction, and external URLs as security-sensitive.
+- Search every producer and consumer before changing a shared contract or event.
+- Keep shared package exports minimal and avoid renderer dependencies in Electron
+  main or preload code.
+- Prefer adding substantial behavior to a focused module over growing central
+  views, stores, preload entry points, or service orchestrators.
+- Check failure, cancellation, empty, stale, and partial-data states where the
+  workflow can encounter them.
+
 ## Dependencies And Formatting
 
 - Use pnpm and commit the corresponding `pnpm-lock.yaml` update.
 - Use the repository's oxlint and oxfmt scripts; do not restate formatter rules
   in code comments or bypass checks with new exclusions.
+- Do not hand-edit `node_modules/`, `dist/`, `release/`, coverage, or generated
+  package resources.

--- a/ecos/gui/AGENTS.md
+++ b/ecos/gui/AGENTS.md
@@ -1,0 +1,73 @@
+# ECOS Studio GUI
+
+These instructions apply to `ecos/gui/` and supplement the parent instruction
+files.
+
+## Stack And Layout
+
+- Electron 41 and electron-vite provide the desktop shell and packaging.
+- Vue 3, Pinia, Vue Router, PrimeVue, Tailwind CSS, and Vite provide the renderer.
+- pnpm manages the workspace and lockfile.
+- `apps/desktop-electron/` contains Electron main, preload, services, and release
+  configuration.
+- `apps/renderer/` contains the Vue application, views, components, stores,
+  composables, and desktop API wrappers.
+- `packages/shared/` contains the desktop bridge, event, runtime, and Agent
+  contracts shared across processes.
+
+## Runtime Boundaries
+
+- Renderer code is sandboxed with context isolation and no Node integration.
+  Privileged operations cross the preload bridge into Electron main.
+- Electron main validates IPC input and owns filesystem, subprocess, workspace,
+  runtime, and native integration behavior.
+- Shared contracts keep main, preload, and renderer on one typed boundary.
+- ECC and ECC-FE run as sidecars so their Python runtimes remain replaceable and
+  isolated from the UI process.
+
+## Setup And Development
+
+```bash
+cd ecos/gui
+pnpm install --frozen-lockfile
+pnpm run dev
+```
+
+Use `pnpm run dev:vm` in sandboxed or VM-like Linux environments. To deliberately
+use an ECC-FE source checkout, start with
+`ECOS_FE_DEV_ROOT=/absolute/path/to/ecc-fe pnpm run dev`; nearby checkouts do not
+override the installed runtime automatically.
+
+## Validation
+
+- Full GUI gate: `pnpm run check`
+- Renderer only: `pnpm run renderer:typecheck && pnpm run renderer:test`
+- Electron only: `pnpm run desktop:typecheck && pnpm run desktop:test`
+- Build: `pnpm run build`
+- Environment diagnostics: `pnpm run doctor`
+- Electron smoke: `pnpm run desktop:build && pnpm run desktop:smoke`
+
+Run targeted Vitest files while iterating, then the affected package's checks.
+Run the full GUI gate when shared contracts or workspace-wide configuration
+change.
+
+## When Changing The Desktop Bridge
+
+- Change the canonical channel or type in `packages/shared/` first.
+- Update Electron main handlers, preload exposure, renderer callers, and their
+  contract tests together.
+- Validate untrusted values in Electron main; renderer validation is only
+  defensive UX.
+
+## When Changing Visible UI
+
+- Follow existing Vue, PrimeVue, and application layout patterns.
+- Add or update focused component tests.
+- Verify the actual Electron view at relevant desktop sizes and include visual
+  evidence when preparing a PR.
+
+## Dependencies And Formatting
+
+- Use pnpm and commit the corresponding `pnpm-lock.yaml` update.
+- Use the repository's oxlint and oxfmt scripts; do not restate formatter rules
+  in code comments or bypass checks with new exclusions.

--- a/ecos/gui/CLAUDE.md
+++ b/ecos/gui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Add repository-level and component-scoped `AGENTS.md` instructions for the ECOS Studio monorepo.
- Add `CLAUDE.md` imports for the root, `ecos`, GUI, Agent, and Chip Viewer scopes.
- Document component ownership, development commands, validation, and conditional guidance for architecture-sensitive changes.

## Scope

Select the areas touched by this PR:

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [x] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other: `git diff --check origin/main...HEAD`; `cd ecos/chip-viewer && cargo fmt --all -- --check`; `cd ecos/chip-viewer && cargo test --workspace`

Skipped checks and reason:

- GUI, demo, manual smoke, and full packaging checks are not applicable to instruction-only changes. CI will still run jobs selected by the `ecos/chip-viewer/**` path filter.

## Screenshots or Recordings

Required for visible GUI changes.

- N/A; there are no visible GUI changes.

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- No source code, dependency, lockfile, generated artifact, or submodule changes are included.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed.
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
