### PR TITLE
feat(chip-viewer): add regex search and keep hidden matches visible

### DIFF
--- a/ecos/chip-viewer/Cargo.lock
+++ b/ecos/chip-viewer/Cargo.lock
@@ -130,6 +130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +698,7 @@ dependencies = [
  "bytemuck",
  "chipgeom-format",
  "chipgeom-reader",
+ "regex",
  "rstar",
 ]
 
@@ -710,6 +720,7 @@ dependencies = [
  "image",
  "log",
  "pollster",
+ "regex",
  "rstar",
  "serde",
  "serde_json",
@@ -2766,6 +2777,35 @@ checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "renderdoc-sys"

--- a/ecos/chip-viewer/Cargo.toml
+++ b/ecos/chip-viewer/Cargo.toml
@@ -26,6 +26,7 @@ egui-wgpu = "0.31"
 image = { version = "0.25", default-features = false, features = ["png"] }
 memmap2 = "0.9"
 rstar = "0.13"
+regex = "1.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/ecos/chip-viewer/apps/chip-viewer-native/Cargo.toml
+++ b/ecos/chip-viewer/apps/chip-viewer-native/Cargo.toml
@@ -20,6 +20,7 @@ image.workspace = true
 log = "0.4"
 pollster = "0.4"
 rstar.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 wgpu.workspace = true

--- a/ecos/chip-viewer/apps/chip-viewer-native/src/app.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/app.rs
@@ -3199,7 +3199,7 @@ impl LoadedViewer {
     fn query_mode_picker(&mut self, ui: &mut egui::Ui) {
         egui::ComboBox::from_id_salt("chip_viewer_query_input_mode")
             .selected_text(match self.query_input_mode {
-                QueryInputMode::Search => format!("⌕ {}", self.search_mode.label()),
+                QueryInputMode::Search => format!("Search: {}", self.search_mode.label()),
                 QueryInputMode::ShapeId => "# Shape ID".to_string(),
             })
             .width(98.0)
@@ -3238,18 +3238,15 @@ impl LoadedViewer {
     }
 
     fn query_send_button(&self, ui: &mut egui::Ui) -> egui::Response {
-        let icon = match self.query_input_mode {
-            QueryInputMode::Search => "⌕",
-            QueryInputMode::ShapeId => "➤",
+        let label = match self.query_input_mode {
+            QueryInputMode::Search => "Search",
+            QueryInputMode::ShapeId => "Select",
         };
-        ui.add_sized(
-            egui::vec2(34.0, 34.0),
-            egui::Button::new(egui::RichText::new(icon).size(19.0).strong()),
-        )
-        .on_hover_text(match self.query_input_mode {
-            QueryInputMode::Search => "Search and locate",
-            QueryInputMode::ShapeId => "Select shape id",
-        })
+        ui.add(egui::Button::new(egui::RichText::new(label).strong()))
+            .on_hover_text(match self.query_input_mode {
+                QueryInputMode::Search => "Search and locate",
+                QueryInputMode::ShapeId => "Select shape id",
+            })
     }
 
     fn submit_query(&mut self) {

--- a/ecos/chip-viewer/apps/chip-viewer-native/src/app.rs
+++ b/ecos/chip-viewer/apps/chip-viewer-native/src/app.rs
@@ -17,6 +17,7 @@ use chipgeom_format::{
     OwnerType, Point32, Rect32, ShapeId, ShapeKind, ShapeRecord, ShapeState,
 };
 use eframe::egui;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::map_data::{ColormapMode, HeatmapData, MapCatalog, MapItem};
@@ -1312,18 +1313,45 @@ impl SearchMode {
         }
     }
 
-    fn query_shape_ids(self, db: &ChipViewDb, name: &str) -> Vec<ShapeId> {
+    fn query_shape_ids(self, db: &ChipViewDb, pattern: &Regex) -> Vec<ShapeId> {
         match self {
-            SearchMode::All => db.query_owner_name(name),
+            SearchMode::All => db.query_owner_name_pattern(pattern),
             SearchMode::Net | SearchMode::Instance => self
                 .owner_types()
-                .map(|owner_types| db.query_owner_name_for_owner_types(name, owner_types))
+                .map(|owner_types| {
+                    db.query_owner_name_for_owner_types_pattern(pattern, owner_types)
+                })
                 .unwrap_or_default(),
-            SearchMode::Pin => db.query_pin_name(name),
-            SearchMode::Bus => db.query_bus_name(name),
-            SearchMode::Group => db.query_group_name(name),
+            SearchMode::Pin => db
+                .connectivity_metadata()
+                .iter()
+                .filter(|endpoint| pattern.is_match(&endpoint.pin_name))
+                .flat_map(|endpoint| db.query_pin_name(&endpoint.pin_name))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect(),
+            SearchMode::Bus => db
+                .bus_metadata()
+                .iter()
+                .filter(|bus| pattern.is_match(&bus.name))
+                .flat_map(|bus| db.query_bus_name(&bus.name))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect(),
+            SearchMode::Group => db
+                .group_metadata()
+                .iter()
+                .filter(|group| pattern.is_match(&group.name))
+                .flat_map(|group| db.query_group_name(&group.name))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect(),
         }
     }
+}
+
+fn search_pattern(query: &str) -> Result<Regex, regex::Error> {
+    Regex::new(query)
 }
 
 impl SidebarInfoPanel {
@@ -3110,22 +3138,49 @@ impl LoadedViewer {
     }
 
     fn query_input_ui(&mut self, ui: &mut egui::Ui, height: f32) {
+        const QUERY_FRAME_VERTICAL_MARGIN: f32 = 24.0;
+        let content_height = (height - QUERY_FRAME_VERTICAL_MARGIN).max(88.0);
         egui::Frame::NONE
             .fill(ecos_canvas())
             .stroke(egui::Stroke::new(1.0_f32, ecos_border()))
             .corner_radius(14)
             .inner_margin(egui::Margin::same(12))
             .show(ui, |ui| {
-                ui.set_min_height(height);
-                ui.set_max_height(height);
+                ui.set_min_height(content_height);
+                ui.set_max_height(content_height);
                 ui.vertical(|ui| {
-                    let input_height = (height - 46.0).max(42.0);
+                    let input_height = (content_height - 46.0).max(42.0);
                     match self.query_input_mode {
                         QueryInputMode::Search => self.search_input_ui(ui, input_height),
                         QueryInputMode::ShapeId => self.shape_id_input_ui(ui, input_height),
                     }
                     ui.with_layout(egui::Layout::bottom_up(egui::Align::Min), |ui| {
                         ui.horizontal(|ui| {
+                            if self.query_input_mode == QueryInputMode::Search {
+                                if let Some(status) = &self.last_query_status {
+                                    ui.label(
+                                        egui::RichText::new(status).small().color(ecos_warning()),
+                                    );
+                                } else if !self.search_text.trim().is_empty() {
+                                    ui.label(
+                                        egui::RichText::new(format!(
+                                            "{} matches",
+                                            self.highlighted.len()
+                                        ))
+                                        .small()
+                                        .color(ecos_text_secondary()),
+                                    );
+                                    if ui.small_button("Locate").clicked() {
+                                        self.focus_highlighted_shapes();
+                                    }
+                                    if ui.small_button("Clear").clicked() {
+                                        clear_search_state(
+                                            &mut self.search_text,
+                                            &mut self.highlighted,
+                                        );
+                                    }
+                                }
+                            }
                             self.query_mode_picker(ui);
                             ui.with_layout(
                                 egui::Layout::right_to_left(egui::Align::Center),
@@ -3211,7 +3266,7 @@ impl LoadedViewer {
         let response = ui.add_sized(
             egui::vec2(ui.available_width(), input_height),
             egui::TextEdit::multiline(&mut self.search_text)
-                .hint_text("Search name, net, instance, pin, bus, group")
+                .hint_text("Regex: name, net, instance, pin, bus, group")
                 .desired_rows(2)
                 .frame(false),
         );
@@ -3222,21 +3277,6 @@ impl LoadedViewer {
         let submit = response.lost_focus() && ui.input(|input| input.key_pressed(egui::Key::Enter));
         if submit {
             self.submit_query();
-        }
-        if !self.search_text.trim().is_empty() {
-            ui.horizontal(|ui| {
-                ui.label(
-                    egui::RichText::new(format!("{} matches", self.highlighted.len()))
-                        .small()
-                        .color(ecos_text_secondary()),
-                );
-                if ui.small_button("Locate").clicked() {
-                    self.focus_highlighted_shapes();
-                }
-                if ui.small_button("Clear").clicked() {
-                    clear_search_state(&mut self.search_text, &mut self.highlighted);
-                }
-            });
         }
     }
 
@@ -4144,10 +4184,10 @@ impl LoadedViewer {
             if !is_renderable_shape(shape) {
                 continue;
             }
-            if !self.shape_is_visible(shape) {
+            if !self.highlighted.contains(shape_id) && !self.shape_is_visible(shape) {
                 continue;
             }
-            if !self.shape_is_drawn_at_current_zoom(shape) {
+            if !self.highlighted.contains(shape_id) && !self.shape_is_drawn_at_current_zoom(shape) {
                 continue;
             }
             let geometry = self.db.shape_geometry(shape);
@@ -6636,19 +6676,22 @@ impl LoadedViewer {
     }
 
     fn refresh_highlight(&mut self) {
-        let name = self.search_text.trim();
-        self.highlighted = if name.is_empty() {
+        let query = self.search_text.trim();
+        self.last_query_status = None;
+        self.highlighted = if query.is_empty() {
             BTreeSet::new()
         } else {
-            self.search_mode
-                .query_shape_ids(&self.db, name)
-                .into_iter()
-                .filter(|shape_id| {
-                    self.db
-                        .find_shape(*shape_id)
-                        .is_some_and(|shape| self.shape_is_visible(shape))
-                })
-                .collect()
+            match search_pattern(query) {
+                Ok(pattern) => self
+                    .search_mode
+                    .query_shape_ids(&self.db, &pattern)
+                    .into_iter()
+                    .collect(),
+                Err(error) => {
+                    self.last_query_status = Some(format!("Invalid search pattern: {error}"));
+                    BTreeSet::new()
+                }
+            }
         };
     }
 
@@ -6657,10 +6700,7 @@ impl LoadedViewer {
             return;
         }
         self.pending_focus = focus_target_for_shape_ids(&self.highlighted, |shape_id| {
-            self.db
-                .find_shape(shape_id)
-                .filter(|shape| self.shape_is_visible(shape))
-                .map(|shape| shape.bbox)
+            self.db.find_shape(shape_id).map(|shape| shape.bbox)
         });
     }
 
@@ -12608,6 +12648,22 @@ mod tests {
         assert_eq!(SearchMode::Pin.label(), "Pin");
         assert_eq!(SearchMode::Bus.label(), "Bus");
         assert_eq!(SearchMode::Group.label(), "Group");
+    }
+
+    #[test]
+    fn search_pattern_uses_standard_regex_syntax() {
+        let pattern = search_pattern("Tile_X[01]_Y0_.*").unwrap();
+        assert!(pattern.is_match("Tile_X0_Y0_ALU_out"));
+        assert!(pattern.is_match("Tile_X1_Y0_ALU_out"));
+        assert!(!pattern.is_match("Tile_X2_Y0_ALU_out"));
+        assert!(!search_pattern("^Tile_X[01]_Y0_*$")
+            .unwrap()
+            .is_match("Tile_X0_Y0_ALU_out"));
+    }
+
+    #[test]
+    fn search_pattern_reports_invalid_regex() {
+        assert!(search_pattern("[").is_err());
     }
 
     #[test]

--- a/ecos/chip-viewer/crates/chip-view-db/Cargo.toml
+++ b/ecos/chip-viewer/crates/chip-view-db/Cargo.toml
@@ -10,3 +10,4 @@ bytemuck.workspace = true
 chipgeom-format = { path = "../chipgeom-format" }
 chipgeom-reader = { path = "../chipgeom-reader" }
 rstar.workspace = true
+regex.workspace = true

--- a/ecos/chip-viewer/crates/chip-view-db/src/lib.rs
+++ b/ecos/chip-viewer/crates/chip-view-db/src/lib.rs
@@ -13,6 +13,7 @@ pub use chipgeom_reader::{
     GroupMetadata, MasterMetadata, NetMetadata, SiteMetadata, ViaMetadata,
 };
 use chipgeom_reader::{GeometrySnapshot, LayerMetadata};
+use regex::Regex;
 use rstar::{RTree, RTreeObject, AABB};
 
 pub struct ChipViewDb {
@@ -601,6 +602,14 @@ impl OwnerNameIndex {
 
     pub fn query(&self, name: &str) -> Vec<ShapeId> {
         self.by_name.get(name).cloned().unwrap_or_default()
+    }
+
+    pub fn query_pattern(&self, pattern: &Regex) -> Vec<ShapeId> {
+        self.by_name
+            .iter()
+            .filter(|(name, _)| pattern.is_match(name))
+            .flat_map(|(_, shape_ids)| shape_ids.iter().copied())
+            .collect()
     }
 
     pub fn query_owner(&self, owner_type: u8, owner_id: u64) -> Vec<ShapeId> {
@@ -1745,6 +1754,10 @@ impl ChipViewDb {
         self.name_index.query(name)
     }
 
+    pub fn query_owner_name_pattern(&self, pattern: &Regex) -> Vec<ShapeId> {
+        self.name_index.query_pattern(pattern)
+    }
+
     pub fn query_owner_shapes(&self, owner_type: OwnerType, owner_id: u64) -> Vec<ShapeId> {
         self.name_index.query_owner(owner_type as u8, owner_id)
     }
@@ -1759,6 +1772,25 @@ impl ChipViewDb {
             .map(|owner_type| *owner_type as u8)
             .collect();
         self.query_owner_name(name)
+            .into_iter()
+            .filter(|shape_id| {
+                self.find_shape(*shape_id)
+                    .and_then(|shape| self.owner_for_shape(shape))
+                    .is_some_and(|owner| owner_type_values.contains(&owner.owner_type))
+            })
+            .collect()
+    }
+
+    pub fn query_owner_name_for_owner_types_pattern(
+        &self,
+        pattern: &Regex,
+        owner_types: &[OwnerType],
+    ) -> Vec<ShapeId> {
+        let owner_type_values: Vec<u8> = owner_types
+            .iter()
+            .map(|owner_type| *owner_type as u8)
+            .collect();
+        self.query_owner_name_pattern(pattern)
             .into_iter()
             .filter(|shape_id| {
                 self.find_shape(*shape_id)


### PR DESCRIPTION
## Summary

Add regex-based search to Chip Viewer, fix hidden-match visibility, and prevent query control overlap on sidebar resize as suggested in https://github.com/openecos-projects/ecos-studio/issues/217 and https://github.com/openecos-projects/ecos-studio/issues/218.

Search now accepts standard Rust regex syntax. Invalid patterns display an error instead of silently returning zero results. Highlighted matches remain visible and locatable even when their layer or drawing category is hidden by the user. Net, Instance, Pin, Bus, and Group search modes all support regex matching against their respective metadata names. The Locate, Clear, and search-mode dropdown controls share a single bottom row inside the query panel, and the panel reserves space for its frame margins so bottom controls never clip at small sidebar heights.

## Scope

- [ ] GUI - desktop UI/runtime changes in `ecos/gui`, including renderer, Electron, and shared packages.
- [ ] ECC - ECC submodule updates or ECOS Studio integration with the ECC CLI/runtime.
- [ ] Resource management - resource registry, downloads, installation, manifests, PDKs, or tool assets.
- [ ] Build, packaging, Nix, or release workflow - build inputs, AppImage packaging, or release metadata.
- [ ] CI - GitHub Actions workflows, reusable actions, triggers, path filters, or automated checks.
- [ ] Documentation only - README, guides, templates, or docs with no runtime behavior change.
- [x] Chip Viewer - native Rust viewer changes in `ecos/chip-viewer` (Rust crates, native app, Cargo workspace).

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `cd ecos/gui && pnpm run typecheck`
- [ ] `cd ecos/gui && pnpm run test`
- [ ] `cd ecos/gui && pnpm run build`
- [ ] `make build`
- [ ] `make demo-gcd`
- [ ] `make demo-retrosoc`
- [ ] Manual GUI smoke: `cd ecos/gui && pnpm run dev`
- [x] Other:
  - `cd ecos/chip-viewer && cargo fmt --all`
  - `cd ecos/chip-viewer && cargo fmt --all -- --check`
  - `cd ecos/chip-viewer && cargo test -p chip-view-db`
  - `cd ecos/chip-viewer && cargo test -p chip-viewer-native`
  - `git diff --check`

Skipped checks and reason:

- GUI/ECC/Build/CI checks not applicable; changes are scoped entirely to the Rust chip-viewer crates.

## Screenshots or Recordings

## Release, Packaging, and Runtime Impact

- [x] No release, packaging, or runtime impact
- [ ] Version metadata changed
- [ ] AppImage or Electron packaging changed
- [ ] ECC CLI runtime resources changed
- [ ] OSS CAD Suite, PDK, resource download, or installer behavior changed
- [x] Submodule gitlink changed (Cargo.lock updated)

Notes:

- Added `regex = "1.11"` to workspace dependencies and `chip-view-db`, `chip-viewer-native`. Lock file updated automatically.
- No schema, persisted format, or cross-process contract changes.

## Checklist

- [x] I kept the change scoped to the affected component.
- [x] I updated docs or user-facing text where behavior changed (search hint text updated to `Regex: ...`).
- [x] I included lockfile changes for dependency updates.
- [x] I documented intentional submodule updates.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained any skipped validation and remaining risk.