### PR TITLE
fix(gui): display notifications in user timezone

### DIFF
--- a/ecos/gui/apps/renderer/src/components/NotificationCenter.test.ts
+++ b/ecos/gui/apps/renderer/src/components/NotificationCenter.test.ts
@@ -1,11 +1,18 @@
 // @vitest-environment happy-dom
 
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { useNotificationStore } from '@/stores/notificationStore'
 import NotificationCenter from './NotificationCenter.vue'
 
 describe('NotificationCenter', () => {
+  afterEach(() => {
+    useNotificationStore().clear()
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
   it('closes the notification panel when Escape is pressed', async () => {
     const wrapper = mount(NotificationCenter)
     await wrapper.get('.notification-trigger').trigger('click')
@@ -15,6 +22,26 @@ describe('NotificationCenter', () => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it.each([
+    ['Asia/Shanghai', '10:33 AM'],
+    ['America/New_York', '10:33 PM'],
+  ])('displays notification times in %s', async (timeZone, expected) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-01T02:33:00Z'))
+    vi.stubEnv('TZ', timeZone)
+    useNotificationStore().addNotification({
+      severity: 'error',
+      title: 'Failed to Create Project',
+      message: 'Test error',
+    })
+
+    const wrapper = mount(NotificationCenter)
+    await wrapper.get('.notification-trigger').trigger('click')
+
+    expect(wrapper.get('time').text()).toBe(expected)
     wrapper.unmount()
   })
 })

--- a/ecos/gui/apps/renderer/src/components/NotificationCenter.vue
+++ b/ecos/gui/apps/renderer/src/components/NotificationCenter.vue
@@ -112,9 +112,11 @@ function iconFor(severity: AppNotificationSeverity): string {
 }
 
 function formatTime(timestamp: number): string {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
   return new Intl.DateTimeFormat(undefined, {
     hour: '2-digit',
     minute: '2-digit',
+    timeZone,
   }).format(timestamp)
 }
 </script>


### PR DESCRIPTION
## Summary

- Format notification timestamps with the user's detected system timezone.
- Cover Asia/Shanghai and America/New_York conversions, including the date-boundary and daylight-saving case.

## Scope

Select the areas touched by this PR:

- [x] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `cd ecos/gui && pnpm run typecheck`
- [x] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other: `cd ecos/gui && pnpm install --frozen-lockfile`
- [x] Other: `cd ecos/gui && pnpm run lint`
- [x] Other: `cd ecos/gui && pnpm run fmt:check`
- [x] Other: `python3 .github/scripts/check-version.py`

Skipped checks and reason:

- Build, packaging, demos, and manual GUI smoke were not run because this is an isolated renderer timestamp-formatting change covered by component and full GUI tests.

## Screenshots or Recordings

Required for visible GUI changes.

- N/A: no layout or styling changed. The component test verifies `02:33 UTC` renders as `10:33 AM` in Asia/Shanghai and `10:33 PM` in America/New_York.

## Release, Packaging, and Runtime Impact

- [ ] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [ ] Submodule gitlink changed

Notes:

- Renderer-only runtime display change; no packaging, native resource, ECC, or persisted-data impact.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed. (N/A: no copy or documentation change needed.)
- [x] I included lockfile changes for dependency updates. (N/A: no dependency changes.)
- [x] I documented intentional submodule updates. (N/A: no submodule updates.)
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.
