### PR TITLE
feat(ohos): add a HarmonyOS shell

### DIFF
--- a/ecos/ohos/AppScope/app.json5
+++ b/ecos/ohos/AppScope/app.json5
@@ -1,0 +1,10 @@
+{
+  "app": {
+    "bundleName": "org.openecos.ecosstudio",
+    "vendor": "openecos",
+    "versionCode": 1,
+    "versionName": "0.1.0",
+    "icon": "$media:app_icon",
+    "label": "$string:app_name"
+  }
+}

--- a/ecos/ohos/AppScope/resources/base/element/string.json
+++ b/ecos/ohos/AppScope/resources/base/element/string.json
@@ -1,0 +1,5 @@
+{
+  "string": [
+    { "name": "app_name", "value": "ECOS Studio" }
+  ]
+}

--- a/ecos/ohos/README.md
+++ b/ecos/ohos/README.md
@@ -1,0 +1,24 @@
+# HarmonyOS shell
+
+A HarmonyOS NEXT ability that loads the ECOS Studio web build in an ArkWeb
+`Web` component. It ports no rendering code: the app is the same web bundle the
+browser target produces, so there is one renderer to maintain rather than one
+per platform.
+
+## Build
+
+Requires DevEco Studio with the HarmonyOS NEXT SDK; open this directory as the
+project root.
+
+```sh
+hvigorw assembleHap
+```
+
+CI does not build it — GitHub Actions has no HarmonyOS runner, and the SDK is
+not redistributable.
+
+## Pointing at a different origin
+
+`Index.ets` reads `appUrl` from `AppStorage` and falls back to the production
+URL, so a development build can be aimed at a local server without a code
+change.

--- a/ecos/ohos/build-profile.json5
+++ b/ecos/ohos/build-profile.json5
@@ -1,0 +1,21 @@
+{
+  "app": {
+    "products": [
+      {
+        "name": "default",
+        "signingConfig": "default",
+        "compatibleSdkVersion": "5.0.0(12)",
+        "runtimeOS": "HarmonyOS"
+      }
+    ]
+  },
+  "modules": [
+    {
+      "name": "entry",
+      "srcPath": "./entry",
+      "targets": [
+        { "name": "default", "applyToProducts": ["default"] }
+      ]
+    }
+  ]
+}

--- a/ecos/ohos/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/ecos/ohos/entry/src/main/ets/entryability/EntryAbility.ets
@@ -1,0 +1,8 @@
+import { UIAbility } from '@kit.AbilityKit'
+import { window } from '@kit.ArkUI'
+
+export default class EntryAbility extends UIAbility {
+  onWindowStageCreate(stage: window.WindowStage): void {
+    stage.loadContent('pages/Index')
+  }
+}

--- a/ecos/ohos/entry/src/main/ets/pages/Index.ets
+++ b/ecos/ohos/entry/src/main/ets/pages/Index.ets
@@ -1,0 +1,19 @@
+import { webview } from '@kit.ArkWeb'
+
+// The app itself is the existing web build; this ability only hosts it, so the
+// renderer stays in one place instead of being ported per platform.
+const DEFAULT_URL: string = 'https://ecos.studio'
+
+@Entry
+@Component
+struct Index {
+  private controller: webview.WebviewController = new webview.WebviewController()
+
+  build() {
+    Web({ src: AppStorage.get<string>('appUrl') ?? DEFAULT_URL, controller: this.controller })
+      .width('100%')
+      .height('100%')
+      .javaScriptAccess(true)
+      .domStorageAccess(true)
+  }
+}

--- a/ecos/ohos/entry/src/main/module.json5
+++ b/ecos/ohos/entry/src/main/module.json5
@@ -1,0 +1,30 @@
+{
+  "module": {
+    "name": "entry",
+    "type": "entry",
+    "srcEntry": "./ets/entryability/EntryAbility.ets",
+    "description": "$string:module_desc",
+    "mainElement": "EntryAbility",
+    "deviceTypes": ["default", "tablet", "2in1"],
+    "deliveryWithInstall": true,
+    "installationFree": false,
+    "abilities": [
+      {
+        "name": "EntryAbility",
+        "srcEntry": "./ets/entryability/EntryAbility.ets",
+        "description": "$string:ability_desc",
+        "icon": "$media:app_icon",
+        "label": "$string:app_name",
+        "startWindowIcon": "$media:app_icon",
+        "startWindowBackground": "$color:start_window_background",
+        "exported": true,
+        "skills": [
+          { "entities": ["entity.system.home"], "actions": ["action.system.home"] }
+        ]
+      }
+    ],
+    "requestPermissions": [
+      { "name": "ohos.permission.INTERNET" }
+    ]
+  }
+}

--- a/ecos/ohos/entry/src/main/resources/base/element/color.json
+++ b/ecos/ohos/entry/src/main/resources/base/element/color.json
@@ -1,0 +1,5 @@
+{
+  "color": [
+    { "name": "start_window_background", "value": "#FFFFFF" }
+  ]
+}

--- a/ecos/ohos/entry/src/main/resources/base/element/string.json
+++ b/ecos/ohos/entry/src/main/resources/base/element/string.json
@@ -1,0 +1,7 @@
+{
+  "string": [
+    { "name": "app_name", "value": "ECOS Studio" },
+    { "name": "module_desc", "value": "ECOS Studio entry module" },
+    { "name": "ability_desc", "value": "Hosts the ECOS Studio web app" }
+  ]
+}

--- a/ecos/ohos/hvigorfile.ts
+++ b/ecos/ohos/hvigorfile.ts
@@ -1,0 +1,1 @@
+export { appTasks } from '@ohos/hvigor-ohos-plugin'

--- a/ecos/ohos/oh-package.json5
+++ b/ecos/ohos/oh-package.json5
@@ -1,0 +1,9 @@
+{
+  "name": "ecos-studio",
+  "version": "0.1.0",
+  "description": "HarmonyOS shell for ECOS Studio",
+  "main": "",
+  "author": "openecos",
+  "license": "Apache-2.0",
+  "dependencies": {}
+}


### PR DESCRIPTION
A HarmonyOS NEXT ability that loads the ECOS Studio web build in an ArkWeb `Web` component. No rendering code is ported — the app is the same web bundle, so there is one renderer to maintain rather than one per platform. Pairs with #212, which adds the browser target.

`Index.ets` reads `appUrl` from `AppStorage` and falls back to the production URL, so a development build can be aimed at a local server without a code change.

## What is not verified

I have no HarmonyOS toolchain, so this has **not** been built or run — the JSON5 manifests parse and the ArkTS follows the documented ArkWeb API, and that is the extent of it. Treat it as a starting skeleton for someone with DevEco Studio rather than a tested target.

CI cannot cover it either: GitHub Actions has no HarmonyOS runner and the SDK is not redistributable. Happy to close this if you would rather not carry an unbuilt directory.
