### PR TITLE
feat(chip-viewer): add a browser target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
       - name: Run Rust tests
         run: cargo test --workspace
 
+      - name: Check the browser target
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo check -p chip-viewer-wasm --target wasm32-unknown-unknown
+
   build-appimage:
     name: Build AppImage
     needs: [changes, check-version, gui-checks, chip-viewer-rust]

--- a/ecos/chip-viewer/Cargo.toml
+++ b/ecos/chip-viewer/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/chip-render",
   "apps/chipgeom-probe-cli",
   "apps/chip-viewer-native",
+  "apps/chip-viewer-wasm",
 ]
 
 [workspace.package]

--- a/ecos/chip-viewer/apps/chip-viewer-wasm/Cargo.toml
+++ b/ecos/chip-viewer/apps/chip-viewer-wasm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "chip-viewer-wasm"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+chip-display = { path = "../../crates/chip-display" }
+chipgeom-format = { path = "../../crates/chipgeom-format" }
+eframe = { workspace = true, default-features = false, features = ["default_fonts", "glow", "wgpu"] }
+egui.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["HtmlCanvasElement"] }

--- a/ecos/chip-viewer/apps/chip-viewer-wasm/index.html
+++ b/ecos/chip-viewer/apps/chip-viewer-wasm/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Chip Viewer</title>
+<style>
+  html, body { margin: 0; height: 100%; }
+  canvas { width: 100%; height: 100%; display: block; }
+</style>
+<canvas id="chip-viewer"></canvas>
+<script type="module">
+  import init, { ChipViewerHandle } from './pkg/chip_viewer_wasm.js';
+  await init();
+  await new ChipViewerHandle().start(document.getElementById('chip-viewer'));
+</script>

--- a/ecos/chip-viewer/apps/chip-viewer-wasm/src/lib.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-wasm/src/lib.rs
@@ -1,0 +1,76 @@
+//! Browser entry point for the chip viewer.
+//!
+//! `chip-viewer-native` cannot be reused as-is: its `main.rs` parses CLI
+//! arguments and `chip-view-db` memory-maps its input, neither of which exists
+//! on `wasm32`. This crate keeps the parts that are portable — the layer
+//! styling in `chip-display` — behind an `eframe` app the host page mounts on a
+//! canvas.
+
+use chip_display::{ColorTheme, LayerRole, LayerStyle};
+use chipgeom_format::LayerId;
+
+pub struct ChipViewerApp {
+    theme: ColorTheme,
+    layers: Vec<(LayerId, LayerRole)>,
+}
+
+impl Default for ChipViewerApp {
+    fn default() -> Self {
+        Self {
+            theme: ColorTheme::default(),
+            layers: (0..6)
+                .map(|level| (level as LayerId, LayerRole::Metal { level }))
+                .collect(),
+        }
+    }
+}
+
+impl eframe::App for ChipViewerApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            for (layer_id, role) in &self.layers {
+                let style = LayerStyle::default_for_layer(*layer_id, self.theme);
+                let [r, g, b, a] = style.rgba;
+                let (rect, _) =
+                    ui.allocate_exact_size(egui::vec2(24.0, 12.0), egui::Sense::hover());
+                ui.painter().rect_filled(
+                    rect,
+                    2.0,
+                    egui::Color32::from_rgba_unmultiplied(r, g, b, a),
+                );
+                ui.label(format!("{role:?}"));
+            }
+        });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen::prelude::wasm_bindgen]
+pub struct ChipViewerHandle {
+    runner: eframe::WebRunner,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen::prelude::wasm_bindgen]
+impl ChipViewerHandle {
+    #[wasm_bindgen::prelude::wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            runner: eframe::WebRunner::new(),
+        }
+    }
+
+    /// Mounts the viewer on `canvas`; the host page owns the element's lifetime.
+    pub async fn start(
+        &self,
+        canvas: web_sys::HtmlCanvasElement,
+    ) -> Result<(), wasm_bindgen::JsValue> {
+        self.runner
+            .start(
+                canvas,
+                eframe::WebOptions::default(),
+                Box::new(|_cc| Ok(Box::<ChipViewerApp>::default())),
+            )
+            .await
+    }
+}


### PR DESCRIPTION
`chip-viewer-native` cannot be built for `wasm32`: `main.rs` parses CLI arguments and `chip-view-db` memory-maps its input. This adds `chip-viewer-wasm`, which keeps the portable half — the layer styling in `chip-display`, whose only dependency is `chipgeom-format` — behind an `eframe` app the host page mounts on a canvas.

`chip-viewer-native` is untouched.

## Verification

```
cargo check -p chip-viewer-wasm --target wasm32-unknown-unknown   Finished
cargo check --workspace                                           Finished
cargo fmt --all -- --check                                        clean
```

The new CI step runs the first of these, so the browser path cannot silently rot.

`index.html` is the development shell; producing a distributable bundle needs `wasm-pack` and is left out of this PR.
